### PR TITLE
Recipes: labor rollup + drop keg portion from BOM preview

### DIFF
--- a/apps/web/src/app/recipes/[id]/page.tsx
+++ b/apps/web/src/app/recipes/[id]/page.tsx
@@ -57,6 +57,7 @@ import { toast } from "@/hooks/use-toast";
 import { canWithOverrides } from "lib/src/rbac/roles";
 import { computeScaledAmount } from "lib/src/recipes/scaling";
 import { computeRecipeBOM, recipeRowsToBomInput } from "lib/src/recipes/bom";
+import { computeRecipeLabor } from "lib/src/recipes/labor";
 import { computeCumulativeOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
 
 // Color helpers (mirrored from the list page)
@@ -126,7 +127,6 @@ export default function RecipeDetailPage() {
   );
 
   const [previewVolumeL, setPreviewVolumeL] = useState<number>(120);
-  const [kegPortionL, setKegPortionL] = useState<number>(0);
   const [versionsOpen, setVersionsOpen] = useState(false);
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
   const [cloneName, setCloneName] = useState("");
@@ -195,15 +195,16 @@ export default function RecipeDetailPage() {
   const ingredients = inputs.filter((i) => i.kind === "ingredient");
   const parentBatchInputs = inputs.filter((i) => i.kind === "parent_batch_requirement");
 
-  // Bill of materials for the previewed batch size + bottle/keg split.
-  const kegL = Math.min(Math.max(0, kegPortionL), previewVolumeL);
+  // Bill of materials for the previewed batch size. Kegs are returnable
+  // vessels (keg tracker), not consumables, so the BOM previews the full batch
+  // as bottled; the real bottle/keg split is set per planned batch in Planning.
   const bom = computeRecipeBOM(
-    recipeRowsToBomInput(inputs, steps, {
-      targetVolumeL: previewVolumeL,
-      bottleL: previewVolumeL - kegL,
-      kegL,
-    }),
+    recipeRowsToBomInput(inputs, steps, { targetVolumeL: previewVolumeL }),
   );
+  // Labor rollup — sum of per-task estimates, grouped by packaging path.
+  const labor = computeRecipeLabor(steps);
+  const fmtHours = (h: number) =>
+    h === 0 ? "0 h" : `${h.toFixed(h < 10 ? 2 : 1).replace(/\.0+$/, "")} h`;
   const fmtQty = (q: number, unit: string) => {
     if (unit === "g" && q >= 1000) return `${(q / 1000).toFixed(2)} kg`;
     if (unit === "mL" && q >= 1000) return `${(q / 1000).toFixed(2)} L`;
@@ -496,29 +497,12 @@ export default function RecipeDetailPage() {
           <CardHeader>
             <CardTitle className="text-base">Bill of materials</CardTitle>
             <CardDescription>
-              Inventory consumed for a {previewVolumeL}L batch. Adjust the batch size
-              above; set the keg portion to split bottle vs keg.
+              Consumables for a {previewVolumeL}L batch, previewed as fully bottled.
+              Adjust the batch size above. Kegs are returnable vessels, not
+              consumables — the bottle/keg split is set per planned batch in Planning.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="flex items-end gap-3 flex-wrap">
-              <div>
-                <Label className="text-xs">Keg portion (L)</Label>
-                <Input
-                  type="number"
-                  min="0"
-                  max={previewVolumeL}
-                  step="1"
-                  value={kegPortionL}
-                  onChange={(e) => setKegPortionL(e.target.value === "" ? 0 : Number(e.target.value))}
-                  className="h-9 w-28"
-                />
-              </div>
-              <div className="text-sm text-muted-foreground pb-2">
-                → {previewVolumeL - kegL}L bottled · {kegL}L kegged
-              </div>
-            </div>
-
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
@@ -582,6 +566,44 @@ export default function RecipeDetailPage() {
                   </p>
                 ))}
               </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Labor estimate */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Labor</CardTitle>
+            <CardDescription>
+              Sum of the per-task labor estimates entered on the steps. Per-task
+              hours only — these don&apos;t yet scale with batch size.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-semibold">{fmtHours(labor.totalHours)}</span>
+              <span className="text-sm text-muted-foreground">estimated per batch</span>
+            </div>
+            <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+              <span className="flex justify-between gap-2">
+                <span className="text-gray-500">Shared</span>
+                <span className="font-mono">{fmtHours(labor.byPath.all)}</span>
+              </span>
+              <span className="flex justify-between gap-2">
+                <span className="text-gray-500">Bottle path</span>
+                <span className="font-mono">{fmtHours(labor.byPath.bottle)}</span>
+              </span>
+              <span className="flex justify-between gap-2">
+                <span className="text-gray-500">Keg path</span>
+                <span className="font-mono">{fmtHours(labor.byPath.keg)}</span>
+              </span>
+            </div>
+            {labor.stepsMissingEstimate > 0 && (
+              <p className="text-xs text-amber-700 flex items-start gap-1.5">
+                <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                {labor.stepsMissingEstimate} step{labor.stepsMissingEstimate === 1 ? "" : "s"} have
+                no labor estimate yet — add one on each step to complete the total.
+              </p>
             )}
           </CardContent>
         </Card>

--- a/packages/lib/src/__tests__/recipes/labor.test.ts
+++ b/packages/lib/src/__tests__/recipes/labor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { computeRecipeLabor } from "../../recipes/labor";
+
+describe("computeRecipeLabor", () => {
+  it("sums per-task hours grouped by packaging path", () => {
+    const labor = computeRecipeLabor([
+      { packagingPath: "all", estimatedDurationHours: "0.2" },
+      { packagingPath: "all", estimatedDurationHours: "0.3" },
+      { packagingPath: "bottle", estimatedDurationHours: 1 },
+      { packagingPath: "keg", estimatedDurationHours: 0.5 },
+    ]);
+    expect(labor.byPath).toEqual({ all: 0.5, bottle: 1, keg: 0.5 });
+    expect(labor.totalHours).toBe(2);
+    expect(labor.stepsCounted).toBe(4);
+    expect(labor.stepsMissingEstimate).toBe(0);
+  });
+
+  it("treats missing/zero/non-numeric estimates as unmeasured (not zero-labor)", () => {
+    const labor = computeRecipeLabor([
+      { packagingPath: "all", estimatedDurationHours: null },
+      { packagingPath: "bottle", estimatedDurationHours: 0 },
+      { packagingPath: "keg", estimatedDurationHours: "" },
+      { packagingPath: "all", estimatedDurationHours: "0.5" },
+    ]);
+    expect(labor.totalHours).toBe(0.5);
+    expect(labor.stepsCounted).toBe(1);
+    expect(labor.stepsMissingEstimate).toBe(3);
+  });
+
+  it("defaults an unknown/absent path to 'all'", () => {
+    const labor = computeRecipeLabor([
+      { estimatedDurationHours: 0.25 },
+      { packagingPath: "weird", estimatedDurationHours: 0.25 },
+    ]);
+    expect(labor.byPath.all).toBe(0.5);
+    expect(labor.totalHours).toBe(0.5);
+  });
+
+  it("returns zeros for an empty recipe", () => {
+    const labor = computeRecipeLabor([]);
+    expect(labor).toEqual({
+      totalHours: 0,
+      byPath: { all: 0, bottle: 0, keg: 0 },
+      stepsCounted: 0,
+      stepsMissingEstimate: 0,
+    });
+  });
+});

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -22,6 +22,7 @@ export * from "./calculations/so2";
 
 // Re-export recipe domain logic (client-safe)
 export * from "./recipes/bom";
+export * from "./recipes/labor";
 
 // Re-export apple-related constants and utilities (client-safe)
 export * from "./apples";

--- a/packages/lib/src/recipes/labor.ts
+++ b/packages/lib/src/recipes/labor.ts
@@ -1,0 +1,70 @@
+/**
+ * Recipe labor rollup — the "labor bill-of-materials".
+ *
+ * Sums the per-task labor estimates (`recipe_steps.estimatedDurationHours`)
+ * a recipe's author entered, into a per-batch total broken down by packaging
+ * path (shared / bottle / keg). This is the interim model: it uses the hours
+ * entered per task as-is.
+ *
+ * NOT YET MODELED (see the labor-requirements-tracking PRD): labor does not
+ * scale linearly with batch volume — fixed setup/cleaning vs volume-variable
+ * work, volume-stepped consumables (filter pads), etc. These estimates are
+ * per-task and volume-independent for now.
+ *
+ * Pure function. No DB, no side effects — easy to unit test.
+ */
+
+export interface LaborStepInput {
+  /** "all" | "bottle" | "keg" — defaults to "all". */
+  packagingPath?: string | null;
+  /** Decimal columns come back as strings from Drizzle; numbers accepted too. */
+  estimatedDurationHours?: string | number | null;
+}
+
+export interface RecipeLabor {
+  /** Sum of every step's estimate (shared + bottle + keg). */
+  totalHours: number;
+  /** Hours grouped by packaging path. */
+  byPath: { all: number; bottle: number; keg: number };
+  /** Steps that contributed a positive estimate. */
+  stepsCounted: number;
+  /** Steps with no usable estimate (null, zero, or non-numeric). */
+  stepsMissingEstimate: number;
+}
+
+/**
+ * Roll up per-task labor estimates for a recipe.
+ *
+ * @example
+ *   computeRecipeLabor([
+ *     { packagingPath: "all", estimatedDurationHours: "0.5" },
+ *     { packagingPath: "bottle", estimatedDurationHours: 1 },
+ *     { packagingPath: "keg", estimatedDurationHours: null },
+ *   ])
+ *   // { totalHours: 1.5, byPath: { all: 0.5, bottle: 1, keg: 0 },
+ *   //   stepsCounted: 2, stepsMissingEstimate: 1 }
+ */
+export function computeRecipeLabor(steps: LaborStepInput[]): RecipeLabor {
+  const byPath = { all: 0, bottle: 0, keg: 0 };
+  let stepsCounted = 0;
+  let stepsMissingEstimate = 0;
+
+  for (const s of steps) {
+    const h = s.estimatedDurationHours == null ? NaN : Number(s.estimatedDurationHours);
+    if (!Number.isFinite(h) || h <= 0) {
+      stepsMissingEstimate++;
+      continue;
+    }
+    const path =
+      s.packagingPath === "bottle" || s.packagingPath === "keg" ? s.packagingPath : "all";
+    byPath[path] += h;
+    stepsCounted++;
+  }
+
+  return {
+    totalHours: byPath.all + byPath.bottle + byPath.keg,
+    byPath,
+    stepsCounted,
+    stepsMissingEstimate,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a labor rollup to the recipe view and removes the keg-portion control from the BOM preview.

## Labor (interim labor BOM)
- New pure function `computeRecipeLabor` (`packages/lib/src/recipes/labor.ts`) sums each step's `estimatedDurationHours` into a per-batch total, grouped by packaging path (shared / bottle / keg).
- New **Labor** card on the recipe view: total estimated hours + the three-way breakdown, plus a hint listing how many steps still have no estimate.
- **Interim only:** per-task hours as entered, no volume scaling. The full model (fixed setup/cleaning vs volume-variable, filter-pad counts, labor-hours per planning period) is tracked in the `labor-requirements-tracking` PRD.
- 4 unit tests; full recipe suite 76/76 pass.

## BOM: keg portion removed
- Kegs are returnable vessels (keg tracker), not consumables, so the "Keg portion (L)" control no longer belongs on the bill of materials. Removed it; the BOM now previews the full batch as bottled.
- The real bottle/keg split is a per-planned-batch decision and lives in Planning (`planned_batches.bottle_volume_l` / `keg_volume_l`).

## Tests
- `pnpm --filter lib exec vitest run src/__tests__/recipes/` → 76/76
- `pnpm --filter web run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
