### PR TITLE
Recipe execution M2: branch-aware + dynamic scheduling, actionable checklist, work queue

### DIFF
--- a/apps/web/src/app/recipes/[id]/page.tsx
+++ b/apps/web/src/app/recipes/[id]/page.tsx
@@ -59,7 +59,7 @@ import { computeScaledAmount } from "lib/src/recipes/scaling";
 import { computeRecipeBOM, recipeRowsToBomInput } from "lib/src/recipes/bom";
 import { computeRecipeLabor } from "lib/src/recipes/labor";
 import { RecipeInstantiateWizard } from "@/components/recipes/RecipeInstantiateWizard";
-import { computeCumulativeOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
+import { computeBranchAwareOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
 
 // Color helpers (mirrored from the list page)
 function productTypeBadgeClass(productType: string): string {
@@ -190,8 +190,12 @@ export default function RecipeDetailPage() {
   if (!data) return null;
 
   const { recipe, inputs, steps } = data;
-  const stepCumulativeHours = computeCumulativeOffsets(
-    steps.map((s) => ({ triggerKind: s.triggerKind, triggerData: s.triggerData as Record<string, unknown> })),
+  const stepCumulativeHours = computeBranchAwareOffsets(
+    steps.map((s) => ({
+      triggerKind: s.triggerKind,
+      triggerData: s.triggerData as Record<string, unknown>,
+      packagingPath: s.packagingPath,
+    })),
   );
   const isArchived = !!recipe.archivedAt;
   const ingredients = inputs.filter((i) => i.kind === "ingredient");

--- a/apps/web/src/app/work/page.tsx
+++ b/apps/web/src/app/work/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * Cross-batch work queue (Phase 5, M2).
+ *
+ * Every open recipe task across all active batches, grouped by due-date
+ * (Overdue / Today / This week / Upcoming / No date) and time-ordered. Complete
+ * or skip from here; both reuse the same mutations as the per-batch checklist
+ * and reschedule downstream work. The pre-filled action modals come in M3 — for
+ * now a task is completed as a checkmark.
+ */
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { trpc } from "@/utils/trpc";
+import { Navbar } from "@/components/navbar";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Check, SkipForward, ListChecks } from "lucide-react";
+
+type QueueTask = {
+  id: string;
+  batchId: string;
+  batchName: string;
+  batchCustomName: string | null;
+  label: string;
+  packagingPath: string;
+  isOptional: boolean;
+  scheduledDate: string | null;
+  status: string;
+};
+
+type Bucket = "overdue" | "today" | "week" | "upcoming" | "none";
+
+const BUCKETS: { key: Bucket; title: string; tone: string }[] = [
+  { key: "overdue", title: "Overdue", tone: "text-red-700" },
+  { key: "today", title: "Today", tone: "text-blue-700" },
+  { key: "week", title: "This week", tone: "text-gray-800" },
+  { key: "upcoming", title: "Upcoming", tone: "text-gray-500" },
+  { key: "none", title: "No scheduled date (operator-driven)", tone: "text-gray-500" },
+];
+
+export default function WorkQueuePage() {
+  const utils = trpc.useUtils();
+  const { data, isLoading } = trpc.recipeExecution.listOpenTasks.useQuery();
+  const refresh = () => utils.recipeExecution.listOpenTasks.invalidate();
+  const complete = trpc.recipeExecution.completeTask.useMutation({ onSuccess: refresh });
+  const skip = trpc.recipeExecution.skipTask.useMutation({ onSuccess: refresh });
+  const busy = complete.isPending || skip.isPending;
+
+  const grouped = useMemo(() => {
+    const now = new Date();
+    const startToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const endToday = new Date(startToday);
+    endToday.setDate(endToday.getDate() + 1);
+    const endWeek = new Date(startToday);
+    endWeek.setDate(endWeek.getDate() + 7);
+    const bucketOf = (d: string | null): Bucket => {
+      if (!d) return "none";
+      const t = new Date(d);
+      if (t < startToday) return "overdue";
+      if (t < endToday) return "today";
+      if (t < endWeek) return "week";
+      return "upcoming";
+    };
+    const out: Record<Bucket, QueueTask[]> = {
+      overdue: [], today: [], week: [], upcoming: [], none: [],
+    };
+    for (const t of (data?.tasks ?? []) as QueueTask[]) out[bucketOf(t.scheduledDate)].push(t);
+    return out;
+  }, [data]);
+
+  const total = data?.tasks?.length ?? 0;
+
+  const onSkip = (t: QueueTask) => {
+    if (!t.isOptional && !confirm("This step isn't marked optional. Skip it anyway?")) return;
+    skip.mutate({ taskId: t.id });
+  };
+
+  const fmtDate = (d: string | null) => (d ? new Date(d).toLocaleDateString() : "—");
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+        <div className="flex items-center gap-2">
+          <ListChecks className="w-6 h-6 text-gray-700" />
+          <h1 className="text-2xl font-semibold">Work queue</h1>
+          <Badge variant="secondary" className="ml-1">{total}</Badge>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : total === 0 ? (
+          <Card>
+            <CardContent className="py-10 text-center text-sm text-muted-foreground">
+              No open recipe tasks. Start a recipe from the Recipes page to populate the queue.
+            </CardContent>
+          </Card>
+        ) : (
+          BUCKETS.filter((b) => grouped[b.key].length > 0).map((b) => (
+            <Card key={b.key}>
+              <CardHeader className="pb-2">
+                <CardTitle className={`text-sm font-semibold ${b.tone}`}>
+                  {b.title} · {grouped[b.key].length}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="divide-y">
+                {grouped[b.key].map((t) => (
+                  <div key={t.id} className="flex items-center justify-between gap-3 py-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <span className="text-sm font-medium truncate">{t.label}</span>
+                        {t.packagingPath !== "all" && (
+                          <Badge variant="outline" className="text-[10px]">
+                            {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
+                          </Badge>
+                        )}
+                        {t.isOptional && (
+                          <Badge variant="outline" className="text-[10px] text-gray-500">Optional</Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        <Link href={`/batch/${t.batchId}`} className="hover:underline">
+                          {t.batchCustomName || t.batchName}
+                        </Link>{" "}
+                        · due {fmtDate(t.scheduledDate)}
+                      </p>
+                    </div>
+                    <div className="flex gap-1 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy}
+                        onClick={() => complete.mutate({ taskId: t.id })}
+                      >
+                        <Check className="w-4 h-4 mr-1" /> Done
+                      </Button>
+                      <Button size="sm" variant="ghost" disabled={busy} onClick={() => onSkip(t)} title="Skip">
+                        <SkipForward className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/work/page.tsx
+++ b/apps/web/src/app/work/page.tsx
@@ -22,6 +22,13 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Check, SkipForward, ListChecks } from "lucide-react";
 
 type QueueTask = {
@@ -34,7 +41,10 @@ type QueueTask = {
   isOptional: boolean;
   scheduledDate: string | null;
   status: string;
+  assignedWorkerId: string | null;
 };
+
+const UNASSIGNED = "__none__";
 
 type Bucket = "overdue" | "today" | "week" | "upcoming" | "none";
 
@@ -49,9 +59,12 @@ const BUCKETS: { key: Bucket; title: string; tone: string }[] = [
 export default function WorkQueuePage() {
   const utils = trpc.useUtils();
   const { data, isLoading } = trpc.recipeExecution.listOpenTasks.useQuery();
+  const { data: workersData } = trpc.workers.list.useQuery();
+  const workers = workersData?.workers ?? [];
   const refresh = () => utils.recipeExecution.listOpenTasks.invalidate();
   const complete = trpc.recipeExecution.completeTask.useMutation({ onSuccess: refresh });
   const skip = trpc.recipeExecution.skipTask.useMutation({ onSuccess: refresh });
+  const assign = trpc.recipeExecution.assignTask.useMutation({ onSuccess: refresh });
   const busy = complete.isPending || skip.isPending;
 
   const grouped = useMemo(() => {
@@ -133,7 +146,23 @@ export default function WorkQueuePage() {
                         · due {fmtDate(t.scheduledDate)}
                       </p>
                     </div>
-                    <div className="flex gap-1 shrink-0">
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Select
+                        value={t.assignedWorkerId ?? UNASSIGNED}
+                        onValueChange={(v) =>
+                          assign.mutate({ taskId: t.id, workerId: v === UNASSIGNED ? null : v })
+                        }
+                      >
+                        <SelectTrigger className="h-8 w-32 text-xs">
+                          <SelectValue placeholder="Unassigned" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+                          {workers.map((w) => (
+                            <SelectItem key={w.id} value={w.id}>{w.name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <Button
                         size="sm"
                         variant="outline"

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -25,6 +25,7 @@ import {
   Apple,
   History,
   Calendar,
+  ListChecks,
 } from "lucide-react";
 import { useState, useMemo } from "react";
 import {
@@ -115,6 +116,12 @@ export function Navbar() {
       href: "/planning",
       icon: Calendar,
       description: "Production Planning",
+    },
+    {
+      name: "Work",
+      href: "/work",
+      icon: ListChecks,
+      description: "Cross-batch work queue",
     },
     {
       name: "Admin",

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 /**
- * Read-only recipe checklist for a batch (Phase 5, M1).
+ * Recipe checklist for a batch (Phase 5, M2).
  *
- * Shows the scheduled per-step task list for a batch that was instantiated from
- * a recipe. M1 is read-only — completing/skipping tasks and the cross-batch
- * work queue come in M2/M3.
+ * Shows the scheduled task list sorted by due-date (so parallel bottle/keg work
+ * sits together) and lets the operator complete / skip / undo tasks. Soft
+ * warnings only: completing out of order or skipping a non-optional step asks
+ * for confirmation but never blocks. Completing a task reschedules the rest from
+ * the actual completion time (server-side).
  */
 
 import { trpc } from "@/utils/trpc";
@@ -17,6 +19,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -25,6 +28,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Check, SkipForward, RotateCcw } from "lucide-react";
 
 const STATUS_STYLE: Record<string, string> = {
   pending: "border-gray-300 text-gray-600",
@@ -36,8 +40,25 @@ const STATUS_STYLE: Record<string, string> = {
 const fmtDate = (d: string | Date | null) =>
   d ? new Date(d).toLocaleDateString() : "—";
 
+type Task = {
+  id: string;
+  sequence: number;
+  label: string;
+  description: string | null;
+  packagingPath: string;
+  isOptional: boolean;
+  scheduledDate: string | Date | null;
+  status: string;
+};
+
 export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
+  const utils = trpc.useUtils();
   const { data, isLoading } = trpc.recipeExecution.getForBatch.useQuery({ batchId });
+
+  const refresh = () => utils.recipeExecution.getForBatch.invalidate({ batchId });
+  const complete = trpc.recipeExecution.completeTask.useMutation({ onSuccess: refresh });
+  const skip = trpc.recipeExecution.skipTask.useMutation({ onSuccess: refresh });
+  const reopen = trpc.recipeExecution.reopenTask.useMutation({ onSuccess: refresh });
 
   if (isLoading) {
     return (
@@ -61,8 +82,29 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
     );
   }
 
-  const { execution, tasks } = data;
+  const { execution } = data;
+  const tasks = data.tasks as Task[];
   const done = tasks.filter((t) => t.status === "done").length;
+  const openBySeq = tasks.filter((t) => t.status === "pending" || t.status === "in_progress");
+
+  // Sorted by due-date (nulls last), tie-break by sequence — parallel work groups.
+  const sorted = [...tasks].sort((a, b) => {
+    const da = a.scheduledDate ? new Date(a.scheduledDate).getTime() : Infinity;
+    const db_ = b.scheduledDate ? new Date(b.scheduledDate).getTime() : Infinity;
+    return da - db_ || a.sequence - b.sequence;
+  });
+
+  const onComplete = (t: Task) => {
+    const earlierOpen = openBySeq.some((o) => o.sequence < t.sequence);
+    if (earlierOpen && !confirm("Earlier steps aren't done yet. Complete this one anyway?")) return;
+    complete.mutate({ taskId: t.id });
+  };
+  const onSkip = (t: Task) => {
+    if (!t.isOptional && !confirm("This step isn't marked optional. Skip it anyway?")) return;
+    skip.mutate({ taskId: t.id });
+  };
+
+  const busy = complete.isPending || skip.isPending || reopen.isPending;
 
   return (
     <Card>
@@ -71,7 +113,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
         <CardDescription>
           Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)} ·{" "}
           {execution.bottleVolumeL ?? 0} L bottled / {execution.kegVolumeL ?? 0} L kegged ·{" "}
-          {done}/{tasks.length} done
+          {done}/{tasks.length} done · sorted by due date
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -82,41 +124,75 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
               <TableHead>Step</TableHead>
               <TableHead>Due</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
-            {tasks.map((t) => (
-              <TableRow key={t.id}>
-                <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    <span>{t.label}</span>
-                    {t.packagingPath !== "all" && (
-                      <Badge variant="outline" className="text-[10px]">
-                        {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
-                      </Badge>
+            {sorted.map((t) => {
+              const terminal = t.status === "done" || t.status === "skipped";
+              return (
+                <TableRow key={t.id} className={terminal ? "opacity-60" : ""}>
+                  <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <span className={t.status === "done" ? "line-through" : ""}>{t.label}</span>
+                      {t.packagingPath !== "all" && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
+                        </Badge>
+                      )}
+                      {t.isOptional && (
+                        <Badge variant="outline" className="text-[10px] text-gray-500">
+                          Optional
+                        </Badge>
+                      )}
+                    </div>
+                    {t.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
                     )}
-                    {t.isOptional && (
-                      <Badge variant="outline" className="text-[10px] text-gray-500">
-                        Optional
-                      </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm">{fmtDate(t.scheduledDate)}</TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className={`text-[10px] ${STATUS_STYLE[t.status] ?? ""}`}>
+                      {t.status.replace("_", " ")}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right whitespace-nowrap">
+                    {terminal ? (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={busy}
+                        onClick={() => reopen.mutate({ taskId: t.id })}
+                        title="Undo"
+                      >
+                        <RotateCcw className="w-4 h-4" />
+                      </Button>
+                    ) : (
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={busy}
+                          onClick={() => onComplete(t)}
+                        >
+                          <Check className="w-4 h-4 mr-1" /> Done
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={busy}
+                          onClick={() => onSkip(t)}
+                          title="Skip"
+                        >
+                          <SkipForward className="w-4 h-4" />
+                        </Button>
+                      </div>
                     )}
-                  </div>
-                  {t.description && (
-                    <p className="text-xs text-muted-foreground mt-0.5">{t.description}</p>
-                  )}
-                </TableCell>
-                <TableCell className="text-sm">{fmtDate(t.scheduledDate)}</TableCell>
-                <TableCell>
-                  <Badge
-                    variant="outline"
-                    className={`text-[10px] ${STATUS_STYLE[t.status] ?? ""}`}
-                  >
-                    {t.status.replace("_", " ")}
-                  </Badge>
-                </TableCell>
-              </TableRow>
-            ))}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </CardContent>

--- a/apps/web/src/components/recipes/RecipeBuilder.tsx
+++ b/apps/web/src/components/recipes/RecipeBuilder.tsx
@@ -18,7 +18,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { calculatePU } from "lib";
-import { computeCumulativeOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
+import { computeBranchAwareOffsets, summarizeStepTrigger } from "lib/src/recipes/triggers";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/lib/utils";
 import { useOrganizationSettings } from "@/contexts/SettingsContext";
@@ -247,7 +247,7 @@ export function RecipeBuilder({
   // Cumulative hours-from-start per step, so each step summary can show the
   // running total (e.g. "day 5 from start"), not just the per-step offset.
   const stepCumulativeHours = useMemo(
-    () => computeCumulativeOffsets(draft.steps),
+    () => computeBranchAwareOffsets(draft.steps),
     [draft.steps],
   );
 

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -91,6 +91,7 @@ export const recipeExecutionRouter = router({
         runSteps.map((s) => ({
           triggerKind: s.triggerKind,
           triggerData: (s.triggerData ?? {}) as Record<string, unknown>,
+          packagingPath: s.packagingPath ?? "all",
         })),
         input.startDate,
       );

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -18,7 +18,7 @@
 
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   db,
   batches,
@@ -27,8 +27,63 @@ import {
   batchRecipeExecutions,
   batchStepTasks,
 } from "db";
-import { buildStepSchedule } from "lib";
+import { buildStepSchedule, rescheduleWithActuals } from "lib";
 import { router, createRbacProcedure } from "../trpc";
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Recompute pending task due-dates from actual progress (done/skipped anchors).
+ * Done tasks keep their own dates; everything else is re-derived.
+ */
+async function recomputeSchedule(tx: Tx, executionId: string) {
+  const [exec] = await tx
+    .select()
+    .from(batchRecipeExecutions)
+    .where(eq(batchRecipeExecutions.id, executionId))
+    .limit(1);
+  if (!exec) return;
+  const tasks = await tx
+    .select()
+    .from(batchStepTasks)
+    .where(eq(batchStepTasks.executionId, executionId))
+    .orderBy(asc(batchStepTasks.sequence));
+  const dates = rescheduleWithActuals(
+    tasks.map((t) => ({
+      triggerKind: t.triggerKind,
+      triggerData: (t.triggerData ?? {}) as Record<string, unknown>,
+      packagingPath: t.packagingPath ?? "all",
+      status: t.status,
+      completedAt: t.completedAt,
+    })),
+    exec.startDate,
+  );
+  for (let i = 0; i < tasks.length; i++) {
+    if (tasks[i].status === "done") continue;
+    await tx
+      .update(batchStepTasks)
+      .set({ scheduledDate: dates[i], updatedAt: new Date() })
+      .where(eq(batchStepTasks.id, tasks[i].id));
+  }
+}
+
+async function loadTask(tx: Tx, taskId: string) {
+  const [task] = await tx
+    .select()
+    .from(batchStepTasks)
+    .where(eq(batchStepTasks.id, taskId))
+    .limit(1);
+  if (!task) throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+  return task;
+}
+
+async function tasksForExecution(tx: Tx, executionId: string) {
+  return tx
+    .select()
+    .from(batchStepTasks)
+    .where(eq(batchStepTasks.executionId, executionId))
+    .orderBy(asc(batchStepTasks.sequence));
+}
 
 const instantiateSchema = z
   .object({
@@ -226,5 +281,119 @@ export const recipeExecutionRouter = router({
         .orderBy(asc(batchStepTasks.sequence));
 
       return { execution, tasks };
+    }),
+
+  /** Cross-batch work queue: every open task across all active executions. */
+  listOpenTasks: createRbacProcedure("read", "batch")
+    .query(async () => {
+      const tasks = await db
+        .select({
+          id: batchStepTasks.id,
+          batchId: batchStepTasks.batchId,
+          batchName: batches.name,
+          batchCustomName: batches.customName,
+          label: batchStepTasks.label,
+          kind: batchStepTasks.kind,
+          packagingPath: batchStepTasks.packagingPath,
+          isOptional: batchStepTasks.isOptional,
+          sequence: batchStepTasks.sequence,
+          scheduledDate: batchStepTasks.scheduledDate,
+          status: batchStepTasks.status,
+          assignedWorkerId: batchStepTasks.assignedWorkerId,
+        })
+        .from(batchStepTasks)
+        .innerJoin(
+          batchRecipeExecutions,
+          eq(batchStepTasks.executionId, batchRecipeExecutions.id),
+        )
+        .innerJoin(batches, eq(batchStepTasks.batchId, batches.id))
+        .where(
+          and(
+            inArray(batchStepTasks.status, ["pending", "in_progress"]),
+            eq(batchRecipeExecutions.status, "active"),
+          ),
+        )
+        .orderBy(asc(batchStepTasks.scheduledDate));
+      return { tasks };
+    }),
+
+  /** Mark a task done (records completion time + optional labor), then reschedule. */
+  completeTask: createRbacProcedure("update", "batch")
+    .input(
+      z.object({
+        taskId: z.string().uuid(),
+        completedAt: z.coerce.date().optional(),
+        actualHours: z.number().nonnegative().nullish(),
+        notes: z.string().nullish(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      return await db.transaction(async (tx) => {
+        const task = await loadTask(tx, input.taskId);
+        await tx
+          .update(batchStepTasks)
+          .set({
+            status: "done",
+            completedAt: input.completedAt ?? new Date(),
+            actualHours: input.actualHours != null ? input.actualHours.toString() : task.actualHours,
+            notes: input.notes ?? task.notes,
+            updatedAt: new Date(),
+          })
+          .where(eq(batchStepTasks.id, task.id));
+        await recomputeSchedule(tx, task.executionId);
+        return { tasks: await tasksForExecution(tx, task.executionId) };
+      });
+    }),
+
+  /** Skip a task (pass-through; doesn't delay the rest), then reschedule. */
+  skipTask: createRbacProcedure("update", "batch")
+    .input(z.object({ taskId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      return await db.transaction(async (tx) => {
+        const task = await loadTask(tx, input.taskId);
+        await tx
+          .update(batchStepTasks)
+          .set({ status: "skipped", completedAt: new Date(), updatedAt: new Date() })
+          .where(eq(batchStepTasks.id, task.id));
+        await recomputeSchedule(tx, task.executionId);
+        return { tasks: await tasksForExecution(tx, task.executionId) };
+      });
+    }),
+
+  /** Undo a completed/skipped task back to pending, then reschedule. */
+  reopenTask: createRbacProcedure("update", "batch")
+    .input(z.object({ taskId: z.string().uuid() }))
+    .mutation(async ({ input }) => {
+      return await db.transaction(async (tx) => {
+        const task = await loadTask(tx, input.taskId);
+        await tx
+          .update(batchStepTasks)
+          .set({ status: "pending", completedAt: null, actualHours: null, updatedAt: new Date() })
+          .where(eq(batchStepTasks.id, task.id));
+        await recomputeSchedule(tx, task.executionId);
+        return { tasks: await tasksForExecution(tx, task.executionId) };
+      });
+    }),
+
+  /** Assign (or unassign) a worker to a task. */
+  assignTask: createRbacProcedure("update", "batch")
+    .input(z.object({ taskId: z.string().uuid(), workerId: z.string().uuid().nullable() }))
+    .mutation(async ({ input }) => {
+      const [task] = await db
+        .select({ executionId: batchStepTasks.executionId })
+        .from(batchStepTasks)
+        .where(eq(batchStepTasks.id, input.taskId))
+        .limit(1);
+      if (!task) throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+      await db
+        .update(batchStepTasks)
+        .set({ assignedWorkerId: input.workerId, updatedAt: new Date() })
+        .where(eq(batchStepTasks.id, input.taskId));
+      const tasks = await db
+        .select()
+        .from(batchStepTasks)
+        .where(eq(batchStepTasks.executionId, task.executionId))
+        .orderBy(asc(batchStepTasks.sequence));
+      return { tasks };
     }),
 });

--- a/packages/lib/src/__tests__/recipes/schedule.test.ts
+++ b/packages/lib/src/__tests__/recipes/schedule.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildStepSchedule } from "../../recipes/schedule";
+import { buildStepSchedule, rescheduleWithActuals } from "../../recipes/schedule";
 
 const START = new Date("2026-06-01T00:00:00Z");
 const iso = (d: Date | null) => (d === null ? null : d.toISOString());
@@ -78,5 +78,56 @@ describe("buildStepSchedule", () => {
     // Keg branch ties to the end of the trunk (filter, day 5), NOT the bottle tail (day 7).
     expect(iso(dates[4])).toBe("2026-06-06T00:00:00.000Z");
     expect(iso(dates[5])).toBe("2026-06-06T00:00:00.000Z");
+  });
+});
+
+describe("rescheduleWithActuals", () => {
+  const STEPS = [
+    { triggerKind: "date_offset_from_start", triggerData: { days: 0 }, packagingPath: "all" },
+    { triggerKind: "date_offset_from_previous", triggerData: { days: 3 }, packagingPath: "all" },
+    { triggerKind: "date_offset_from_previous", triggerData: { days: 2 }, packagingPath: "all" },
+  ];
+
+  it("matches buildStepSchedule when nothing is done yet", () => {
+    const a = buildStepSchedule(STEPS, START).map(iso);
+    const b = rescheduleWithActuals(STEPS, START).map(iso);
+    expect(b).toEqual(a);
+  });
+
+  it("re-anchors downstream steps to a step's actual completion", () => {
+    // Step 1 (planned day 3) actually finished day 5 → step 2 (+2d) shifts to day 7.
+    const dates = rescheduleWithActuals(
+      [
+        { ...STEPS[0], status: "done", completedAt: new Date("2026-06-01T00:00:00Z") },
+        { ...STEPS[1], status: "done", completedAt: new Date("2026-06-06T00:00:00Z") },
+        STEPS[2],
+      ],
+      START,
+    );
+    expect(iso(dates[2])).toBe("2026-06-08T00:00:00.000Z"); // day-5 completion + 2 days
+  });
+
+  it("treats a skipped step as pass-through (no delay)", () => {
+    const dates = rescheduleWithActuals(
+      [
+        { ...STEPS[0], status: "done", completedAt: new Date("2026-06-01T00:00:00Z") },
+        { ...STEPS[1], status: "skipped" },
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "all" },
+      ],
+      START,
+    );
+    // Skipped step contributes nothing → after_previous follows step 0 (day 0).
+    expect(iso(dates[2])).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("keeps date_offset_from_start anchored to batch start, not actuals", () => {
+    const dates = rescheduleWithActuals(
+      [
+        { ...STEPS[0], status: "done", completedAt: new Date("2026-06-03T00:00:00Z") },
+        { triggerKind: "date_offset_from_start", triggerData: { days: 10 }, packagingPath: "all" },
+      ],
+      START,
+    );
+    expect(iso(dates[1])).toBe("2026-06-11T00:00:00.000Z"); // start + 10d, regardless of the late step 0
   });
 });

--- a/packages/lib/src/__tests__/recipes/schedule.test.ts
+++ b/packages/lib/src/__tests__/recipes/schedule.test.ts
@@ -58,4 +58,25 @@ describe("buildStepSchedule", () => {
   it("returns an empty array for no steps", () => {
     expect(buildStepSchedule([], START)).toEqual([]);
   });
+
+  it("schedules bottle and keg branches in parallel off the shared trunk", () => {
+    // Trunk: start (day 0) → filter (day 5). Then bottle and keg branches.
+    const dates = buildStepSchedule(
+      [
+        { triggerKind: "date_offset_from_start", triggerData: { days: 0 }, packagingPath: "all" },
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 5 }, packagingPath: "all" }, // filter, day 5
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "bottle" }, // bottle carbonate
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 2 }, packagingPath: "bottle" }, // pasteurize, day 7
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "keg" }, // keg package — follows FILTER, not pasteurize
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "keg" }, // keg measure
+      ],
+      START,
+    );
+    expect(iso(dates[1])).toBe("2026-06-06T00:00:00.000Z"); // filter, day 5
+    expect(iso(dates[2])).toBe("2026-06-06T00:00:00.000Z"); // bottle carbonate, day 5
+    expect(iso(dates[3])).toBe("2026-06-08T00:00:00.000Z"); // pasteurize, day 7
+    // Keg branch ties to the end of the trunk (filter, day 5), NOT the bottle tail (day 7).
+    expect(iso(dates[4])).toBe("2026-06-06T00:00:00.000Z");
+    expect(iso(dates[5])).toBe("2026-06-06T00:00:00.000Z");
+  });
 });

--- a/packages/lib/src/recipes/schedule.ts
+++ b/packages/lib/src/recipes/schedule.ts
@@ -40,3 +40,74 @@ export function buildStepSchedule(
   const startMs = startDate.getTime();
   return offsets.map((h) => (h === null ? null : new Date(startMs + h * MS_PER_HOUR)));
 }
+
+/** A step's offset in hours, or null when absent. */
+function offsetHours(data: Record<string, unknown>): number | null {
+  if (typeof data.days === "number") return data.days * 24;
+  if (typeof data.hours === "number") return data.hours;
+  return null;
+}
+
+export interface RuntimeStep extends ScheduleStep {
+  /** "pending" | "in_progress" | "done" | "skipped". */
+  status?: string;
+  /** Real completion time for a done step — anchors everything after it. */
+  completedAt?: Date | null;
+}
+
+/**
+ * Recompute due-dates from ACTUAL progress. Branch-aware, like
+ * `buildStepSchedule`, but each step's effective time is:
+ *   - a DONE step → its real `completedAt` (becomes the anchor for what follows),
+ *   - a SKIPPED step → pass-through (adds nothing; downstream follows the step
+ *     before it),
+ *   - otherwise → its trigger relative to the previous step's effective time.
+ *
+ * `date_offset_from_start` stays anchored to the batch start (absolute), so a
+ * fixed calendar step doesn't drift when earlier work runs early/late. With no
+ * done/skipped steps this returns exactly what `buildStepSchedule` does.
+ */
+export function rescheduleWithActuals(
+  steps: RuntimeStep[],
+  startDate: Date,
+): (Date | null)[] {
+  const out: (Date | null)[] = new Array(steps.length).fill(null);
+  for (const path of ["bottle", "keg"] as const) {
+    const idxs = steps
+      .map((_, i) => i)
+      .filter((i) => {
+        const p = steps[i].packagingPath ?? "all";
+        return p === "all" || p === path;
+      });
+    if (idxs.length === 0) continue;
+    let prev: Date | null = startDate;
+    for (const i of idxs) {
+      const s = steps[i];
+      let eff: Date | null;
+      if (s.status === "done" && s.completedAt) {
+        eff = s.completedAt;
+      } else if (s.status === "skipped") {
+        eff = prev; // pass-through — a skipped step doesn't delay the rest
+      } else {
+        const off = offsetHours(s.triggerData);
+        switch (s.triggerKind) {
+          case "manual":
+          case "after_previous":
+            eff = prev;
+            break;
+          case "date_offset_from_previous":
+            eff = prev !== null && off !== null ? new Date(prev.getTime() + off * MS_PER_HOUR) : null;
+            break;
+          case "date_offset_from_start":
+            eff = off !== null ? new Date(startDate.getTime() + off * MS_PER_HOUR) : null;
+            break;
+          default:
+            eff = null; // sg_threshold / sg_terminal_confirmed — operator-driven
+        }
+      }
+      out[i] = eff;
+      prev = eff;
+    }
+  }
+  return out;
+}

--- a/packages/lib/src/recipes/schedule.ts
+++ b/packages/lib/src/recipes/schedule.ts
@@ -2,9 +2,10 @@
  * Recipe execution scheduling.
  *
  * Turns a recipe's ordered steps + a batch start date into a calendar due-date
- * per step, by walking the trigger model. Reuses `computeCumulativeOffsets`
- * (the same math the recipe view uses for "day 5 from start"), so the preview
- * and the live schedule never diverge.
+ * per step, by walking the trigger model. Uses `computeBranchAwareOffsets` so
+ * bottle and keg branches each chain along their own lineage (the shared steps
+ * + that path's steps) and run in parallel — e.g. keg packaging follows the end
+ * of filtering, not the end of the bottle tail.
  *
  * SG-based / indeterminate triggers (sg_threshold, sg_terminal_confirmed, or a
  * missing offset) yield a null due-date — those steps are operator-driven and
@@ -13,7 +14,7 @@
  * Pure functions. No DB, no side effects — easy to unit test.
  */
 
-import { computeCumulativeOffsets, type ScheduleStep } from "./triggers";
+import { computeBranchAwareOffsets, type ScheduleStep } from "./triggers";
 
 const MS_PER_HOUR = 3_600_000;
 
@@ -35,7 +36,7 @@ export function buildStepSchedule(
   steps: ScheduleStep[],
   startDate: Date,
 ): (Date | null)[] {
-  const offsets = computeCumulativeOffsets(steps);
+  const offsets = computeBranchAwareOffsets(steps);
   const startMs = startDate.getTime();
   return offsets.map((h) => (h === null ? null : new Date(startMs + h * MS_PER_HOUR)));
 }

--- a/packages/lib/src/recipes/triggers.ts
+++ b/packages/lib/src/recipes/triggers.ts
@@ -218,6 +218,8 @@ function parseOffset(data: Record<string, unknown>): number | null {
 export interface ScheduleStep {
   triggerKind: string;
   triggerData: Record<string, unknown>;
+  /** "all" | "bottle" | "keg" — for branch-aware scheduling. Defaults "all". */
+  packagingPath?: string | null;
 }
 
 /** Pull a date-offset trigger's {days}|{hours} as hours. Null when absent. */
@@ -271,6 +273,33 @@ export function computeCumulativeOffsets(steps: ScheduleStep[]): (number | null)
         out.push(null);
         break;
     }
+  }
+  return out;
+}
+
+/**
+ * Branch-aware cumulative offsets. Bottle-path and keg-path steps each chain
+ * along their OWN lineage (the shared "all" steps + that path's steps), not the
+ * flat list. So a keg step's "after previous" follows the last *shared* step
+ * (e.g. filtering) rather than the end of the bottle tail — letting bottle and
+ * keg packaging run in parallel.
+ *
+ * "all" steps belong to both lineages and take the trunk offset.
+ */
+export function computeBranchAwareOffsets(steps: ScheduleStep[]): (number | null)[] {
+  const out: (number | null)[] = new Array(steps.length).fill(null);
+  for (const path of ["bottle", "keg"] as const) {
+    const idxs = steps
+      .map((_, i) => i)
+      .filter((i) => {
+        const p = steps[i].packagingPath ?? "all";
+        return p === "all" || p === path;
+      });
+    if (idxs.length === 0) continue;
+    const lineageOffsets = computeCumulativeOffsets(idxs.map((i) => steps[i]));
+    idxs.forEach((origIdx, k) => {
+      out[origIdx] = lineageOffsets[k];
+    });
   }
   return out;
 }


### PR DESCRIPTION
## Summary
Milestone 2 of recipe execution: the recipe checklist becomes **actionable**, scheduling becomes **branch-aware + dynamic**, and a **cross-batch work queue** lands.

## Branch-aware scheduling
- `computeBranchAwareOffsets` — bottle and keg branches each chain along their own lineage (shared steps + that path's steps), so they schedule **in parallel** off the shared trunk. Keg packaging now ties to the end of filtering, not the end of the bottle tail.
- Recipe view/editor previews + instantiation all use it. Coastal Hop's keg packaging retriggered to "after previous" (ties to actual filter completion).

## Dynamic reschedule
- `rescheduleWithActuals` — recompute due-dates from real progress: done steps anchor to their actual completion time, skipped steps pass through (no delay), and `date_offset_from_start` stays anchored to batch start.

## Actions
- API: `completeTask` / `skipTask` / `reopenTask` (each reschedules), `assignTask`, `listOpenTasks`.
- **Batch checklist** is now actionable — sorted by due-date (parallel bottle/keg work groups together), complete/skip/undo with **soft warnings** (confirm on out-of-order completion or skipping a non-optional step).
- **New `/work` cross-batch work queue** — Overdue / Today / This week / Upcoming / No date, time-ordered, with complete/skip and an **optional worker assignee** per task. Nav link added.

## Verification
- 86 lib tests pass (10 schedule tests incl. parallel-branch + reschedule cases).
- web/api/db typecheck clean.
- Smoke-tested branch-aware schedule + the work-queue query against the real test batch.

## Decisions / deferred
Decisions baked in (per earlier discussion): both instantiation modes, shared queue + optional assignee, dynamic reschedule, soft warnings.
**Deferred (user asked to address later):** editable volume / keg split after instantiation — needs packaging-path task reconciliation; the one remaining M2 item.
**M3 next:** wire each task to its real action modal (add additive, transfer incl. partial draw from a base cider into a target vessel, package…) + BOM inventory drawdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
