### PR TITLE
Fix: recipe update mutation drops packagingPath and isOptional

### DIFF
--- a/packages/api/src/routers/recipes.ts
+++ b/packages/api/src/routers/recipes.ts
@@ -434,6 +434,8 @@ export const recipesRouter = router({
                 actionData: s.actionData,
                 estimatedDurationHours: s.estimatedDurationHours?.toString() ?? null,
                 notes: s.notes ?? null,
+                packagingPath: s.packagingPath,
+                isOptional: s.isOptional,
               })),
             );
           }


### PR DESCRIPTION
## Summary
Fixes a data-loss bug in the recipe **update** mutation: it dropped `packagingPath` and `isOptional` on every save.

## The bug
- The **create** mutation persists `packagingPath` + `isOptional` per step.
- The **update** mutation omitted both from its `INSERT`.
- `recipe_steps.packaging_path` is `NOT NULL DEFAULT 'all'` (and `is_optional` defaults `false`), so editing any recipe silently reset **every** step back to "All packaging" and cleared all Optional flags.

Net effect: bottle/keg branching and optional steps were impossible to save through the editor — they vanished the moment you hit Save.

## Fix
Add `packagingPath` and `isOptional` to the update insert so it matches the create path (`packages/api/src/routers/recipes.ts`).

## Testing
Verified by restructuring a real recipe (Coastal Hop) into shared trunk + bottle branch + keg branch; with the fix, the per-step paths persist across the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
