### PR TITLE
Recipe execution M1: instantiate + schedule + batch checklist

### DIFF
--- a/.claude/prds/recipe-execution-work-queue.md
+++ b/.claude/prds/recipe-execution-work-queue.md
@@ -119,6 +119,14 @@ work-queue surface, and wiring into the existing action modals.
 - **M3 — Action wiring (the payoff).** Task → pre-filled modal for the kinds that
   already have mutations (add_additive, measurement, rack, filter, transfer, carbonate,
   package). Record operation + link `result_ref` + BOM-prefilled quantities.
+  - **Partial draw from a base cider (user, 2026-06-18).** When a new batch starts
+    from an existing cider, the first transfer step must move just the chosen
+    portion (e.g. 120 L out of a 1000 L base) into a target vessel — exactly the
+    existing split-transfer/rack mechanism (`batchTransfers` + partial volume +
+    new vessel) used to make fruited cider today. The wizard's "Total volume" is
+    that portion; M3's transfer step needs a TARGET VESSEL input and reuses
+    `rackBatch`/transfer to draw the portion and seed the working batch. New-mode
+    M1 batches are shells (no vessel/liquid) until this transfer runs.
 - **M4 — Fill the gaps.** Pasteurize + label mutations; qa_gate sign-off; inventory
   drawdown pre-fill + soft shortfall warnings; per-task labor capture.
 - **M5 — Later.** Due-date notifications; role-scoped queue views (ties to
@@ -134,6 +142,11 @@ work-queue surface, and wiring into the existing action modals.
   (`parent_batch_requirement` vs `press_run_requirement` vs `juice_purchase_requirement`).
 - Where labor `actual_hours` is entered — in the action modal, or a quick prompt on
   complete.
+- **Editable volume + bottle/keg split after instantiation (user, 2026-06-18).** M1
+  sets total volume + keg split once at start. Make them editable later (M2): updating
+  the split must reconcile packaging-path tasks (add keg/bottle tasks when a side goes
+  >0, remove/skip when it goes to 0); changing total volume just re-derives BOM
+  quantities (not stored). Edit lives on the execution / checklist header.
 
 ## References
 

--- a/apps/web/src/app/batch/[id]/page.tsx
+++ b/apps/web/src/app/batch/[id]/page.tsx
@@ -61,6 +61,7 @@ import {
   XCircle,
   Gauge,
   TrendingDown,
+  ClipboardList,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -77,6 +78,7 @@ import { BatchVolumeTrace } from "@/components/batch/BatchVolumeTrace";
 import { CarbonateModal } from "@/components/batch/CarbonateModal";
 import { CompleteCarbonationModal } from "@/components/batch/CompleteCarbonationModal";
 import { EditCarbonationModal } from "@/components/batch/EditCarbonationModal";
+import { BatchRecipeChecklist } from "@/components/recipes/BatchRecipeChecklist";
 import { toast } from "@/hooks/use-toast";
 import {
   WeightDisplay,
@@ -738,6 +740,10 @@ export default function BatchDetailsPage() {
       >
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="recipe">
+            <ClipboardList className="w-4 h-4 mr-2" />
+            Recipe
+          </TabsTrigger>
           <TabsTrigger value="activity">
             <Activity className="w-4 h-4 mr-2" />
             Activity History
@@ -760,6 +766,11 @@ export default function BatchDetailsPage() {
             Volume Trace
           </TabsTrigger>
         </TabsList>
+
+        {/* Recipe Tab */}
+        <TabsContent value="recipe" className="space-y-6">
+          <BatchRecipeChecklist batchId={batchId} />
+        </TabsContent>
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-6">

--- a/apps/web/src/app/recipes/[id]/page.tsx
+++ b/apps/web/src/app/recipes/[id]/page.tsx
@@ -58,6 +58,7 @@ import { canWithOverrides } from "lib/src/rbac/roles";
 import { computeScaledAmount } from "lib/src/recipes/scaling";
 import { computeRecipeBOM, recipeRowsToBomInput } from "lib/src/recipes/bom";
 import { computeRecipeLabor } from "lib/src/recipes/labor";
+import { RecipeInstantiateWizard } from "@/components/recipes/RecipeInstantiateWizard";
 import { computeCumulativeOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
 
 // Color helpers (mirrored from the list page)
@@ -128,6 +129,7 @@ export default function RecipeDetailPage() {
 
   const [previewVolumeL, setPreviewVolumeL] = useState<number>(120);
   const [versionsOpen, setVersionsOpen] = useState(false);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
   const [cloneName, setCloneName] = useState("");
 
@@ -266,11 +268,21 @@ export default function RecipeDetailPage() {
                 <RotateCcw className="w-4 h-4 mr-1" /> Restore
               </Button>
             )}
-            <Button size="sm" disabled title="Coming in Phase 2 (batch wizard)">
-              <Play className="w-4 h-4 mr-1" /> Use this recipe
-            </Button>
+            {!isArchived && (
+              <Button size="sm" onClick={() => setWizardOpen(true)}>
+                <Play className="w-4 h-4 mr-1" /> Use this recipe
+              </Button>
+            )}
           </div>
         </div>
+
+        <RecipeInstantiateWizard
+          open={wizardOpen}
+          onClose={() => setWizardOpen(false)}
+          recipe={{ id: recipe.id, name: recipe.name, productType: recipe.productType }}
+          inputs={inputs}
+          steps={steps}
+        />
 
         {/* Recipe header */}
         <Card>

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * Read-only recipe checklist for a batch (Phase 5, M1).
+ *
+ * Shows the scheduled per-step task list for a batch that was instantiated from
+ * a recipe. M1 is read-only — completing/skipping tasks and the cross-batch
+ * work queue come in M2/M3.
+ */
+
+import { trpc } from "@/utils/trpc";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const STATUS_STYLE: Record<string, string> = {
+  pending: "border-gray-300 text-gray-600",
+  in_progress: "border-blue-300 text-blue-700",
+  done: "border-green-300 text-green-700",
+  skipped: "border-gray-200 text-gray-400",
+};
+
+const fmtDate = (d: string | Date | null) =>
+  d ? new Date(d).toLocaleDateString() : "—";
+
+export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
+  const { data, isLoading } = trpc.recipeExecution.getForBatch.useQuery({ batchId });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-sm text-muted-foreground">Loading…</CardContent>
+      </Card>
+    );
+  }
+
+  if (!data?.execution) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recipe checklist</CardTitle>
+          <CardDescription>
+            No recipe is attached to this batch. Open a recipe and choose “Use this
+            recipe” to generate a scheduled checklist.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const { execution, tasks } = data;
+  const done = tasks.filter((t) => t.status === "done").length;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Recipe checklist</CardTitle>
+        <CardDescription>
+          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)} ·{" "}
+          {execution.bottleVolumeL ?? 0} L bottled / {execution.kegVolumeL ?? 0} L kegged ·{" "}
+          {done}/{tasks.length} done
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">#</TableHead>
+              <TableHead>Step</TableHead>
+              <TableHead>Due</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tasks.map((t) => (
+              <TableRow key={t.id}>
+                <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span>{t.label}</span>
+                    {t.packagingPath !== "all" && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
+                      </Badge>
+                    )}
+                    {t.isOptional && (
+                      <Badge variant="outline" className="text-[10px] text-gray-500">
+                        Optional
+                      </Badge>
+                    )}
+                  </div>
+                  {t.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm">{fmtDate(t.scheduledDate)}</TableCell>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className={`text-[10px] ${STATUS_STYLE[t.status] ?? ""}`}
+                  >
+                    {t.status.replace("_", " ")}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
+++ b/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
@@ -120,8 +120,10 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
 
   const [mode, setMode] = useState<"new" | "attach">("new");
   const [startDate, setStartDate] = useState(todayStr());
-  const [totalVolumeL, setTotalVolumeL] = useState<number>(120);
-  const [kegVolumeL, setKegVolumeL] = useState<number>(0);
+  // String-backed so the field can be cleared/retyped freely (a numeric state
+  // would coerce an empty field back to 0, making the 0 impossible to delete).
+  const [totalVolumeStr, setTotalVolumeStr] = useState("120");
+  const [kegVolumeStr, setKegVolumeStr] = useState("0");
   const [newBatchName, setNewBatchName] = useState("");
   const [parentBatchIds, setParentBatchIds] = useState<string[]>([]);
   const [pressRunId, setPressRunId] = useState<string | null>(null);
@@ -177,6 +179,8 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
       description: `${b.currentVolume ?? "?"} ${b.currentVolumeUnit ?? "L"} · ${b.productType} · ${b.status}`,
     }));
 
+  const totalVolumeL = Number(totalVolumeStr) || 0;
+  const kegVolumeL = Number(kegVolumeStr) || 0;
   const bottleVolumeL = Math.max(0, totalVolumeL - kegVolumeL);
 
   const mutation = trpc.recipeExecution.instantiate.useMutation({
@@ -329,9 +333,13 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                 <Input
                   value={newBatchName}
                   onChange={(e) => setNewBatchName(e.target.value)}
-                  placeholder="Auto-generated if blank"
+                  placeholder={`${recipe.name} ${startDate.slice(0, 4)}-NNN`}
                   className="h-9"
                 />
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  Leave blank to auto-name “{recipe.name} {startDate.slice(0, 4)}-NNN”,
+                  where NNN is the next batch number for the year.
+                </p>
               </div>
             </div>
           )}
@@ -365,8 +373,8 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                 type="number"
                 min="0"
                 step="1"
-                value={totalVolumeL}
-                onChange={(e) => setTotalVolumeL(e.target.value === "" ? 0 : Number(e.target.value))}
+                value={totalVolumeStr}
+                onChange={(e) => setTotalVolumeStr(e.target.value)}
                 className="h-9"
               />
             </div>
@@ -377,8 +385,8 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                 min="0"
                 max={totalVolumeL}
                 step="1"
-                value={kegVolumeL}
-                onChange={(e) => setKegVolumeL(e.target.value === "" ? 0 : Number(e.target.value))}
+                value={kegVolumeStr}
+                onChange={(e) => setKegVolumeStr(e.target.value)}
                 className="h-9"
               />
             </div>

--- a/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
+++ b/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+/**
+ * "Use this recipe" wizard — instantiates a recipe into a live, scheduled batch.
+ *
+ * Mode is chosen each time: create a NEW batch (seeded from the source the
+ * recipe declares — existing ciders to blend, a press run, or a juice lot) or
+ * ATTACH the schedule to an existing batch. The bottle/keg split and which
+ * optional steps to include are set here. On success, navigates to the batch.
+ */
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { trpc } from "@/utils/trpc";
+import { toast } from "@/hooks/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+
+interface RecipeInput {
+  id: string;
+  kind: string;
+  label: string;
+  sourceProductType?: string | null;
+}
+interface RecipeStep {
+  id: string;
+  sequence: number;
+  label: string;
+  isOptional: boolean;
+  packagingPath: string;
+}
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  recipe: { id: string; name: string; productType: string };
+  inputs: RecipeInput[];
+  steps: RecipeStep[];
+}
+
+const todayStr = () => new Date().toISOString().slice(0, 10);
+
+export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }: Props) {
+  const router = useRouter();
+
+  const [mode, setMode] = useState<"new" | "attach">("new");
+  const [startDate, setStartDate] = useState(todayStr());
+  const [totalVolumeL, setTotalVolumeL] = useState<number>(120);
+  const [kegVolumeL, setKegVolumeL] = useState<number>(0);
+  const [newBatchName, setNewBatchName] = useState("");
+  const [parentBatchIds, setParentBatchIds] = useState<string[]>([]);
+  const [pressRunId, setPressRunId] = useState<string | null>(null);
+  const [juicePurchaseItemId, setJuicePurchaseItemId] = useState<string | null>(null);
+  const [existingBatchId, setExistingBatchId] = useState<string | null>(null);
+  const [skippedStepIds, setSkippedStepIds] = useState<Set<string>>(new Set());
+
+  const hasParentReq = inputs.some((i) => i.kind === "parent_batch_requirement");
+  const hasPressReq = inputs.some((i) => i.kind === "press_run_requirement");
+  const hasJuiceReq = inputs.some((i) => i.kind === "juice_purchase_requirement");
+  const optionalSteps = useMemo(() => steps.filter((s) => s.isOptional), [steps]);
+
+  // Source data — only fetch what's relevant while the dialog is open.
+  const batchesQuery = trpc.batch.list.useQuery(
+    { limit: 100 },
+    { enabled: open && (mode === "attach" || hasParentReq) },
+  );
+  const pressRunsQuery = trpc.pressRun.list.useQuery(
+    { status: "completed", limit: 100 },
+    { enabled: open && mode === "new" && hasPressReq },
+  );
+  const juiceQuery = trpc.juicePurchases.listInventory.useQuery(
+    { limit: 100 },
+    { enabled: open && mode === "new" && hasJuiceReq },
+  );
+
+  const activeBatches = (batchesQuery.data?.batches ?? []).filter(
+    (b) => b.status !== "completed" && b.status !== "discarded",
+  );
+  const batchOptions = activeBatches.map((b) => ({
+    value: b.id,
+    label: b.customName || b.name,
+    description: `${b.productType} · ${b.currentVolume ?? "?"} ${b.currentVolumeUnit ?? "L"} · ${b.status}`,
+  }));
+
+  const bottleVolumeL = Math.max(0, totalVolumeL - kegVolumeL);
+
+  const mutation = trpc.recipeExecution.instantiate.useMutation({
+    onSuccess: (res) => {
+      toast({ title: "Recipe started", description: `${res.taskCount} steps scheduled.` });
+      onClose();
+      router.push(`/batch/${res.batchId}`);
+    },
+    onError: (err) => {
+      toast({ title: "Couldn't start recipe", description: err.message, variant: "destructive" });
+    },
+  });
+
+  const sourceMissing =
+    mode === "new" &&
+    (hasParentReq || hasPressReq || hasJuiceReq) &&
+    parentBatchIds.length === 0 &&
+    !pressRunId &&
+    !juicePurchaseItemId;
+  const canSubmit =
+    totalVolumeL > 0 &&
+    kegVolumeL >= 0 &&
+    kegVolumeL <= totalVolumeL &&
+    (mode === "attach" ? !!existingBatchId : !sourceMissing) &&
+    !mutation.isPending;
+
+  const submit = () => {
+    mutation.mutate({
+      recipeId: recipe.id,
+      mode,
+      startDate,
+      totalVolumeL,
+      kegVolumeL,
+      parentBatchIds,
+      pressRunId: pressRunId ?? undefined,
+      juicePurchaseItemId: juicePurchaseItemId ?? undefined,
+      newBatchName: newBatchName.trim() || undefined,
+      existingBatchId: existingBatchId ?? undefined,
+      skippedStepIds: Array.from(skippedStepIds),
+    });
+  };
+
+  const addParentBatch = (id: string) => {
+    setParentBatchIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Use “{recipe.name}”</DialogTitle>
+          <DialogDescription>
+            Create a scheduled batch from this recipe, or attach it to a batch you
+            already have.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Mode */}
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={mode === "new" ? "default" : "outline"}
+              onClick={() => setMode("new")}
+              size="sm"
+            >
+              Create new batch
+            </Button>
+            <Button
+              type="button"
+              variant={mode === "attach" ? "default" : "outline"}
+              onClick={() => setMode("attach")}
+              size="sm"
+            >
+              Attach to existing
+            </Button>
+          </div>
+
+          {/* Source (new mode) */}
+          {mode === "new" && (
+            <div className="space-y-3">
+              {hasParentReq && (
+                <div>
+                  <Label className="text-xs">
+                    Start from cider {parentBatchIds.length > 1 ? "(blend)" : ""}
+                  </Label>
+                  {parentBatchIds.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 my-1.5">
+                      {parentBatchIds.map((id) => {
+                        const b = activeBatches.find((x) => x.id === id);
+                        return (
+                          <Badge key={id} variant="secondary" className="gap-1">
+                            {b?.customName || b?.name || id.slice(0, 8)}
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setParentBatchIds((p) => p.filter((x) => x !== id))
+                              }
+                            >
+                              <X className="w-3 h-3" />
+                            </button>
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  )}
+                  <SearchableSelect
+                    options={batchOptions.filter((o) => !parentBatchIds.includes(o.value))}
+                    value=""
+                    onValueChange={addParentBatch}
+                    placeholder="Add a base cider…"
+                    searchPlaceholder="Search batches…"
+                    emptyText="No batches available."
+                  />
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    Pick one for a single varietal, or several to blend.
+                  </p>
+                </div>
+              )}
+              {hasPressReq && (
+                <div>
+                  <Label className="text-xs">Start from a press run (juice)</Label>
+                  <SearchableSelect
+                    options={(pressRunsQuery.data?.pressRuns ?? []).map((p) => ({
+                      value: p.id,
+                      label: p.pressRunName || p.id.slice(0, 8),
+                      description: `${p.totalJuiceVolume ?? "?"} ${p.totalJuiceVolumeUnit ?? "L"}`,
+                    }))}
+                    value={pressRunId ?? ""}
+                    onValueChange={(v) => setPressRunId(v || null)}
+                    placeholder="Select a press run…"
+                  />
+                </div>
+              )}
+              {hasJuiceReq && (
+                <div>
+                  <Label className="text-xs">Start from purchased juice</Label>
+                  <SearchableSelect
+                    options={(juiceQuery.data?.items ?? []).map((j) => ({
+                      value: j.id,
+                      label: j.varietyName || j.juiceType || j.id.slice(0, 8),
+                      description: `${j.availableVolume ?? "?"} ${j.volumeUnit ?? "L"} available`,
+                    }))}
+                    value={juicePurchaseItemId ?? ""}
+                    onValueChange={(v) => setJuicePurchaseItemId(v || null)}
+                    placeholder="Select a juice lot…"
+                  />
+                </div>
+              )}
+              <div>
+                <Label className="text-xs">New batch name (optional)</Label>
+                <Input
+                  value={newBatchName}
+                  onChange={(e) => setNewBatchName(e.target.value)}
+                  placeholder="Auto-generated if blank"
+                  className="h-9"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Attach mode */}
+          {mode === "attach" && (
+            <div>
+              <Label className="text-xs">Attach to batch</Label>
+              <SearchableSelect
+                options={batchOptions}
+                value={existingBatchId ?? ""}
+                onValueChange={(v) => setExistingBatchId(v || null)}
+                placeholder="Select a batch…"
+                searchPlaceholder="Search batches…"
+              />
+            </div>
+          )}
+
+          {/* Start date + volume split */}
+          <div className="grid grid-cols-3 gap-2">
+            <div>
+              <Label className="text-xs">Start date</Label>
+              <Input
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="h-9"
+              />
+            </div>
+            <div>
+              <Label className="text-xs">Total volume (L)</Label>
+              <Input
+                type="number"
+                min="0"
+                step="1"
+                value={totalVolumeL}
+                onChange={(e) => setTotalVolumeL(e.target.value === "" ? 0 : Number(e.target.value))}
+                className="h-9"
+              />
+            </div>
+            <div>
+              <Label className="text-xs">Keg portion (L)</Label>
+              <Input
+                type="number"
+                min="0"
+                max={totalVolumeL}
+                step="1"
+                value={kegVolumeL}
+                onChange={(e) => setKegVolumeL(e.target.value === "" ? 0 : Number(e.target.value))}
+                className="h-9"
+              />
+            </div>
+          </div>
+          <p className="text-[11px] text-muted-foreground -mt-2">
+            → {bottleVolumeL} L bottled · {kegVolumeL} L kegged. Keg-only and
+            bottle-only steps are included only if that portion is &gt; 0.
+          </p>
+
+          {/* Optional steps */}
+          {optionalSteps.length > 0 && (
+            <div>
+              <Label className="text-xs">Optional steps</Label>
+              <div className="space-y-1.5 mt-1">
+                {optionalSteps.map((s) => (
+                  <label key={s.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                    <Checkbox
+                      checked={!skippedStepIds.has(s.id)}
+                      onCheckedChange={(c) =>
+                        setSkippedStepIds((prev) => {
+                          const next = new Set(prev);
+                          if (c === true) next.delete(s.id);
+                          else next.add(s.id);
+                          return next;
+                        })
+                      }
+                    />
+                    <span>{s.label}</span>
+                    {s.packagingPath !== "all" && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {s.packagingPath}
+                      </Badge>
+                    )}
+                  </label>
+                ))}
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-1">
+                Unchecked steps are skipped for this batch.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={submit} disabled={!canSubmit}>
+              {mutation.isPending ? "Starting…" : "Start batch"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
+++ b/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
@@ -26,7 +26,71 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Badge } from "@/components/ui/badge";
-import { X } from "lucide-react";
+import { X, Check } from "lucide-react";
+
+/**
+ * Inline, scrollable, searchable batch list. Lives directly in the dialog flow
+ * (not a nested popover) so it scrolls reliably and shows every match.
+ */
+function InlineBatchList({
+  options,
+  selectedIds,
+  onPick,
+}: {
+  options: { value: string; label: string; description?: string }[];
+  selectedIds: string[];
+  onPick: (id: string) => void;
+}) {
+  const [q, setQ] = useState("");
+  const ql = q.trim().toLowerCase();
+  const filtered = ql
+    ? options.filter(
+        (o) =>
+          o.label.toLowerCase().includes(ql) ||
+          (o.description ?? "").toLowerCase().includes(ql),
+      )
+    : options;
+  return (
+    <div>
+      <Input
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Search batches…"
+        className="h-9 mb-1.5"
+      />
+      <div className="max-h-48 overflow-y-auto border rounded-md divide-y">
+        {filtered.length === 0 ? (
+          <p className="text-sm text-muted-foreground px-2.5 py-3">No batches found.</p>
+        ) : (
+          filtered.map((o) => {
+            const selected = selectedIds.includes(o.value);
+            return (
+              <button
+                key={o.value}
+                type="button"
+                onClick={() => onPick(o.value)}
+                className={`w-full text-left px-2.5 py-1.5 text-sm hover:bg-gray-50 flex items-center justify-between gap-2 ${
+                  selected ? "bg-green-50" : ""
+                }`}
+              >
+                <span className="min-w-0">
+                  <span className="block truncate">{o.label}</span>
+                  {o.description && (
+                    <span className="block text-xs text-muted-foreground truncate">
+                      {o.description}
+                    </span>
+                  )}
+                </span>
+                {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}
+              </button>
+            );
+          })
+        )}
+      </div>
+      <p className="text-[11px] text-muted-foreground mt-1">{filtered.length} shown</p>
+    </div>
+  );
+}
 
 interface RecipeInput {
   id: string;
@@ -87,11 +151,31 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
   const activeBatches = (batchesQuery.data?.batches ?? []).filter(
     (b) => b.status !== "completed" && b.status !== "discarded",
   );
+  // Attach mode: any active batch.
   const batchOptions = activeBatches.map((b) => ({
     value: b.id,
     label: b.customName || b.name,
-    description: `${b.productType} · ${b.currentVolume ?? "?"} ${b.currentVolumeUnit ?? "L"} · ${b.status}`,
+    description: `${b.vesselName ?? "no vessel"} · ${b.currentVolume ?? "?"} ${b.currentVolumeUnit ?? "L"} · ${b.status}`,
   }));
+
+  // "Start from cider": only batches sitting in a cellar vessel with liquid in
+  // them (ready to use), filtered to the product type(s) the recipe declares.
+  const parentReqTypes = inputs
+    .filter((i) => i.kind === "parent_batch_requirement")
+    .map((i) => i.sourceProductType)
+    .filter((t): t is string => !!t);
+  const parentCiderOptions = activeBatches
+    .filter(
+      (b) =>
+        !!b.vesselName &&
+        Number(b.currentVolume ?? 0) > 0 &&
+        (parentReqTypes.length === 0 || parentReqTypes.includes(b.productType)),
+    )
+    .map((b) => ({
+      value: b.id,
+      label: `${b.customName || b.name} — ${b.vesselName}`,
+      description: `${b.currentVolume ?? "?"} ${b.currentVolumeUnit ?? "L"} · ${b.productType} · ${b.status}`,
+    }));
 
   const bottleVolumeL = Math.max(0, totalVolumeL - kegVolumeL);
 
@@ -133,10 +217,6 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
       existingBatchId: existingBatchId ?? undefined,
       skippedStepIds: Array.from(skippedStepIds),
     });
-  };
-
-  const addParentBatch = (id: string) => {
-    setParentBatchIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
   };
 
   return (
@@ -185,7 +265,7 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                         const b = activeBatches.find((x) => x.id === id);
                         return (
                           <Badge key={id} variant="secondary" className="gap-1">
-                            {b?.customName || b?.name || id.slice(0, 8)}
+                            {b ? `${b.customName || b.name} — ${b.vesselName ?? "?"}` : id.slice(0, 8)}
                             <button
                               type="button"
                               onClick={() =>
@@ -199,16 +279,18 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                       })}
                     </div>
                   )}
-                  <SearchableSelect
-                    options={batchOptions.filter((o) => !parentBatchIds.includes(o.value))}
-                    value=""
-                    onValueChange={addParentBatch}
-                    placeholder="Add a base cider…"
-                    searchPlaceholder="Search batches…"
-                    emptyText="No batches available."
+                  <InlineBatchList
+                    options={parentCiderOptions}
+                    selectedIds={parentBatchIds}
+                    onPick={(id) =>
+                      setParentBatchIds((p) =>
+                        p.includes(id) ? p.filter((x) => x !== id) : [...p, id],
+                      )
+                    }
                   />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Pick one for a single varietal, or several to blend.
+                    Ciders currently in a cellar vessel. Pick one for a single varietal,
+                    or several to blend. Click again to remove.
                   </p>
                 </div>
               )}
@@ -258,12 +340,10 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
           {mode === "attach" && (
             <div>
               <Label className="text-xs">Attach to batch</Label>
-              <SearchableSelect
+              <InlineBatchList
                 options={batchOptions}
-                value={existingBatchId ?? ""}
-                onValueChange={(v) => setExistingBatchId(v || null)}
-                placeholder="Select a batch…"
-                searchPlaceholder="Search batches…"
+                selectedIds={existingBatchId ? [existingBatchId] : []}
+                onPick={(id) => setExistingBatchId((cur) => (cur === id ? null : id))}
               />
             </div>
           )}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -40,6 +40,7 @@ import { customProductTypesRouter } from "./customProductTypes";
 import { distillationRouter } from "./distillation";
 import { productionReportsRouter } from "./productionReports";
 import { recipesRouter } from "./recipes";
+import { recipeExecutionRouter } from "./recipeExecution";
 import { planningRouter } from "./planning";
 import { MIN_WORKING_VOLUME_L } from "lib";
 import { writeLedgerEntry } from "../lib/volume-ledger";
@@ -6914,6 +6915,9 @@ export const appRouter = router({
 
   // Recipes
   recipes: recipesRouter,
+
+  // Recipe execution (instantiate → scheduled work queue)
+  recipeExecution: recipeExecutionRouter,
 
   // Production planning (plans, planned batches, requirements)
   planning: planningRouter,

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -1,0 +1,229 @@
+/**
+ * Recipe execution router (Phase 5, M1).
+ *
+ * `instantiate` turns a recipe version into a live batch with a scheduled,
+ * per-step task list (the work-queue items). Two modes:
+ *   - "new": create a batch seeded from the chosen source (existing cider
+ *     batches to blend, a press run, or a juice lot — whatever the recipe
+ *     declares), then attach the schedule.
+ *   - "attach": apply the schedule to a batch that already exists.
+ *
+ * Steps are SNAPSHOTTED into `batch_step_tasks` at instantiation so later edits
+ * to the recipe template never disrupt an in-flight batch. The bottle/keg split
+ * determines which packaging-path steps are generated. Optional steps the
+ * operator chose to skip are omitted. Due-dates come from `buildStepSchedule`.
+ *
+ * RBAC: `batch` entity (execution creates/reads batch-level work).
+ */
+
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import {
+  db,
+  batches,
+  recipes,
+  recipeSteps,
+  batchRecipeExecutions,
+  batchStepTasks,
+} from "db";
+import { buildStepSchedule } from "lib";
+import { router, createRbacProcedure } from "../trpc";
+
+const instantiateSchema = z
+  .object({
+    recipeId: z.string().uuid(),
+    mode: z.enum(["new", "attach"]),
+    startDate: z.coerce.date(),
+    totalVolumeL: z.number().positive(),
+    kegVolumeL: z.number().min(0).default(0),
+    // "new" mode source selection (only the ones the recipe declares are used)
+    parentBatchIds: z.array(z.string().uuid()).default([]),
+    pressRunId: z.string().uuid().nullish(),
+    juicePurchaseItemId: z.string().uuid().nullish(),
+    newBatchName: z.string().max(200).nullish(),
+    // "attach" mode
+    existingBatchId: z.string().uuid().nullish(),
+    // Optional steps to skip (recipe_steps.id)
+    skippedStepIds: z.array(z.string().uuid()).default([]),
+  })
+  .refine((v) => v.kegVolumeL <= v.totalVolumeL, {
+    message: "Keg portion can't exceed total volume",
+    path: ["kegVolumeL"],
+  })
+  .refine((v) => v.mode !== "attach" || !!v.existingBatchId, {
+    message: "Pick a batch to attach to",
+    path: ["existingBatchId"],
+  });
+
+export const recipeExecutionRouter = router({
+  /** Instantiate a recipe into a live, scheduled batch. */
+  instantiate: createRbacProcedure("create", "batch")
+    .input(instantiateSchema)
+    .mutation(async ({ input, ctx }) => {
+      const [recipe] = await db
+        .select()
+        .from(recipes)
+        .where(eq(recipes.id, input.recipeId))
+        .limit(1);
+      if (!recipe) throw new TRPCError({ code: "NOT_FOUND", message: "Recipe not found" });
+
+      const allSteps = await db
+        .select()
+        .from(recipeSteps)
+        .where(eq(recipeSteps.recipeId, input.recipeId))
+        .orderBy(asc(recipeSteps.sequence));
+
+      const bottleVolumeL = Math.max(0, input.totalVolumeL - input.kegVolumeL);
+      const kegVolumeL = input.kegVolumeL;
+
+      // Which steps actually run: respect the split + skipped optional steps.
+      const skipped = new Set(input.skippedStepIds);
+      const runSteps = allSteps.filter((s) => {
+        if (skipped.has(s.id)) return false;
+        const path = s.packagingPath ?? "all";
+        if (path === "bottle" && bottleVolumeL <= 0) return false;
+        if (path === "keg" && kegVolumeL <= 0) return false;
+        return true;
+      });
+
+      const scheduled = buildStepSchedule(
+        runSteps.map((s) => ({
+          triggerKind: s.triggerKind,
+          triggerData: (s.triggerData ?? {}) as Record<string, unknown>,
+        })),
+        input.startDate,
+      );
+
+      return await db.transaction(async (tx) => {
+        let batchId: string;
+
+        if (input.mode === "attach") {
+          const [existing] = await tx
+            .select({ id: batches.id })
+            .from(batches)
+            .where(eq(batches.id, input.existingBatchId!))
+            .limit(1);
+          if (!existing) throw new TRPCError({ code: "NOT_FOUND", message: "Batch not found" });
+          batchId = existing.id;
+        } else {
+          // Create a new batch shell seeded from the chosen source. Liquid is
+          // moved when the transfer step runs (M3); here we record origin/lineage.
+          const year = input.startDate.getFullYear();
+          const [{ count }] = await tx
+            .select({ count: sql<number>`count(*)` })
+            .from(batches)
+            .where(
+              and(
+                sql`EXTRACT(YEAR FROM ${batches.startDate}) = ${year}`,
+                isNull(batches.deletedAt),
+              ),
+            );
+          const batchNumber = `${year}-${String(Number(count) + 1).padStart(3, "0")}`;
+          const name = input.newBatchName?.trim() || `${recipe.name} ${batchNumber}`;
+          const status =
+            input.parentBatchIds.length > 0
+              ? "conditioning"
+              : recipe.productType === "brandy" || recipe.productType === "pommeau"
+                ? "aging"
+                : "fermentation";
+
+          const [created] = await tx
+            .insert(batches)
+            .values({
+              name,
+              batchNumber,
+              vesselId: null,
+              initialVolume: input.totalVolumeL.toString(),
+              initialVolumeUnit: "L",
+              currentVolume: input.totalVolumeL.toString(),
+              currentVolumeUnit: "L",
+              productType: recipe.productType,
+              status,
+              startDate: input.startDate,
+              parentBatchId: input.parentBatchIds[0] ?? null,
+              originPressRunId: input.pressRunId ?? null,
+              originJuicePurchaseItemId: input.juicePurchaseItemId ?? null,
+            })
+            .returning({ id: batches.id });
+          batchId = created.id;
+        }
+
+        // Guard: one active execution per batch (also enforced by unique index).
+        const [dupe] = await tx
+          .select({ id: batchRecipeExecutions.id })
+          .from(batchRecipeExecutions)
+          .where(eq(batchRecipeExecutions.batchId, batchId))
+          .limit(1);
+        if (dupe) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "This batch already has a recipe attached.",
+          });
+        }
+
+        const [execution] = await tx
+          .insert(batchRecipeExecutions)
+          .values({
+            batchId,
+            recipeId: recipe.id,
+            recipeVersion: recipe.currentVersion,
+            mode: input.mode,
+            startDate: input.startDate,
+            sourceRefs: {
+              parentBatchIds: input.parentBatchIds,
+              pressRunId: input.pressRunId ?? null,
+              juicePurchaseItemId: input.juicePurchaseItemId ?? null,
+            },
+            bottleVolumeL: bottleVolumeL.toString(),
+            kegVolumeL: kegVolumeL.toString(),
+            status: "active",
+            createdBy: ctx.user.id,
+          })
+          .returning({ id: batchRecipeExecutions.id });
+
+        if (runSteps.length > 0) {
+          await tx.insert(batchStepTasks).values(
+            runSteps.map((s, i) => ({
+              executionId: execution.id,
+              batchId,
+              sequence: i,
+              kind: s.kind,
+              label: s.label,
+              description: s.description ?? null,
+              packagingPath: s.packagingPath ?? "all",
+              isOptional: s.isOptional ?? false,
+              triggerKind: s.triggerKind,
+              triggerData: (s.triggerData ?? {}) as Record<string, unknown>,
+              actionData: (s.actionData ?? {}) as Record<string, unknown>,
+              scheduledDate: scheduled[i],
+              status: "pending",
+              estimatedHours: s.estimatedDurationHours ?? null,
+            })),
+          );
+        }
+
+        return { batchId, executionId: execution.id, taskCount: runSteps.length };
+      });
+    }),
+
+  /** The recipe execution + ordered task list for a batch (null if none). */
+  getForBatch: createRbacProcedure("read", "batch")
+    .input(z.object({ batchId: z.string().uuid() }))
+    .query(async ({ input }) => {
+      const [execution] = await db
+        .select()
+        .from(batchRecipeExecutions)
+        .where(eq(batchRecipeExecutions.batchId, input.batchId))
+        .limit(1);
+      if (!execution) return { execution: null, tasks: [] };
+
+      const tasks = await db
+        .select()
+        .from(batchStepTasks)
+        .where(eq(batchStepTasks.executionId, execution.id))
+        .orderBy(asc(batchStepTasks.sequence));
+
+      return { execution, tasks };
+    }),
+});

--- a/packages/db/migrations/0138_recipe_execution.sql
+++ b/packages/db/migrations/0138_recipe_execution.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS batch_recipe_executions (
   recipe_version  INTEGER NOT NULL,
   mode            TEXT NOT NULL,
   start_date      TIMESTAMPTZ NOT NULL,
+  source_refs     JSONB,
   bottle_volume_l NUMERIC(12, 3),
   keg_volume_l    NUMERIC(12, 3),
   status          TEXT NOT NULL DEFAULT 'active',

--- a/packages/db/migrations/0138_recipe_execution.sql
+++ b/packages/db/migrations/0138_recipe_execution.sql
@@ -1,0 +1,56 @@
+-- Recipe execution (Phase 5 — work queue).
+--
+-- batch_recipe_executions: links a batch to the recipe version it runs. One
+-- active execution per batch (unique batch_id). mode = 'new' | 'attach'.
+-- batch_step_tasks: a snapshot of each recipe step at instantiation, so editing
+-- the recipe template never disrupts an in-flight batch. Drives the work queue.
+
+CREATE TABLE IF NOT EXISTS batch_recipe_executions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  batch_id        UUID NOT NULL REFERENCES batches(id) ON DELETE CASCADE,
+  recipe_id       UUID NOT NULL REFERENCES recipes(id),
+  recipe_version  INTEGER NOT NULL,
+  mode            TEXT NOT NULL,
+  start_date      TIMESTAMPTZ NOT NULL,
+  bottle_volume_l NUMERIC(12, 3),
+  keg_volume_l    NUMERIC(12, 3),
+  status          TEXT NOT NULL DEFAULT 'active',
+  created_by      UUID REFERENCES users(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS batch_recipe_executions_batch_unique
+  ON batch_recipe_executions (batch_id);
+
+CREATE TABLE IF NOT EXISTS batch_step_tasks (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  execution_id       UUID NOT NULL REFERENCES batch_recipe_executions(id) ON DELETE CASCADE,
+  batch_id           UUID NOT NULL REFERENCES batches(id) ON DELETE CASCADE,
+  sequence           INTEGER NOT NULL,
+  kind               TEXT NOT NULL,
+  label              TEXT NOT NULL,
+  description        TEXT,
+  packaging_path     TEXT NOT NULL DEFAULT 'all',
+  is_optional        BOOLEAN NOT NULL DEFAULT FALSE,
+  trigger_kind       TEXT NOT NULL DEFAULT 'manual',
+  trigger_data       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  action_data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  scheduled_date     TIMESTAMPTZ,
+  status             TEXT NOT NULL DEFAULT 'pending',
+  completed_at       TIMESTAMPTZ,
+  assigned_worker_id UUID REFERENCES workers(id),
+  result_ref         JSONB,
+  estimated_hours    NUMERIC(6, 2),
+  actual_hours       NUMERIC(6, 2),
+  notes              TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS batch_step_tasks_exec_seq_idx
+  ON batch_step_tasks (execution_id, sequence);
+CREATE INDEX IF NOT EXISTS batch_step_tasks_batch_idx
+  ON batch_step_tasks (batch_id);
+CREATE INDEX IF NOT EXISTS batch_step_tasks_status_sched_idx
+  ON batch_step_tasks (status, scheduled_date);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1934,6 +1934,83 @@ export const recipeVersions = pgTable(
 );
 
 // ============================================
+// RECIPE EXECUTION (Phase 5 — work queue)
+// ============================================
+
+// Links a batch to the recipe version it is running. One active execution per
+// batch (one batch per recipe). `mode` records how it was instantiated: 'new'
+// (a batch created from a source) or 'attach' (an existing batch). The
+// bottle/keg split is the per-batch input the BOM/scheduling needs.
+export const batchRecipeExecutions = pgTable(
+  "batch_recipe_executions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    batchId: uuid("batch_id")
+      .notNull()
+      .references(() => batches.id, { onDelete: "cascade" }),
+    recipeId: uuid("recipe_id")
+      .notNull()
+      .references(() => recipes.id),
+    recipeVersion: integer("recipe_version").notNull(),
+    mode: text("mode").notNull(), // 'new' | 'attach'
+    startDate: timestamp("start_date", { withTimezone: true }).notNull(),
+    bottleVolumeL: decimal("bottle_volume_l", { precision: 12, scale: 3 }),
+    kegVolumeL: decimal("keg_volume_l", { precision: 12, scale: 3 }),
+    status: text("status").notNull().default("active"), // active | completed | abandoned
+    createdBy: uuid("created_by").references(() => users.id),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    // One active recipe execution per batch.
+    batchUnique: uniqueIndex("batch_recipe_executions_batch_unique").on(table.batchId),
+  }),
+);
+
+// The work-queue items: a SNAPSHOT of each recipe step at instantiation, so
+// later edits to the recipe template never disrupt an in-flight batch. Status +
+// scheduled_date drive the cross-batch work queue; result_ref links the
+// operation row created when the task's action runs (M3).
+export const batchStepTasks = pgTable(
+  "batch_step_tasks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    executionId: uuid("execution_id")
+      .notNull()
+      .references(() => batchRecipeExecutions.id, { onDelete: "cascade" }),
+    batchId: uuid("batch_id")
+      .notNull()
+      .references(() => batches.id, { onDelete: "cascade" }),
+    sequence: integer("sequence").notNull(),
+    kind: text("kind").notNull(),
+    label: text("label").notNull(),
+    description: text("description"),
+    packagingPath: text("packaging_path").notNull().default("all"),
+    isOptional: boolean("is_optional").notNull().default(false),
+    triggerKind: text("trigger_kind").notNull().default("manual"),
+    triggerData: jsonb("trigger_data").notNull().default({}),
+    actionData: jsonb("action_data").notNull().default({}),
+    // Computed calendar due-date; null when the trigger is SG-based / indeterminate.
+    scheduledDate: timestamp("scheduled_date", { withTimezone: true }),
+    status: text("status").notNull().default("pending"), // pending | in_progress | done | skipped
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    assignedWorkerId: uuid("assigned_worker_id").references(() => workers.id),
+    // {type, id} of the operation row created when this task ran (e.g. batchAdditive).
+    resultRef: jsonb("result_ref"),
+    estimatedHours: decimal("estimated_hours", { precision: 6, scale: 2 }),
+    actualHours: decimal("actual_hours", { precision: 6, scale: 2 }),
+    notes: text("notes"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    execSeqIdx: index("batch_step_tasks_exec_seq_idx").on(table.executionId, table.sequence),
+    batchIdx: index("batch_step_tasks_batch_idx").on(table.batchId),
+    statusSchedIdx: index("batch_step_tasks_status_sched_idx").on(table.status, table.scheduledDate),
+  }),
+);
+
+// ============================================
 // BATCH VOLUME LEDGER
 // ============================================
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1954,6 +1954,9 @@ export const batchRecipeExecutions = pgTable(
     recipeVersion: integer("recipe_version").notNull(),
     mode: text("mode").notNull(), // 'new' | 'attach'
     startDate: timestamp("start_date", { withTimezone: true }).notNull(),
+    // Chosen starting liquid for 'new' mode: { parentBatchIds: [], pressRunId, juicePurchaseItemId }.
+    // Used to seed the batch and (in M3) pre-fill the first transfer/blend action.
+    sourceRefs: jsonb("source_refs"),
     bottleVolumeL: decimal("bottle_volume_l", { precision: 12, scale: 3 }),
     kegVolumeL: decimal("keg_volume_l", { precision: 12, scale: 3 }),
     status: text("status").notNull().default("active"), // active | completed | abandoned

--- a/packages/lib/src/__tests__/recipes/schedule.test.ts
+++ b/packages/lib/src/__tests__/recipes/schedule.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildStepSchedule } from "../../recipes/schedule";
+
+const START = new Date("2026-06-01T00:00:00Z");
+const iso = (d: Date | null) => (d === null ? null : d.toISOString());
+
+describe("buildStepSchedule", () => {
+  it("places steps by cumulative offset from the start date", () => {
+    const dates = buildStepSchedule(
+      [
+        { triggerKind: "date_offset_from_start", triggerData: { days: 0 } },
+        { triggerKind: "after_previous", triggerData: {} }, // same point as prev
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 3 } },
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 2 } },
+      ],
+      START,
+    );
+    expect(iso(dates[0])).toBe("2026-06-01T00:00:00.000Z");
+    expect(iso(dates[1])).toBe("2026-06-01T00:00:00.000Z");
+    expect(iso(dates[2])).toBe("2026-06-04T00:00:00.000Z"); // +3 days
+    expect(iso(dates[3])).toBe("2026-06-06T00:00:00.000Z"); // +2 more days
+  });
+
+  it("supports hour offsets", () => {
+    const dates = buildStepSchedule(
+      [{ triggerKind: "date_offset_from_start", triggerData: { hours: 12 } }],
+      START,
+    );
+    expect(iso(dates[0])).toBe("2026-06-01T12:00:00.000Z");
+  });
+
+  it("returns null from an SG-based trigger onward (indeterminate)", () => {
+    const dates = buildStepSchedule(
+      [
+        { triggerKind: "date_offset_from_start", triggerData: { days: 1 } },
+        { triggerKind: "sg_terminal_confirmed", triggerData: {} },
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 2 } },
+      ],
+      START,
+    );
+    expect(iso(dates[0])).toBe("2026-06-02T00:00:00.000Z");
+    expect(dates[1]).toBeNull();
+    expect(dates[2]).toBeNull();
+  });
+
+  it("treats manual triggers as the running position (no advance)", () => {
+    const dates = buildStepSchedule(
+      [
+        { triggerKind: "date_offset_from_start", triggerData: { days: 5 } },
+        { triggerKind: "manual", triggerData: {} },
+      ],
+      START,
+    );
+    expect(iso(dates[0])).toBe("2026-06-06T00:00:00.000Z");
+    expect(iso(dates[1])).toBe("2026-06-06T00:00:00.000Z");
+  });
+
+  it("returns an empty array for no steps", () => {
+    expect(buildStepSchedule([], START)).toEqual([]);
+  });
+});

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -23,6 +23,7 @@ export * from "./calculations/so2";
 // Re-export recipe domain logic (client-safe)
 export * from "./recipes/bom";
 export * from "./recipes/labor";
+export * from "./recipes/schedule";
 
 // Re-export apple-related constants and utilities (client-safe)
 export * from "./apples";

--- a/packages/lib/src/recipes/schedule.ts
+++ b/packages/lib/src/recipes/schedule.ts
@@ -1,0 +1,41 @@
+/**
+ * Recipe execution scheduling.
+ *
+ * Turns a recipe's ordered steps + a batch start date into a calendar due-date
+ * per step, by walking the trigger model. Reuses `computeCumulativeOffsets`
+ * (the same math the recipe view uses for "day 5 from start"), so the preview
+ * and the live schedule never diverge.
+ *
+ * SG-based / indeterminate triggers (sg_threshold, sg_terminal_confirmed, or a
+ * missing offset) yield a null due-date — those steps are operator-driven and
+ * can't be placed on the calendar ahead of time.
+ *
+ * Pure functions. No DB, no side effects — easy to unit test.
+ */
+
+import { computeCumulativeOffsets, type ScheduleStep } from "./triggers";
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Compute the initial scheduled due-date for each step, in order.
+ *
+ * @example
+ *   buildStepSchedule(
+ *     [
+ *       { triggerKind: "date_offset_from_start", triggerData: { days: 0 } },
+ *       { triggerKind: "date_offset_from_previous", triggerData: { days: 3 } },
+ *       { triggerKind: "sg_terminal_confirmed", triggerData: {} },
+ *     ],
+ *     new Date("2026-06-01T00:00:00Z"),
+ *   )
+ *   // [2026-06-01, 2026-06-04, null]
+ */
+export function buildStepSchedule(
+  steps: ScheduleStep[],
+  startDate: Date,
+): (Date | null)[] {
+  const offsets = computeCumulativeOffsets(steps);
+  const startMs = startDate.getTime();
+  return offsets.map((h) => (h === null ? null : new Date(startMs + h * MS_PER_HOUR)));
+}


### PR DESCRIPTION
## Summary
Milestone 1 of recipe execution (Phase 5): turn a recipe into a live batch with a **scheduled, per-step task list**. Sets up the data model, the instantiation flow (the "Use this recipe" wizard), and a read-only checklist on the batch page. Completing tasks + the cross-batch work queue come in M2/M3.

## What's included
**Data model** (migration `0138`, already applied to the dev DB)
- `batch_recipe_executions` — links a batch to the recipe version it runs; **one active execution per batch** (unique index). Stores mode, start date, bottle/keg split, and `source_refs` (the chosen starting liquid).
- `batch_step_tasks` — a **snapshot** of each recipe step at instantiation, so editing a recipe later never disrupts an in-flight batch. Status, scheduled date, optional assignee, `result_ref` (for M3).

**Scheduling** (`packages/lib/src/recipes/schedule.ts`)
- `buildStepSchedule(steps, startDate)` → calendar due-date per step from the trigger model (reuses `computeCumulativeOffsets`); SG-based steps left operator-driven (null). 5 unit tests.

**API** (`packages/api/src/routers/recipeExecution.ts`)
- `instantiate` — both modes (new batch from source / attach to existing). The bottle/keg split filters which packaging-path steps run; skipped optional steps omitted; due-dates computed; tasks snapshotted. New-batch mode seeds origin/lineage from the chosen source.
- `getForBatch` — execution + ordered task list.

**UI**
- `RecipeInstantiateWizard` — "Use this recipe" now opens a wizard: mode, source pickers **driven by the recipe's declared inputs** (parent cider multi-select to blend, press run, or juice lot), start date, volume + keg split, optional-step include/skip.
- Read-only **Recipe** tab on the batch page with the scheduled checklist.

## Verification
- Typecheck clean across web/api/db/lib.
- 81/81 lib recipe tests pass (5 new schedule tests).
- Smoke-tested the instantiate core against real Coastal Hop data (v9): all 17 steps filter + schedule correctly, including the keg branch re-anchoring to "5 days from start".

## Decisions baked in (agreed with user)
One execution per batch · both instantiation modes · shared queue + optional assignee (assignment lands in M2) · dynamic reschedule (M2) · soft warnings (M2).

## Deliberately deferred / open (for M2+)
- Completing/skipping tasks, the cross-batch work queue, dynamic reschedule-on-completion (the schedule recompute fn was left out of M1 to handle the `date_offset_from_start`-in-tail edge case properly in M2).
- Multi-recipe-per-batch (v1 is one), bulk "mark first N done" on attach.
- New-batch mode creates a shell (vessel/liquid move happens when the transfer step runs in M3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
