### PR TITLE
BOM: exclude kegs (returnable vessels) from the bill of materials

### DIFF
--- a/packages/lib/src/__tests__/recipes/bom.test.ts
+++ b/packages/lib/src/__tests__/recipes/bom.test.ts
@@ -103,7 +103,7 @@ describe("computeRecipeBOM", () => {
       actionData: { containerVarietyId: null, containerVarietyName: "19L Keg", sizeML: 19000 },
     };
 
-    it("routes each package step to its portion and does not label kegs", () => {
+    it("packages only the bottled portion; kegs are vessels, not BOM lines", () => {
       const bom = computeRecipeBOM({
         ingredients: [],
         steps: [bottlePackageStep, kegPackageStep, labelStep],
@@ -113,8 +113,10 @@ describe("computeRecipeBOM", () => {
       });
       // bottles: 400 L / 0.75 = 533.3 → 534
       expect(bom.packaging.find((p) => p.name === "750ml Glass Bottles")?.quantity).toBe(534);
-      // kegs: 600 L / 19 L = 31.6 → 32
-      expect(bom.packaging.find((p) => p.name === "19L Keg")?.quantity).toBe(32);
+      // kegs are returnable vessels (keg tracker), never a BOM/buy-list line
+      expect(bom.packaging.find((p) => p.name === "19L Keg")).toBeUndefined();
+      // and a keg-path package step produces no "no container size" warning
+      expect(bom.warnings.some((w) => w.includes("19L Keg") || w.includes("Package into kegs"))).toBe(false);
       // labels apply to bottles only → 534, not 534 + kegs
       expect(bom.packaging.find((p) => p.name === "Heritage Label")?.quantity).toBe(534);
     });

--- a/packages/lib/src/recipes/bom.ts
+++ b/packages/lib/src/recipes/bom.ts
@@ -3,8 +3,10 @@
  *
  * Resolves a recipe + a target finished volume + a bottle/keg split into the
  * exact inventory it consumes: additive amounts (rate × volume) and packaging
- * unit counts (⌈volume ÷ container size⌉), respecting each step's packaging
- * path so a split batch (e.g. 600 L kegged, 400 L bottled) is handled.
+ * unit counts (⌈volume ÷ container size⌉). Only consumables count: bottles,
+ * caps, and labels. Kegs are returnable reusable vessels (tracked like a
+ * fermentation tank in the keg tracker), so keg-path package steps are
+ * excluded from the BOM — only the bottled portion drives packaging.
  *
  * Every line carries a `varietyId` + numeric `quantity` + `unit`, so the
  * annual planner can SUM lines across many batches by (varietyId, unit).
@@ -133,9 +135,13 @@ export function computeRecipeBOM(input: RecipeBomInput): RecipeBom {
   let bottleUnits = 0;
   for (const s of input.steps) {
     if (s.kind !== "package") continue;
-    const d = (s.actionData ?? {}) as Record<string, unknown>;
     const path = s.packagingPath ?? "all";
-    const portionL = path === "keg" ? kegL : path === "bottle" ? bottleL : bottleL + kegL;
+    // Kegs are returnable, reusable vessels — tracked like a fermentation tank
+    // in the keg tracker, not a consumable. They never belong in the BOM; keg
+    // counts are a capacity/keg-tracker concern, not a purchasing one.
+    if (path === "keg") continue;
+    const d = (s.actionData ?? {}) as Record<string, unknown>;
+    const portionL = path === "bottle" ? bottleL : bottleL + kegL;
     const sizeML = typeof d.sizeML === "number" ? d.sizeML : null;
     if (!sizeML || sizeML <= 0) {
       warnings.push(`Package step "${s.label ?? "package"}" has no container size; can't count units.`);


### PR DESCRIPTION
## Summary
Kegs are returnable, reusable vessels — tracked like a fermentation tank in the keg tracker — not consumable packaging. They must not appear in the recipe bill-of-materials or the planning buy list.

## Problem
`computeRecipeBOM` emitted a packaging line for **any** `package` step with a `sizeML`, including keg-path steps. So a keg-path step produced a phantom **"buy N kegs"** line (flagged as unlinked-to-inventory) in the planning buy list — wrong, since kegs are reused, not purchased per batch.

## Fix
- Skip `packagingPath === "keg"` package steps in `computeRecipeBOM`: no buy-list line, and no "no container size" warning for kegs.
- Only the bottled portion drives packaging (bottles, caps, labels). Keg counts/occupancy are a capacity / keg-tracker concern, addressed separately.
- Updated `bom.test.ts`: the split-batch case now asserts kegs produce no BOM line and no warning.

## Tests
`pnpm --filter lib exec vitest run src/__tests__/recipes/bom.test.ts` → 16/16 pass.

## Follow-up (not in this PR)
Counting "how many kegs are needed per period" belongs with the deferred capacity/occupancy work and the eventual batch↔keg linkage in recipe execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
