### PR TITLE
Recipe execution M3: steps drive their real operations (prefilled), incl. pasteurize/label

### DIFF
--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -104,6 +104,9 @@ interface CarbonateModalProps {
     maxPressure: number;
   } | null;
   onSuccess?: () => void;
+  /** Recipe-planned values to prefill (method uses recipe terms forced|natural). */
+  prefillTargetCo2Volumes?: number;
+  prefillMethod?: "forced" | "natural";
 }
 
 export function CarbonateModal({
@@ -112,6 +115,8 @@ export function CarbonateModal({
   batch,
   vessel,
   onSuccess,
+  prefillTargetCo2Volumes,
+  prefillMethod,
 }: CarbonateModalProps) {
   const utils = trpc.useUtils();
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
@@ -253,7 +258,14 @@ export function CarbonateModal({
   // Reset form when modal opens
   useEffect(() => {
     if (open) {
-      const defaultMethod = vessel?.isPressureVessel === "yes" ? "forced" : "bottle_conditioning";
+      const recipeMethod =
+        prefillMethod === "natural"
+          ? "bottle_conditioning"
+          : prefillMethod === "forced"
+            ? "forced"
+            : undefined;
+      const defaultMethod =
+        recipeMethod ?? (vessel?.isPressureVessel === "yes" ? "forced" : "bottle_conditioning");
       reset({
         carbonationMethod: defaultMethod,
         startedAt: formatDateTimeForInput(new Date()) as any,
@@ -261,7 +273,7 @@ export function CarbonateModal({
         startingVolumeUnit: (batch.currentVolumeUnit as "L" | "gal") || "L",
         startingTemperature: 10,
         residualCo2Volumes: 0.7,
-        targetCo2Volumes: 2.0,
+        targetCo2Volumes: prefillTargetCo2Volumes ?? 2.0,
         pressureApplied: 0,
         sugarPerLiter: undefined,
       } as any);
@@ -274,7 +286,7 @@ export function CarbonateModal({
       setDateWarning(null);
       setLaborAssignments([]);
     }
-  }, [open, reset, batch.currentVolume, batch.currentVolumeUnit, vessel?.isPressureVessel]);
+  }, [open, reset, batch.currentVolume, batch.currentVolumeUnit, vessel?.isPressureVessel, prefillMethod, prefillTargetCo2Volumes]);
 
   // Convert volume to liters for calculations
   const volumeInLiters = useMemo(() => {

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -45,6 +45,13 @@ interface AddBatchAdditiveFormProps {
   batchId: string;
   onSuccess: () => void;
   onCancel: () => void;
+  /** Recipe-planned values to prefill (e.g. Cascade Hops @ 1.5 g/L = 180 g). */
+  prefillAdditiveType?: string | null;
+  prefillVarietyName?: string | null;
+  prefillDosageRate?: number | null;
+  prefillDosageRateUnit?: string | null;
+  prefillAmount?: number | null;
+  prefillUnit?: string | null;
 }
 
 // Grouped so absolute amounts and concentrations can be visually separated
@@ -155,6 +162,12 @@ export function AddBatchAdditiveForm({
   batchId,
   onSuccess,
   onCancel,
+  prefillAdditiveType,
+  prefillVarietyName,
+  prefillDosageRate,
+  prefillDosageRateUnit,
+  prefillAmount,
+  prefillUnit,
 }: AddBatchAdditiveFormProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
   const [selectedAdditiveType, setSelectedAdditiveType] = useState("");
@@ -212,6 +225,28 @@ export function AddBatchAdditiveForm({
         enabled: !!selectedAdditiveType,
       },
     );
+
+  // Prefill from a recipe step (run once on mount): planned type, dosage rate,
+  // and computed amount. The operator confirms or adjusts.
+  React.useEffect(() => {
+    if (prefillAdditiveType) setSelectedAdditiveType(prefillAdditiveType);
+    if (prefillDosageRate != null) setDosageRate(String(prefillDosageRate));
+    if (prefillDosageRateUnit) setDosageRateUnit(prefillDosageRateUnit);
+    if (prefillAmount != null) setAmount(String(prefillAmount));
+    if (prefillUnit) setUnit(prefillUnit);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Once the type's inventory loads, auto-select the lot matching the recipe
+  // variety — only when there's exactly one, to avoid guessing.
+  React.useEffect(() => {
+    if (!prefillVarietyName || selectedInventoryItem) return;
+    const items = inventoryData?.items ?? [];
+    const matches = items.filter(
+      (i: any) => (i.varietyName || i.productName) === prefillVarietyName,
+    );
+    if (matches.length === 1) setSelectedInventoryItem(matches[0]);
+  }, [inventoryData, prefillVarietyName, selectedInventoryItem]);
 
   // Detect if the selected inventory item is a sulfite product (KMS)
   const isSulfiteProduct = useMemo(() => {

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -55,6 +55,8 @@ interface FilterModalProps {
   currentVolumeL: number;
   /** Called after a filter operation succeeds (e.g. to complete a recipe task). */
   onSuccess?: () => void;
+  /** Recipe-planned filter type to prefill. */
+  prefillFilterType?: "coarse" | "fine" | "sterile";
 }
 
 export function FilterModal({
@@ -65,6 +67,7 @@ export function FilterModal({
   batchId,
   currentVolumeL,
   onSuccess,
+  prefillFilterType,
 }: FilterModalProps) {
   const utils = trpc.useUtils();
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
@@ -133,7 +136,7 @@ export function FilterModal({
   useEffect(() => {
     if (open) {
       reset({
-        filterType: "fine" as const,
+        filterType: prefillFilterType ?? ("fine" as const),
         volumeBefore: currentVolumeL,
         volumeAfter: currentVolumeL,
         volumeBeforeUnit: "L",
@@ -143,7 +146,7 @@ export function FilterModal({
       });
       setLaborAssignments([]);
     }
-  }, [open, currentVolumeL, reset]);
+  }, [open, currentVolumeL, reset, prefillFilterType]);
 
   const filterMutation = trpc.batch.filter.useMutation({
     onSuccess: (data) => {

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -53,6 +53,8 @@ interface FilterModalProps {
   vesselName: string;
   batchId: string;
   currentVolumeL: number;
+  /** Called after a filter operation succeeds (e.g. to complete a recipe task). */
+  onSuccess?: () => void;
 }
 
 export function FilterModal({
@@ -62,6 +64,7 @@ export function FilterModal({
   vesselName,
   batchId,
   currentVolumeL,
+  onSuccess,
 }: FilterModalProps) {
   const utils = trpc.useUtils();
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
@@ -154,6 +157,7 @@ export function FilterModal({
       utils.batch.list.invalidate();
       onClose();
       reset();
+      onSuccess?.();
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
+++ b/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
@@ -20,6 +20,7 @@ interface UnifiedPackagingModalProps {
   currentVolumeL: number;
   initialType?: PackagingType;
   preBottling?: PreBottlingData;
+  onSuccess?: () => void;
 }
 
 /**
@@ -37,6 +38,7 @@ export function UnifiedPackagingModal({
   currentVolumeL,
   initialType = "bottles",
   preBottling,
+  onSuccess,
 }: UnifiedPackagingModalProps) {
   const [packagingType, setPackagingType] = useState<PackagingType>(initialType);
 
@@ -60,6 +62,7 @@ export function UnifiedPackagingModal({
         showTypeSelector={true}
         onTypeChange={setPackagingType}
         preBottling={preBottling}
+        onSuccess={onSuccess}
       />
     );
   }
@@ -75,6 +78,7 @@ export function UnifiedPackagingModal({
       showTypeSelector={true}
       onTypeChange={setPackagingType}
       preBottling={preBottling}
+      onSuccess={onSuccess}
     />
   );
 }

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -72,6 +72,7 @@ interface BottleModalProps {
   showTypeSelector?: boolean; // Show package type selector (bottles vs kegs)
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
+  onSuccess?: () => void; // Called after a packaging run is created
 }
 
 type InputMode = "volume" | "units";
@@ -87,6 +88,7 @@ export function BottleModal({
   showTypeSelector = false,
   onTypeChange,
   preBottling,
+  onSuccess,
 }: BottleModalProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -434,6 +436,7 @@ export function BottleModal({
 
       console.log("Packaging run created:", result);
       onClose();
+      onSuccess?.();
     } catch (error) {
       console.error("Failed to create packaging run:", error);
 

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -52,6 +52,7 @@ interface FillKegModalProps {
   showTypeSelector?: boolean; // Show package type selector (bottles vs kegs)
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
+  onSuccess?: () => void; // Called after kegs are filled
 }
 
 // Memoized keg item component to prevent re-renders
@@ -112,6 +113,7 @@ export function FillKegModal({
   showTypeSelector = false,
   onTypeChange,
   preBottling,
+  onSuccess,
 }: FillKegModalProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
   const [selectedKegIds, setSelectedKegIds] = useState<string[]>([]);
@@ -163,6 +165,7 @@ export function FillKegModal({
       setSelectedKegIds([]);
       setKegVolumes({});
       onClose();
+      onSuccess?.();
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -17,6 +17,8 @@ import { StepDetailModal } from "@/components/recipes/StepDetailModal";
 import { FilterModal } from "@/components/cellar/FilterModal";
 import { CarbonateModal } from "@/components/batch/CarbonateModal";
 import { UnifiedPackagingModal } from "@/components/packaging/UnifiedPackagingModal";
+import { PasteurizeModal } from "@/components/packaging/PasteurizeModal";
+import { LabelModal } from "@/components/packaging/LabelModal";
 import {
   Card,
   CardContent,
@@ -57,6 +59,7 @@ type Task = {
   scheduledDate: string | Date | null;
   status: string;
   notes: string | null;
+  actionData: Record<string, unknown> | null;
   actualData: Record<string, unknown> | null;
 };
 
@@ -64,8 +67,19 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const utils = trpc.useUtils();
   const { data, isLoading } = trpc.recipeExecution.getForBatch.useQuery({ batchId });
   const { data: batchData } = trpc.batch.get.useQuery({ batchId });
+  const { data: runsData } = trpc.packaging.list.useQuery({ batchId });
+  // Pasteurize/label apply to bottle runs (not keg fills). Union type → access
+  // the run's fields loosely.
+  const latestRun = ((runsData?.runs ?? []) as Array<Record<string, any>>)
+    .filter((r) => r.source === "bottle_run")
+    .sort(
+      (a, b) =>
+        new Date(b.packagedAt ?? b.createdAt).getTime() -
+        new Date(a.packagedAt ?? a.createdAt).getTime(),
+    )[0];
   const [openTask, setOpenTask] = useState<Task | null>(null);
-  // filter/carbonate/package open the real cellar modals (need a vessel).
+  // filter/carbonate/package open the real cellar modals (need a vessel);
+  // pasteurize/label open the packaging modals (need a packaging run).
   const [actionTask, setActionTask] = useState<Task | null>(null);
 
   const refresh = () => {
@@ -76,20 +90,35 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const skip = trpc.recipeExecution.skipTask.useMutation({ onSuccess: refresh });
   const reopen = trpc.recipeExecution.reopenTask.useMutation({ onSuccess: refresh });
 
-  const ACTION_KINDS = new Set(["filter", "carbonate", "package"]);
+  const VESSEL_KINDS = new Set(["filter", "carbonate", "package"]);
+  const RUN_KINDS = new Set(["pasteurize", "label"]);
   const currentVolumeL = batchData
     ? (batchData.currentVolumeUnit === "gal" ? 3.785411784 : 1) * Number(batchData.currentVolume ?? 0)
     : 0;
   const openStep = (t: Task) => {
-    if (ACTION_KINDS.has(t.kind) && !batchData?.vesselId) {
-      toast({
-        title: "No vessel yet",
-        description: "Do the Transfer step first — this action needs the batch in a vessel.",
-      });
+    if (VESSEL_KINDS.has(t.kind)) {
+      if (!batchData?.vesselId) {
+        toast({
+          title: "No vessel yet",
+          description: "Do the Transfer step first — this action needs the batch in a vessel.",
+        });
+        return;
+      }
+      setActionTask(t);
       return;
     }
-    if (ACTION_KINDS.has(t.kind)) setActionTask(t);
-    else setOpenTask(t);
+    if (RUN_KINDS.has(t.kind)) {
+      if (!latestRun) {
+        toast({
+          title: "No packaging run yet",
+          description: "Package the batch first — pasteurize/label apply to a packaging run.",
+        });
+        return;
+      }
+      setActionTask(t);
+      return;
+    }
+    setOpenTask(t);
   };
 
   if (isLoading) {
@@ -243,6 +272,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
       plannedVolumeL={
         Number(execution.bottleVolumeL ?? 0) + Number(execution.kegVolumeL ?? 0)
       }
+      ingredients={data.ingredients ?? []}
     />
 
     {/* Real cellar action modals — completing one marks the recipe step done. */}
@@ -255,6 +285,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           vesselName={batchData.vesselName ?? ""}
           batchId={batchId}
           currentVolumeL={currentVolumeL}
+          prefillFilterType={
+            /coarse/i.test(actionTask?.label ?? "")
+              ? "coarse"
+              : /sterile/i.test(actionTask?.label ?? "")
+                ? "sterile"
+                : "fine"
+          }
           onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
         />
         <CarbonateModal
@@ -274,6 +311,18 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
             isPressureVessel: batchData.vesselIsPressureVessel === "yes" ? "yes" : "no",
             maxPressure: Number(batchData.vesselMaxPressure ?? 30),
           }}
+          prefillTargetCo2Volumes={
+            typeof actionTask?.actionData?.targetCo2Volumes === "number"
+              ? (actionTask.actionData.targetCo2Volumes as number)
+              : undefined
+          }
+          prefillMethod={
+            actionTask?.actionData?.method === "natural"
+              ? "natural"
+              : actionTask?.actionData?.method === "forced"
+                ? "forced"
+                : undefined
+          }
           onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
         />
         <UnifiedPackagingModal
@@ -284,6 +333,30 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           batchId={batchId}
           currentVolumeL={currentVolumeL}
           initialType={actionTask?.packagingPath === "keg" ? "kegs" : "bottles"}
+          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+        />
+      </>
+    )}
+
+    {/* Pasteurize / label operate on the batch's latest packaging run. */}
+    {latestRun && (
+      <>
+        <PasteurizeModal
+          open={actionTask?.kind === "pasteurize"}
+          onClose={() => setActionTask(null)}
+          bottleRunId={latestRun.id}
+          bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
+          batchId={batchId}
+          unitsProduced={Number(latestRun.unitsProduced ?? 0)}
+          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+        />
+        <LabelModal
+          open={actionTask?.kind === "label"}
+          onClose={() => setActionTask(null)}
+          bottleRunId={latestRun.id}
+          bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
+          unitsProduced={Number(latestRun.unitsProduced ?? 0)}
+          unitsLabeled={Number(latestRun.unitsLabeled ?? 0)}
           onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
         />
       </>

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -138,17 +138,15 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
             {sorted.map((t) => {
               const terminal = t.status === "done" || t.status === "skipped";
               return (
-                <TableRow key={t.id} className={terminal ? "opacity-60" : ""}>
+                <TableRow
+                  key={t.id}
+                  onClick={() => setOpenTask(t)}
+                  className={`cursor-pointer hover:bg-gray-50 ${terminal ? "opacity-60" : ""}`}
+                >
                   <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <button
-                        type="button"
-                        onClick={() => setOpenTask(t)}
-                        className={`text-left hover:underline ${t.status === "done" ? "line-through" : ""}`}
-                      >
-                        {t.label}
-                      </button>
+                      <span className={t.status === "done" ? "line-through" : ""}>{t.label}</span>
                       {t.packagingPath !== "all" && (
                         <Badge variant="outline" className="text-[10px]">
                           {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
@@ -170,7 +168,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                       {t.status.replace("_", " ")}
                     </Badge>
                   </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
+                  <TableCell className="text-right whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
                     {terminal ? (
                       <Button
                         size="sm"

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -10,7 +10,9 @@
  * the actual completion time (server-side).
  */
 
+import { useState } from "react";
 import { trpc } from "@/utils/trpc";
+import { StepDetailModal } from "@/components/recipes/StepDetailModal";
 import {
   Card,
   CardContent,
@@ -43,17 +45,21 @@ const fmtDate = (d: string | Date | null) =>
 type Task = {
   id: string;
   sequence: number;
+  kind: string;
   label: string;
   description: string | null;
   packagingPath: string;
   isOptional: boolean;
   scheduledDate: string | Date | null;
   status: string;
+  notes: string | null;
+  actualData: Record<string, unknown> | null;
 };
 
 export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const utils = trpc.useUtils();
   const { data, isLoading } = trpc.recipeExecution.getForBatch.useQuery({ batchId });
+  const [openTask, setOpenTask] = useState<Task | null>(null);
 
   const refresh = () => utils.recipeExecution.getForBatch.invalidate({ batchId });
   const complete = trpc.recipeExecution.completeTask.useMutation({ onSuccess: refresh });
@@ -107,6 +113,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const busy = complete.isPending || skip.isPending || reopen.isPending;
 
   return (
+    <>
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Recipe checklist</CardTitle>
@@ -135,7 +142,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                   <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className={t.status === "done" ? "line-through" : ""}>{t.label}</span>
+                      <button
+                        type="button"
+                        onClick={() => setOpenTask(t)}
+                        className={`text-left hover:underline ${t.status === "done" ? "line-through" : ""}`}
+                      >
+                        {t.label}
+                      </button>
                       {t.packagingPath !== "all" && (
                         <Badge variant="outline" className="text-[10px]">
                           {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
@@ -197,5 +210,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
         </Table>
       </CardContent>
     </Card>
+    <StepDetailModal
+      open={!!openTask}
+      onClose={() => setOpenTask(null)}
+      batchId={batchId}
+      task={openTask}
+      sources={data.sources ?? []}
+    />
+    </>
   );
 }

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -214,6 +214,9 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
       batchId={batchId}
       task={openTask}
       sources={data.sources ?? []}
+      plannedVolumeL={
+        Number(execution.bottleVolumeL ?? 0) + Number(execution.kegVolumeL ?? 0)
+      }
     />
     </>
   );

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -12,7 +12,11 @@
 
 import { useState } from "react";
 import { trpc } from "@/utils/trpc";
+import { toast } from "@/hooks/use-toast";
 import { StepDetailModal } from "@/components/recipes/StepDetailModal";
+import { FilterModal } from "@/components/cellar/FilterModal";
+import { CarbonateModal } from "@/components/batch/CarbonateModal";
+import { UnifiedPackagingModal } from "@/components/packaging/UnifiedPackagingModal";
 import {
   Card,
   CardContent,
@@ -59,12 +63,34 @@ type Task = {
 export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const utils = trpc.useUtils();
   const { data, isLoading } = trpc.recipeExecution.getForBatch.useQuery({ batchId });
+  const { data: batchData } = trpc.batch.get.useQuery({ batchId });
   const [openTask, setOpenTask] = useState<Task | null>(null);
+  // filter/carbonate/package open the real cellar modals (need a vessel).
+  const [actionTask, setActionTask] = useState<Task | null>(null);
 
-  const refresh = () => utils.recipeExecution.getForBatch.invalidate({ batchId });
+  const refresh = () => {
+    utils.recipeExecution.getForBatch.invalidate({ batchId });
+    utils.recipeExecution.listOpenTasks.invalidate();
+  };
   const complete = trpc.recipeExecution.completeTask.useMutation({ onSuccess: refresh });
   const skip = trpc.recipeExecution.skipTask.useMutation({ onSuccess: refresh });
   const reopen = trpc.recipeExecution.reopenTask.useMutation({ onSuccess: refresh });
+
+  const ACTION_KINDS = new Set(["filter", "carbonate", "package"]);
+  const currentVolumeL = batchData
+    ? (batchData.currentVolumeUnit === "gal" ? 3.785411784 : 1) * Number(batchData.currentVolume ?? 0)
+    : 0;
+  const openStep = (t: Task) => {
+    if (ACTION_KINDS.has(t.kind) && !batchData?.vesselId) {
+      toast({
+        title: "No vessel yet",
+        description: "Do the Transfer step first — this action needs the batch in a vessel.",
+      });
+      return;
+    }
+    if (ACTION_KINDS.has(t.kind)) setActionTask(t);
+    else setOpenTask(t);
+  };
 
   if (isLoading) {
     return (
@@ -140,7 +166,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
               return (
                 <TableRow
                   key={t.id}
-                  onClick={() => setOpenTask(t)}
+                  onClick={() => openStep(t)}
                   className={`cursor-pointer hover:bg-gray-50 ${terminal ? "opacity-60" : ""}`}
                 >
                   <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
@@ -218,6 +244,50 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
         Number(execution.bottleVolumeL ?? 0) + Number(execution.kegVolumeL ?? 0)
       }
     />
+
+    {/* Real cellar action modals — completing one marks the recipe step done. */}
+    {batchData?.vesselId && (
+      <>
+        <FilterModal
+          open={actionTask?.kind === "filter"}
+          onClose={() => setActionTask(null)}
+          vesselId={batchData.vesselId}
+          vesselName={batchData.vesselName ?? ""}
+          batchId={batchId}
+          currentVolumeL={currentVolumeL}
+          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+        />
+        <CarbonateModal
+          open={actionTask?.kind === "carbonate"}
+          onOpenChange={(o) => !o && setActionTask(null)}
+          batch={{
+            id: batchId,
+            name: batchData.name ?? "",
+            vesselId: batchData.vesselId,
+            currentVolume: Number(batchData.currentVolume ?? 0),
+            currentVolumeUnit: batchData.currentVolumeUnit ?? "L",
+            status: batchData.status ?? "",
+          }}
+          vessel={{
+            id: batchData.vesselId,
+            name: batchData.vesselName ?? "",
+            isPressureVessel: batchData.vesselIsPressureVessel === "yes" ? "yes" : "no",
+            maxPressure: Number(batchData.vesselMaxPressure ?? 30),
+          }}
+          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+        />
+        <UnifiedPackagingModal
+          open={actionTask?.kind === "package"}
+          onClose={() => setActionTask(null)}
+          vesselId={batchData.vesselId}
+          vesselName={batchData.vesselName ?? ""}
+          batchId={batchId}
+          currentVolumeL={currentVolumeL}
+          initialType={actionTask?.packagingPath === "keg" ? "kegs" : "bottles"}
+          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+        />
+      </>
+    )}
     </>
   );
 }

--- a/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
+++ b/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
@@ -126,6 +126,7 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
   const [kegVolumeStr, setKegVolumeStr] = useState("0");
   const [newBatchName, setNewBatchName] = useState("");
   const [parentBatchIds, setParentBatchIds] = useState<string[]>([]);
+  const [parentVolumes, setParentVolumes] = useState<Record<string, string>>({});
   const [pressRunId, setPressRunId] = useState<string | null>(null);
   const [juicePurchaseItemId, setJuicePurchaseItemId] = useState<string | null>(null);
   const [existingBatchId, setExistingBatchId] = useState<string | null>(null);
@@ -183,6 +184,31 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
   const kegVolumeL = Number(kegVolumeStr) || 0;
   const bottleVolumeL = Math.max(0, totalVolumeL - kegVolumeL);
 
+  // Blend draws: each selected cider's volume must total the batch volume and
+  // can't exceed what's on hand.
+  const parentSumL = parentBatchIds.reduce((s, id) => s + (Number(parentVolumes[id]) || 0), 0);
+  const blendMismatch =
+    mode === "new" && hasParentReq && parentBatchIds.length > 0 && Math.abs(parentSumL - totalVolumeL) > 0.5;
+  const parentOverdraw = parentBatchIds.some((id) => {
+    const b = activeBatches.find((x) => x.id === id);
+    return (Number(parentVolumes[id]) || 0) > Number(b?.currentVolume ?? 0) + 0.001;
+  });
+
+  const toggleParent = (id: string) =>
+    setParentBatchIds((prev) => {
+      if (prev.includes(id)) {
+        setParentVolumes((v) => {
+          const next = { ...v };
+          delete next[id];
+          return next;
+        });
+        return prev.filter((x) => x !== id);
+      }
+      // First cider added → default it to the whole batch volume; others blank.
+      setParentVolumes((v) => ({ ...v, [id]: prev.length === 0 ? String(totalVolumeL || "") : "" }));
+      return [...prev, id];
+    });
+
   const mutation = trpc.recipeExecution.instantiate.useMutation({
     onSuccess: (res) => {
       toast({ title: "Recipe started", description: `${res.taskCount} steps scheduled.` });
@@ -205,6 +231,8 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
     kegVolumeL >= 0 &&
     kegVolumeL <= totalVolumeL &&
     (mode === "attach" ? !!existingBatchId : !sourceMissing) &&
+    !blendMismatch &&
+    !parentOverdraw &&
     !mutation.isPending;
 
   const submit = () => {
@@ -214,7 +242,10 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
       startDate,
       totalVolumeL,
       kegVolumeL,
-      parentBatchIds,
+      parentBatches: parentBatchIds.map((id) => ({
+        batchId: id,
+        volumeL: Number(parentVolumes[id]) || 0,
+      })),
       pressRunId: pressRunId ?? undefined,
       juicePurchaseItemId: juicePurchaseItemId ?? undefined,
       newBatchName: newBatchName.trim() || undefined,
@@ -264,37 +295,48 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
                     Start from cider {parentBatchIds.length > 1 ? "(blend)" : ""}
                   </Label>
                   {parentBatchIds.length > 0 && (
-                    <div className="flex flex-wrap gap-1.5 my-1.5">
+                    <div className="space-y-1.5 my-1.5">
                       {parentBatchIds.map((id) => {
                         const b = activeBatches.find((x) => x.id === id);
+                        const avail = Number(b?.currentVolume ?? 0);
+                        const over = (Number(parentVolumes[id]) || 0) > avail + 0.001;
                         return (
-                          <Badge key={id} variant="secondary" className="gap-1">
-                            {b ? `${b.customName || b.name} — ${b.vesselName ?? "?"}` : id.slice(0, 8)}
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setParentBatchIds((p) => p.filter((x) => x !== id))
-                              }
-                            >
-                              <X className="w-3 h-3" />
+                          <div key={id} className="flex items-center gap-2 text-sm">
+                            <span className="min-w-0 flex-1 truncate">
+                              {b ? `${b.customName || b.name} — ${b.vesselName ?? "?"}` : id.slice(0, 8)}
+                              <span className="text-xs text-muted-foreground ml-1">({avail.toFixed(0)} L avail)</span>
+                            </span>
+                            <Input
+                              type="number"
+                              min="0"
+                              step="1"
+                              value={parentVolumes[id] ?? ""}
+                              onChange={(e) => setParentVolumes((v) => ({ ...v, [id]: e.target.value }))}
+                              className={`h-8 w-20 ${over ? "border-red-400" : ""}`}
+                              placeholder="L"
+                            />
+                            <span className="text-xs text-muted-foreground">L</span>
+                            <button type="button" onClick={() => toggleParent(id)}>
+                              <X className="w-3.5 h-3.5 text-gray-400" />
                             </button>
-                          </Badge>
+                          </div>
                         );
                       })}
+                      <p className={`text-[11px] ${blendMismatch ? "text-red-600" : "text-muted-foreground"}`}>
+                        Blend total: {parentSumL.toFixed(0)} L of {totalVolumeL} L batch
+                        {blendMismatch ? " — must equal the batch volume" : ""}
+                        {parentOverdraw ? " · a draw exceeds what's on hand" : ""}
+                      </p>
                     </div>
                   )}
                   <InlineBatchList
                     options={parentCiderOptions}
                     selectedIds={parentBatchIds}
-                    onPick={(id) =>
-                      setParentBatchIds((p) =>
-                        p.includes(id) ? p.filter((x) => x !== id) : [...p, id],
-                      )
-                    }
+                    onPick={toggleParent}
                   />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Ciders currently in a cellar vessel. Pick one for a single varietal,
-                    or several to blend. Click again to remove.
+                    Ciders currently in a cellar vessel. Pick one for a single varietal, or
+                    several to blend (set how much from each). Click again to remove.
                   </p>
                 </div>
               )}

--- a/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
+++ b/apps/web/src/components/recipes/RecipeInstantiateWizard.tsx
@@ -193,6 +193,10 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
     const b = activeBatches.find((x) => x.id === id);
     return (Number(parentVolumes[id]) || 0) > Number(b?.currentVolume ?? 0) + 0.001;
   });
+  // Every selected cider needs a positive draw — the server requires volumeL > 0
+  // per cider, so a blank field would otherwise fail validation on submit.
+  const parentBlank =
+    mode === "new" && hasParentReq && parentBatchIds.some((id) => !(Number(parentVolumes[id]) > 0));
 
   const toggleParent = (id: string) =>
     setParentBatchIds((prev) => {
@@ -233,6 +237,7 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
     (mode === "attach" ? !!existingBatchId : !sourceMissing) &&
     !blendMismatch &&
     !parentOverdraw &&
+    !parentBlank &&
     !mutation.isPending;
 
   const submit = () => {
@@ -242,10 +247,9 @@ export function RecipeInstantiateWizard({ open, onClose, recipe, inputs, steps }
       startDate,
       totalVolumeL,
       kegVolumeL,
-      parentBatches: parentBatchIds.map((id) => ({
-        batchId: id,
-        volumeL: Number(parentVolumes[id]) || 0,
-      })),
+      parentBatches: parentBatchIds
+        .map((id) => ({ batchId: id, volumeL: Number(parentVolumes[id]) || 0 }))
+        .filter((p) => p.volumeL > 0),
       pressRunId: pressRunId ?? undefined,
       juicePurchaseItemId: juicePurchaseItemId ?? undefined,
       newBatchName: newBatchName.trim() || undefined,

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -56,12 +56,14 @@ export function StepDetailModal({
   batchId,
   task,
   sources,
+  plannedVolumeL,
 }: {
   open: boolean;
   onClose: () => void;
   batchId: string;
   task: Task | null;
   sources: Source[];
+  plannedVolumeL: number;
 }) {
   const utils = trpc.useUtils();
   const ad = (task?.actualData ?? {}) as Record<string, unknown>;
@@ -69,6 +71,9 @@ export function StepDetailModal({
     (ad.destinationVesselId as string) ?? null,
   );
   const [vesselSearch, setVesselSearch] = useState("");
+  const [transferVolume, setTransferVolume] = useState(
+    String(ad.volumeL ?? (plannedVolumeL || "")),
+  );
   const [notes, setNotes] = useState(task?.notes ?? "");
 
   const vesselsQuery = trpc.vessel.list.useQuery({}, { enabled: open && task?.kind === "transfer" });
@@ -88,6 +93,15 @@ export function StepDetailModal({
   });
   const reopen = trpc.recipeExecution.reopenTask.useMutation({
     onSuccess: () => { refresh(); onClose(); },
+  });
+  const transfer = trpc.recipeExecution.performTransfer.useMutation({
+    onSuccess: () => {
+      toast({ title: "Transfer recorded" });
+      refresh();
+      utils.batch.get.invalidate({ batchId });
+      onClose();
+    },
+    onError: (e) => toast({ title: "Couldn't transfer", description: e.message, variant: "destructive" }),
   });
 
   if (!task) return null;
@@ -197,6 +211,22 @@ export function StepDetailModal({
                     )}
                   </div>
                 </div>
+                <div>
+                  <Label className="text-xs">Volume to transfer (L)</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={transferVolume}
+                    onChange={(e) => setTransferVolume(e.target.value)}
+                    className="h-9 w-32"
+                    disabled={isDone}
+                  />
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    Drawn from the source cider into the destination vessel, and this
+                    batch is assigned to that vessel.
+                  </p>
+                </div>
               </>
             )}
 
@@ -224,6 +254,20 @@ export function StepDetailModal({
                   onClick={() => reopen.mutate({ taskId: task.id })}
                 >
                   Reopen
+                </Button>
+              ) : task.kind === "transfer" ? (
+                <Button
+                  size="sm"
+                  disabled={transfer.isPending || !destVesselId || !(Number(transferVolume) > 0)}
+                  onClick={() =>
+                    transfer.mutate({
+                      taskId: task.id,
+                      destinationVesselId: destVesselId!,
+                      volumeL: Number(transferVolume),
+                    })
+                  }
+                >
+                  <Check className="w-4 h-4 mr-1" /> Perform transfer
                 </Button>
               ) : (
                 <Button size="sm" disabled={complete.isPending} onClick={onMarkDone}>

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -48,6 +48,7 @@ interface Source {
   vesselName: string | null;
   currentVolume: string | null;
   currentVolumeUnit: string | null;
+  plannedVolumeL: number | null;
 }
 
 export function StepDetailModal({
@@ -71,10 +72,12 @@ export function StepDetailModal({
     (ad.destinationVesselId as string) ?? null,
   );
   const [vesselSearch, setVesselSearch] = useState("");
-  const [transferVolume, setTransferVolume] = useState(
-    String(ad.volumeL ?? (plannedVolumeL || "")),
-  );
   const [notes, setNotes] = useState(task?.notes ?? "");
+
+  // Total to transfer = sum of each source cider's planned draw (set at
+  // instantiation); falls back to the batch's planned volume.
+  const plannedTotalL =
+    sources.reduce((s, x) => s + (x.plannedVolumeL ?? 0), 0) || plannedVolumeL;
 
   const vesselsQuery = trpc.vessel.listWithBatches.useQuery(undefined, {
     enabled: open && task?.kind === "transfer",
@@ -122,7 +125,6 @@ export function StepDetailModal({
     });
   };
 
-  const transferVolNum = Number(transferVolume) || 0;
   const q = vesselSearch.trim().toLowerCase();
   const vesselOptions = (vesselsQuery.data?.vessels ?? [])
     .map((v) => {
@@ -137,7 +139,7 @@ export function StepDetailModal({
         spaceL,
         isEmpty: !v.currentBatch || contentsL < 0.1,
         batchName: v.currentBatch?.name ?? null,
-        fits: spaceL + 0.001 >= transferVolNum,
+        fits: spaceL + 0.001 >= plannedTotalL,
       };
     })
     .filter((v) => !q || v.name.toLowerCase().includes(q))
@@ -178,17 +180,29 @@ export function StepDetailModal({
             {task.kind === "transfer" && (
               <>
                 <div className="rounded-md bg-gray-50 border p-2.5 text-sm">
-                  <p className="text-xs font-medium text-gray-500 mb-1">Source cider</p>
+                  <p className="text-xs font-medium text-gray-500 mb-1">
+                    {sources.length > 1 ? "Blend — drawn from:" : "Source cider"}
+                  </p>
                   {sources.length === 0 ? (
                     <p className="text-muted-foreground">No source recorded.</p>
                   ) : (
                     sources.map((s) => (
-                      <p key={s.id}>
-                        {s.customName || s.name}
-                        {s.vesselName ? ` — ${s.vesselName}` : ""}
-                        {s.currentVolume ? ` (${s.currentVolume} ${s.currentVolumeUnit ?? "L"})` : ""}
+                      <p key={s.id} className="flex justify-between gap-2">
+                        <span className="truncate">
+                          {s.customName || s.name}
+                          {s.vesselName ? ` — ${s.vesselName}` : ""}
+                        </span>
+                        {s.plannedVolumeL != null && (
+                          <span className="font-mono shrink-0">{s.plannedVolumeL} L</span>
+                        )}
                       </p>
                     ))
+                  )}
+                  {sources.length > 1 && (
+                    <p className="flex justify-between gap-2 border-t mt-1 pt-1 font-medium">
+                      <span>Total</span>
+                      <span className="font-mono">{plannedTotalL.toFixed(0)} L</span>
+                    </p>
                   )}
                 </div>
                 <div>
@@ -232,7 +246,7 @@ export function StepDetailModal({
                               </span>
                               <span className="block text-xs text-muted-foreground">
                                 {v.spaceL.toFixed(0)} L free of {v.capacityL.toFixed(0)} L
-                                {!v.fits && transferVolNum > 0 ? " · not enough space" : ""}
+                                {!v.fits && plannedTotalL > 0 ? " · not enough space" : ""}
                               </span>
                             </span>
                             {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}
@@ -241,21 +255,9 @@ export function StepDetailModal({
                       })
                     )}
                   </div>
-                </div>
-                <div>
-                  <Label className="text-xs">Volume to transfer (L)</Label>
-                  <Input
-                    type="number"
-                    min="0"
-                    step="1"
-                    value={transferVolume}
-                    onChange={(e) => setTransferVolume(e.target.value)}
-                    className="h-9 w-32"
-                    disabled={isDone}
-                  />
                   <p className="text-[11px] text-muted-foreground mt-1">
-                    Drawn from the source cider into the destination vessel, and this
-                    batch is assigned to that vessel.
+                    {plannedTotalL.toFixed(0)} L is drawn into this vessel and the batch is
+                    assigned to it. Vessels without room are disabled.
                   </p>
                 </div>
               </>
@@ -289,13 +291,9 @@ export function StepDetailModal({
               ) : task.kind === "transfer" ? (
                 <Button
                   size="sm"
-                  disabled={transfer.isPending || !destVesselId || !(Number(transferVolume) > 0)}
+                  disabled={transfer.isPending || !destVesselId || !(plannedTotalL > 0)}
                   onClick={() =>
-                    transfer.mutate({
-                      taskId: task.id,
-                      destinationVesselId: destVesselId!,
-                      volumeL: Number(transferVolume),
-                    })
+                    transfer.mutate({ taskId: task.id, destinationVesselId: destVesselId! })
                   }
                 >
                   <Check className="w-4 h-4 mr-1" /> Perform transfer

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -39,7 +39,16 @@ interface Task {
   isOptional: boolean;
   status: string;
   notes: string | null;
+  actionData: Record<string, unknown> | null;
   actualData: Record<string, unknown> | null;
+}
+interface Ingredient {
+  label: string;
+  additiveType: string | null;
+  additiveName: string | null;
+  additiveVarietyId: string | null;
+  rateValue: string | number | null;
+  rateUnit: string | null;
 }
 interface Source {
   id: string;
@@ -58,6 +67,7 @@ export function StepDetailModal({
   task,
   sources,
   plannedVolumeL,
+  ingredients,
 }: {
   open: boolean;
   onClose: () => void;
@@ -65,6 +75,7 @@ export function StepDetailModal({
   task: Task | null;
   sources: Source[];
   plannedVolumeL: number;
+  ingredients: Ingredient[];
 }) {
   const utils = trpc.useUtils();
   const ad = (task?.actualData ?? {}) as Record<string, unknown>;
@@ -153,6 +164,32 @@ export function StepDetailModal({
     (task.kind === "measurement" || task.kind === "add_additive" || task.kind === "pitch_yeast");
   const onRealSuccess = () => complete.mutate({ taskId: task.id });
 
+  // Prefill the add-additive form from the recipe ingredient this step references.
+  const additivePrefill = (() => {
+    if (task.kind !== "add_additive" && task.kind !== "pitch_yeast") return null;
+    const ingLabel = (task.actionData?.ingredientLabel as string) ?? task.label ?? "";
+    const ing =
+      ingredients.find((i) => i.label === ingLabel || i.additiveName === ingLabel) ??
+      ingredients.find((i) => ingLabel.includes(i.label));
+    if (!ing) return null;
+    const rate = ing.rateValue != null ? Number(ing.rateValue) : undefined;
+    const rateUnit = ing.rateUnit ?? undefined;
+    let amount: number | undefined;
+    let unit: string | undefined;
+    if (rate != null && rateUnit?.endsWith("/L") && plannedTotalL > 0) {
+      amount = Number((rate * plannedTotalL).toFixed(2));
+      unit = rateUnit.replace("/L", "");
+    }
+    return {
+      additiveType: ing.additiveType ?? undefined,
+      varietyName: ing.additiveName ?? ing.label,
+      dosageRate: rate,
+      dosageRateUnit: rateUnit,
+      amount,
+      unit,
+    };
+  })();
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className={`${useRealForm ? "max-w-2xl" : "max-w-lg"} max-h-[85vh] overflow-y-auto`}>
@@ -172,7 +209,17 @@ export function StepDetailModal({
           task.kind === "measurement" ? (
             <AddBatchMeasurementForm batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
           ) : (
-            <AddBatchAdditiveForm batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
+            <AddBatchAdditiveForm
+              batchId={batchId}
+              onSuccess={onRealSuccess}
+              onCancel={onClose}
+              prefillAdditiveType={additivePrefill?.additiveType}
+              prefillVarietyName={additivePrefill?.varietyName}
+              prefillDosageRate={additivePrefill?.dosageRate}
+              prefillDosageRateUnit={additivePrefill?.dosageRateUnit}
+              prefillAmount={additivePrefill?.amount}
+              prefillUnit={additivePrefill?.unit}
+            />
           )
         ) : (
           <div className="space-y-4">

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -27,6 +27,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Check } from "lucide-react";
+import { AddBatchMeasurementForm } from "@/components/cellar/AddBatchMeasurementForm";
+import { AddBatchAdditiveForm } from "@/components/cellar/AddBatchAdditiveForm";
 
 interface Task {
   id: string;
@@ -63,9 +65,6 @@ export function StepDetailModal({
 }) {
   const utils = trpc.useUtils();
   const ad = (task?.actualData ?? {}) as Record<string, unknown>;
-  const [actualAmount, setActualAmount] = useState(String(ad.actualAmount ?? ""));
-  const [actualUnit, setActualUnit] = useState(String(ad.actualUnit ?? ""));
-  const [readings, setReadings] = useState(String(ad.readings ?? ""));
   const [destVesselId, setDestVesselId] = useState<string | null>(
     (ad.destinationVesselId as string) ?? null,
   );
@@ -96,11 +95,6 @@ export function StepDetailModal({
 
   const buildActualData = () => {
     const out: Record<string, unknown> = {};
-    if (task.kind === "add_additive" || task.kind === "pitch_yeast") {
-      if (actualAmount.trim()) out.actualAmount = actualAmount.trim();
-      if (actualUnit.trim()) out.actualUnit = actualUnit.trim();
-    }
-    if (task.kind === "measurement" && readings.trim()) out.readings = readings.trim();
     if (task.kind === "transfer" && destVesselId) out.destinationVesselId = destVesselId;
     return Object.keys(out).length ? out : null;
   };
@@ -118,9 +112,16 @@ export function StepDetailModal({
     ? vessels.filter((v) => (v.name ?? "").toLowerCase().includes(q))
     : vessels;
 
+  // Measurement + additive steps open the SAME forms as the manual cellar flow;
+  // completing one records the real operation and marks the step done.
+  const useRealForm =
+    !isDone &&
+    (task.kind === "measurement" || task.kind === "add_additive" || task.kind === "pitch_yeast");
+  const onRealSuccess = () => complete.mutate({ taskId: task.id });
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+      <DialogContent className={`${useRealForm ? "max-w-2xl" : "max-w-lg"} max-h-[85vh] overflow-y-auto`}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 flex-wrap">
             {task.label}
@@ -133,141 +134,105 @@ export function StepDetailModal({
           {task.description && <DialogDescription>{task.description}</DialogDescription>}
         </DialogHeader>
 
-        <div className="space-y-4">
-          {/* Transfer: source + destination vessel */}
-          {task.kind === "transfer" && (
-            <>
-              <div className="rounded-md bg-gray-50 border p-2.5 text-sm">
-                <p className="text-xs font-medium text-gray-500 mb-1">Source cider</p>
-                {sources.length === 0 ? (
-                  <p className="text-muted-foreground">No source recorded.</p>
-                ) : (
-                  sources.map((s) => (
-                    <p key={s.id}>
-                      {s.customName || s.name}
-                      {s.vesselName ? ` — ${s.vesselName}` : ""}
-                      {s.currentVolume ? ` (${s.currentVolume} ${s.currentVolumeUnit ?? "L"})` : ""}
-                    </p>
-                  ))
-                )}
-              </div>
-              <div>
-                <Label className="text-xs">Destination vessel (which tank this batch goes into)</Label>
-                <Input
-                  value={vesselSearch}
-                  onChange={(e) => setVesselSearch(e.target.value)}
-                  placeholder="Search vessels…"
-                  className="h-9 mb-1.5"
-                  disabled={isDone}
-                />
-                <div className="max-h-40 overflow-y-auto border rounded-md divide-y">
-                  {filteredVessels.length === 0 ? (
-                    <p className="text-sm text-muted-foreground px-2.5 py-3">No vessels found.</p>
+        {useRealForm ? (
+          task.kind === "measurement" ? (
+            <AddBatchMeasurementForm batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
+          ) : (
+            <AddBatchAdditiveForm batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
+          )
+        ) : (
+          <div className="space-y-4">
+            {/* Transfer: source + destination vessel (capture-first; real transfer wired next) */}
+            {task.kind === "transfer" && (
+              <>
+                <div className="rounded-md bg-gray-50 border p-2.5 text-sm">
+                  <p className="text-xs font-medium text-gray-500 mb-1">Source cider</p>
+                  {sources.length === 0 ? (
+                    <p className="text-muted-foreground">No source recorded.</p>
                   ) : (
-                    filteredVessels.map((v) => {
-                      const selected = destVesselId === v.id;
-                      return (
-                        <button
-                          key={v.id}
-                          type="button"
-                          disabled={isDone}
-                          onClick={() => setDestVesselId(selected ? null : v.id)}
-                          className={`w-full text-left px-2.5 py-1.5 text-sm hover:bg-gray-50 flex items-center justify-between gap-2 ${
-                            selected ? "bg-green-50" : ""
-                          }`}
-                        >
-                          <span className="truncate">
-                            {v.name}
-                            <span className="text-xs text-muted-foreground ml-1">
-                              {v.capacity} {v.capacityUnit} · {v.status}
-                            </span>
-                          </span>
-                          {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}
-                        </button>
-                      );
-                    })
+                    sources.map((s) => (
+                      <p key={s.id}>
+                        {s.customName || s.name}
+                        {s.vesselName ? ` — ${s.vesselName}` : ""}
+                        {s.currentVolume ? ` (${s.currentVolume} ${s.currentVolumeUnit ?? "L"})` : ""}
+                      </p>
+                    ))
                   )}
                 </div>
-              </div>
-            </>
-          )}
+                <div>
+                  <Label className="text-xs">Destination vessel (which tank this batch goes into)</Label>
+                  <Input
+                    value={vesselSearch}
+                    onChange={(e) => setVesselSearch(e.target.value)}
+                    placeholder="Search vessels…"
+                    className="h-9 mb-1.5"
+                    disabled={isDone}
+                  />
+                  <div className="max-h-40 overflow-y-auto border rounded-md divide-y">
+                    {filteredVessels.length === 0 ? (
+                      <p className="text-sm text-muted-foreground px-2.5 py-3">No vessels found.</p>
+                    ) : (
+                      filteredVessels.map((v) => {
+                        const selected = destVesselId === v.id;
+                        return (
+                          <button
+                            key={v.id}
+                            type="button"
+                            disabled={isDone}
+                            onClick={() => setDestVesselId(selected ? null : v.id)}
+                            className={`w-full text-left px-2.5 py-1.5 text-sm hover:bg-gray-50 flex items-center justify-between gap-2 ${
+                              selected ? "bg-green-50" : ""
+                            }`}
+                          >
+                            <span className="truncate">
+                              {v.name}
+                              <span className="text-xs text-muted-foreground ml-1">
+                                {v.capacity} {v.capacityUnit} · {v.status}
+                              </span>
+                            </span>
+                            {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
 
-          {/* Additive: actual amount */}
-          {(task.kind === "add_additive" || task.kind === "pitch_yeast") && (
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <Label className="text-xs">Actual amount added</Label>
-                <Input
-                  value={actualAmount}
-                  onChange={(e) => setActualAmount(e.target.value)}
-                  placeholder="e.g. 2.0"
-                  className="h-9"
-                  disabled={isDone}
-                />
-              </div>
-              <div>
-                <Label className="text-xs">Unit</Label>
-                <Input
-                  value={actualUnit}
-                  onChange={(e) => setActualUnit(e.target.value)}
-                  placeholder="e.g. g/L"
-                  className="h-9"
-                  disabled={isDone}
-                />
-              </div>
-              <p className="col-span-2 text-[11px] text-muted-foreground -mt-1">
-                Leave blank if you used the planned amount. Enter what you actually added
-                to track the deviation.
-              </p>
-            </div>
-          )}
-
-          {/* Measurement: readings */}
-          {task.kind === "measurement" && (
+            {/* Notes — every capture-first kind */}
             <div>
-              <Label className="text-xs">Readings</Label>
+              <Label className="text-xs">Notes</Label>
               <Textarea
-                value={readings}
-                onChange={(e) => setReadings(e.target.value)}
-                placeholder="e.g. SG 1.005 · pH 3.6"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Anything worth recording about this step…"
                 className="text-sm"
                 disabled={isDone}
               />
             </div>
-          )}
 
-          {/* Notes — every kind */}
-          <div>
-            <Label className="text-xs">Notes</Label>
-            <Textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              placeholder="Anything worth recording about this step…"
-              className="text-sm"
-              disabled={isDone}
-            />
-          </div>
-
-          <div className="flex justify-end gap-2 pt-1">
-            <Button variant="outline" size="sm" onClick={onClose}>
-              {isDone ? "Close" : "Cancel"}
-            </Button>
-            {isDone ? (
-              <Button
-                size="sm"
-                variant="secondary"
-                disabled={reopen.isPending}
-                onClick={() => reopen.mutate({ taskId: task.id })}
-              >
-                Reopen
+            <div className="flex justify-end gap-2 pt-1">
+              <Button variant="outline" size="sm" onClick={onClose}>
+                {isDone ? "Close" : "Cancel"}
               </Button>
-            ) : (
-              <Button size="sm" disabled={complete.isPending} onClick={onMarkDone}>
-                <Check className="w-4 h-4 mr-1" /> Mark done
-              </Button>
-            )}
+              {isDone ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={reopen.isPending}
+                  onClick={() => reopen.mutate({ taskId: task.id })}
+                >
+                  Reopen
+                </Button>
+              ) : (
+                <Button size="sm" disabled={complete.isPending} onClick={onMarkDone}>
+                  <Check className="w-4 h-4 mr-1" /> Mark done
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+/**
+ * Step detail modal (Phase 5, M3 — capture-first).
+ *
+ * Opening a step shows its plan and lets the operator record what they ACTUALLY
+ * did before marking it done: an actual amount for additives, the destination
+ * vessel for a transfer, readings for a measurement, plus free-text notes for
+ * any step. Captured into batch_step_tasks.actual_data / notes (deviation
+ * tracking). Real operations (insert the additive, perform the transfer + assign
+ * the vessel, draw down inventory) get wired in next, kind by kind.
+ */
+
+import { useState } from "react";
+import { trpc } from "@/utils/trpc";
+import { toast } from "@/hooks/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Check } from "lucide-react";
+
+interface Task {
+  id: string;
+  kind: string;
+  label: string;
+  description: string | null;
+  packagingPath: string;
+  isOptional: boolean;
+  status: string;
+  notes: string | null;
+  actualData: Record<string, unknown> | null;
+}
+interface Source {
+  id: string;
+  name: string;
+  customName: string | null;
+  vesselName: string | null;
+  currentVolume: string | null;
+  currentVolumeUnit: string | null;
+}
+
+export function StepDetailModal({
+  open,
+  onClose,
+  batchId,
+  task,
+  sources,
+}: {
+  open: boolean;
+  onClose: () => void;
+  batchId: string;
+  task: Task | null;
+  sources: Source[];
+}) {
+  const utils = trpc.useUtils();
+  const ad = (task?.actualData ?? {}) as Record<string, unknown>;
+  const [actualAmount, setActualAmount] = useState(String(ad.actualAmount ?? ""));
+  const [actualUnit, setActualUnit] = useState(String(ad.actualUnit ?? ""));
+  const [readings, setReadings] = useState(String(ad.readings ?? ""));
+  const [destVesselId, setDestVesselId] = useState<string | null>(
+    (ad.destinationVesselId as string) ?? null,
+  );
+  const [vesselSearch, setVesselSearch] = useState("");
+  const [notes, setNotes] = useState(task?.notes ?? "");
+
+  const vesselsQuery = trpc.vessel.list.useQuery({}, { enabled: open && task?.kind === "transfer" });
+  const vessels = vesselsQuery.data?.vessels ?? [];
+
+  const refresh = () => {
+    utils.recipeExecution.getForBatch.invalidate({ batchId });
+    utils.recipeExecution.listOpenTasks.invalidate();
+  };
+  const complete = trpc.recipeExecution.completeTask.useMutation({
+    onSuccess: () => {
+      toast({ title: "Step completed" });
+      refresh();
+      onClose();
+    },
+    onError: (e) => toast({ title: "Couldn't complete", description: e.message, variant: "destructive" }),
+  });
+  const reopen = trpc.recipeExecution.reopenTask.useMutation({
+    onSuccess: () => { refresh(); onClose(); },
+  });
+
+  if (!task) return null;
+  const isDone = task.status === "done" || task.status === "skipped";
+
+  const buildActualData = () => {
+    const out: Record<string, unknown> = {};
+    if (task.kind === "add_additive" || task.kind === "pitch_yeast") {
+      if (actualAmount.trim()) out.actualAmount = actualAmount.trim();
+      if (actualUnit.trim()) out.actualUnit = actualUnit.trim();
+    }
+    if (task.kind === "measurement" && readings.trim()) out.readings = readings.trim();
+    if (task.kind === "transfer" && destVesselId) out.destinationVesselId = destVesselId;
+    return Object.keys(out).length ? out : null;
+  };
+
+  const onMarkDone = () => {
+    complete.mutate({
+      taskId: task.id,
+      actualData: buildActualData(),
+      notes: notes.trim() || null,
+    });
+  };
+
+  const q = vesselSearch.trim().toLowerCase();
+  const filteredVessels = q
+    ? vessels.filter((v) => (v.name ?? "").toLowerCase().includes(q))
+    : vessels;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 flex-wrap">
+            {task.label}
+            {task.packagingPath !== "all" && (
+              <Badge variant="outline" className="text-[10px]">
+                {task.packagingPath === "bottle" ? "Bottle only" : "Keg only"}
+              </Badge>
+            )}
+          </DialogTitle>
+          {task.description && <DialogDescription>{task.description}</DialogDescription>}
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Transfer: source + destination vessel */}
+          {task.kind === "transfer" && (
+            <>
+              <div className="rounded-md bg-gray-50 border p-2.5 text-sm">
+                <p className="text-xs font-medium text-gray-500 mb-1">Source cider</p>
+                {sources.length === 0 ? (
+                  <p className="text-muted-foreground">No source recorded.</p>
+                ) : (
+                  sources.map((s) => (
+                    <p key={s.id}>
+                      {s.customName || s.name}
+                      {s.vesselName ? ` — ${s.vesselName}` : ""}
+                      {s.currentVolume ? ` (${s.currentVolume} ${s.currentVolumeUnit ?? "L"})` : ""}
+                    </p>
+                  ))
+                )}
+              </div>
+              <div>
+                <Label className="text-xs">Destination vessel (which tank this batch goes into)</Label>
+                <Input
+                  value={vesselSearch}
+                  onChange={(e) => setVesselSearch(e.target.value)}
+                  placeholder="Search vessels…"
+                  className="h-9 mb-1.5"
+                  disabled={isDone}
+                />
+                <div className="max-h-40 overflow-y-auto border rounded-md divide-y">
+                  {filteredVessels.length === 0 ? (
+                    <p className="text-sm text-muted-foreground px-2.5 py-3">No vessels found.</p>
+                  ) : (
+                    filteredVessels.map((v) => {
+                      const selected = destVesselId === v.id;
+                      return (
+                        <button
+                          key={v.id}
+                          type="button"
+                          disabled={isDone}
+                          onClick={() => setDestVesselId(selected ? null : v.id)}
+                          className={`w-full text-left px-2.5 py-1.5 text-sm hover:bg-gray-50 flex items-center justify-between gap-2 ${
+                            selected ? "bg-green-50" : ""
+                          }`}
+                        >
+                          <span className="truncate">
+                            {v.name}
+                            <span className="text-xs text-muted-foreground ml-1">
+                              {v.capacity} {v.capacityUnit} · {v.status}
+                            </span>
+                          </span>
+                          {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* Additive: actual amount */}
+          {(task.kind === "add_additive" || task.kind === "pitch_yeast") && (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label className="text-xs">Actual amount added</Label>
+                <Input
+                  value={actualAmount}
+                  onChange={(e) => setActualAmount(e.target.value)}
+                  placeholder="e.g. 2.0"
+                  className="h-9"
+                  disabled={isDone}
+                />
+              </div>
+              <div>
+                <Label className="text-xs">Unit</Label>
+                <Input
+                  value={actualUnit}
+                  onChange={(e) => setActualUnit(e.target.value)}
+                  placeholder="e.g. g/L"
+                  className="h-9"
+                  disabled={isDone}
+                />
+              </div>
+              <p className="col-span-2 text-[11px] text-muted-foreground -mt-1">
+                Leave blank if you used the planned amount. Enter what you actually added
+                to track the deviation.
+              </p>
+            </div>
+          )}
+
+          {/* Measurement: readings */}
+          {task.kind === "measurement" && (
+            <div>
+              <Label className="text-xs">Readings</Label>
+              <Textarea
+                value={readings}
+                onChange={(e) => setReadings(e.target.value)}
+                placeholder="e.g. SG 1.005 · pH 3.6"
+                className="text-sm"
+                disabled={isDone}
+              />
+            </div>
+          )}
+
+          {/* Notes — every kind */}
+          <div>
+            <Label className="text-xs">Notes</Label>
+            <Textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Anything worth recording about this step…"
+              className="text-sm"
+              disabled={isDone}
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="outline" size="sm" onClick={onClose}>
+              {isDone ? "Close" : "Cancel"}
+            </Button>
+            {isDone ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={reopen.isPending}
+                onClick={() => reopen.mutate({ taskId: task.id })}
+              >
+                Reopen
+              </Button>
+            ) : (
+              <Button size="sm" disabled={complete.isPending} onClick={onMarkDone}>
+                <Check className="w-4 h-4 mr-1" /> Mark done
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -76,8 +76,9 @@ export function StepDetailModal({
   );
   const [notes, setNotes] = useState(task?.notes ?? "");
 
-  const vesselsQuery = trpc.vessel.list.useQuery({}, { enabled: open && task?.kind === "transfer" });
-  const vessels = vesselsQuery.data?.vessels ?? [];
+  const vesselsQuery = trpc.vessel.listWithBatches.useQuery(undefined, {
+    enabled: open && task?.kind === "transfer",
+  });
 
   const refresh = () => {
     utils.recipeExecution.getForBatch.invalidate({ batchId });
@@ -121,10 +122,27 @@ export function StepDetailModal({
     });
   };
 
+  const transferVolNum = Number(transferVolume) || 0;
   const q = vesselSearch.trim().toLowerCase();
-  const filteredVessels = q
-    ? vessels.filter((v) => (v.name ?? "").toLowerCase().includes(q))
-    : vessels;
+  const vesselOptions = (vesselsQuery.data?.vessels ?? [])
+    .map((v) => {
+      const capacityL = (v.capacityUnit === "gal" ? 3.785411784 : 1) * Number(v.capacity ?? 0);
+      const contentsL = v.currentBatch ? Number(v.currentBatch.currentVolume ?? 0) : 0;
+      const spaceL = capacityL - contentsL;
+      return {
+        id: v.id,
+        name: v.name ?? "",
+        capacityL,
+        contentsL,
+        spaceL,
+        isEmpty: !v.currentBatch || contentsL < 0.1,
+        batchName: v.currentBatch?.name ?? null,
+        fits: spaceL + 0.001 >= transferVolNum,
+      };
+    })
+    .filter((v) => !q || v.name.toLowerCase().includes(q))
+    // Empty vessels first, then most free space.
+    .sort((a, b) => Number(b.isEmpty) - Number(a.isEmpty) || b.spaceL - a.spaceL);
 
   // Measurement + additive steps open the SAME forms as the manual cellar flow;
   // completing one records the real operation and marks the step done.
@@ -182,26 +200,39 @@ export function StepDetailModal({
                     className="h-9 mb-1.5"
                     disabled={isDone}
                   />
-                  <div className="max-h-40 overflow-y-auto border rounded-md divide-y">
-                    {filteredVessels.length === 0 ? (
+                  <div className="max-h-48 overflow-y-auto border rounded-md divide-y">
+                    {vesselOptions.length === 0 ? (
                       <p className="text-sm text-muted-foreground px-2.5 py-3">No vessels found.</p>
                     ) : (
-                      filteredVessels.map((v) => {
+                      vesselOptions.map((v) => {
                         const selected = destVesselId === v.id;
+                        const disabled = isDone || !v.fits;
                         return (
                           <button
                             key={v.id}
                             type="button"
-                            disabled={isDone}
+                            disabled={disabled}
                             onClick={() => setDestVesselId(selected ? null : v.id)}
-                            className={`w-full text-left px-2.5 py-1.5 text-sm hover:bg-gray-50 flex items-center justify-between gap-2 ${
-                              selected ? "bg-green-50" : ""
-                            }`}
+                            className={`w-full text-left px-2.5 py-1.5 text-sm flex items-center justify-between gap-2 ${
+                              selected ? "bg-green-50" : "hover:bg-gray-50"
+                            } ${disabled ? "opacity-40 cursor-not-allowed" : ""}`}
                           >
-                            <span className="truncate">
-                              {v.name}
-                              <span className="text-xs text-muted-foreground ml-1">
-                                {v.capacity} {v.capacityUnit} · {v.status}
+                            <span className="min-w-0">
+                              <span className="flex items-center gap-1.5">
+                                <span className="font-medium truncate">{v.name}</span>
+                                {v.isEmpty ? (
+                                  <Badge variant="outline" className="text-[10px] border-green-400 text-green-700">
+                                    Empty
+                                  </Badge>
+                                ) : (
+                                  <span className="text-xs text-muted-foreground truncate">
+                                    {v.contentsL.toFixed(0)} L · {v.batchName}
+                                  </span>
+                                )}
+                              </span>
+                              <span className="block text-xs text-muted-foreground">
+                                {v.spaceL.toFixed(0)} L free of {v.capacityL.toFixed(0)} L
+                                {!v.fits && transferVolNum > 0 ? " · not enough space" : ""}
                               </span>
                             </span>
                             {selected && <Check className="w-4 h-4 text-green-600 shrink-0" />}

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -95,7 +95,12 @@ const instantiateSchema = z
     startDate: z.coerce.date(),
     totalVolumeL: z.number().positive(),
     kegVolumeL: z.number().min(0).default(0),
-    // "new" mode source selection (only the ones the recipe declares are used)
+    // "new" mode source selection (only the ones the recipe declares are used).
+    // parentBatches carries the per-cider draw for blends; parentBatchIds is the
+    // legacy id-only form (still accepted).
+    parentBatches: z
+      .array(z.object({ batchId: z.string().uuid(), volumeL: z.number().positive() }))
+      .default([]),
     parentBatchIds: z.array(z.string().uuid()).default([]),
     pressRunId: z.string().uuid().nullish(),
     juicePurchaseItemId: z.string().uuid().nullish(),
@@ -134,6 +139,11 @@ export const recipeExecutionRouter = router({
 
       const bottleVolumeL = Math.max(0, input.totalVolumeL - input.kegVolumeL);
       const kegVolumeL = input.kegVolumeL;
+      // Per-cider draw for blends (parentBatches) falls back to the id-only form.
+      const parentBatches = input.parentBatches.length
+        ? input.parentBatches
+        : input.parentBatchIds.map((batchId) => ({ batchId, volumeL: input.totalVolumeL }));
+      const parentBatchIds = parentBatches.map((p) => p.batchId);
 
       // Which steps actually run: respect the split + skipped optional steps.
       const skipped = new Set(input.skippedStepIds);
@@ -181,7 +191,7 @@ export const recipeExecutionRouter = router({
           const batchNumber = `${year}-${String(Number(count) + 1).padStart(3, "0")}`;
           const name = input.newBatchName?.trim() || `${recipe.name} ${batchNumber}`;
           const status =
-            input.parentBatchIds.length > 0
+            parentBatchIds.length > 0
               ? "conditioning"
               : recipe.productType === "brandy" || recipe.productType === "pommeau"
                 ? "aging"
@@ -200,7 +210,7 @@ export const recipeExecutionRouter = router({
               productType: recipe.productType,
               status,
               startDate: input.startDate,
-              parentBatchId: input.parentBatchIds[0] ?? null,
+              parentBatchId: parentBatchIds[0] ?? null,
               originPressRunId: input.pressRunId ?? null,
               originJuicePurchaseItemId: input.juicePurchaseItemId ?? null,
             })
@@ -230,7 +240,8 @@ export const recipeExecutionRouter = router({
             mode: input.mode,
             startDate: input.startDate,
             sourceRefs: {
-              parentBatchIds: input.parentBatchIds,
+              parentBatchIds,
+              parentBatches,
               pressRunId: input.pressRunId ?? null,
               juicePurchaseItemId: input.juicePurchaseItemId ?? null,
             },
@@ -284,10 +295,16 @@ export const recipeExecutionRouter = router({
         .orderBy(asc(batchStepTasks.sequence));
 
       // Resolve the source cider batch(es) + their vessel, so a transfer step
-      // can show "the base cider is in TANK-X".
-      const refs = (execution.sourceRefs ?? {}) as { parentBatchIds?: string[] };
-      const parentIds = refs.parentBatchIds ?? [];
-      const sources = parentIds.length
+      // can show "the base cider is in TANK-X" and the planned draw per cider.
+      const refs = (execution.sourceRefs ?? {}) as {
+        parentBatchIds?: string[];
+        parentBatches?: { batchId: string; volumeL: number }[];
+      };
+      const parentBatches = refs.parentBatches ?? [];
+      const parentIds = parentBatches.length
+        ? parentBatches.map((p) => p.batchId)
+        : refs.parentBatchIds ?? [];
+      const sourceRows = parentIds.length
         ? await db
             .select({
               id: batches.id,
@@ -301,6 +318,10 @@ export const recipeExecutionRouter = router({
             .leftJoin(vessels, eq(batches.vesselId, vessels.id))
             .where(inArray(batches.id, parentIds))
         : [];
+      const sources = sourceRows.map((s) => ({
+        ...s,
+        plannedVolumeL: parentBatches.find((p) => p.batchId === s.id)?.volumeL ?? null,
+      }));
 
       return { execution, tasks, sources };
     }),
@@ -370,23 +391,16 @@ export const recipeExecutionRouter = router({
     }),
 
   /**
-   * Perform the "transfer base cider into the mixing vessel" step: move the
-   * chosen volume from the source cider into the destination vessel, assign that
-   * vessel to this batch, debit the source, record lineage, and mark the task
-   * done. Custom because the recipe batch is a pre-created shell (the manual
-   * rack/transfer flow creates its own destination batch).
+   * Perform the "transfer base cider into the mixing vessel" step. Moves each
+   * source cider's planned draw (recorded at instantiation) into the chosen
+   * destination vessel, assigns that vessel to this batch, debits each source,
+   * blends ABV/OG volume-weighted, records per-source lineage, and marks the
+   * task done. Custom because the recipe batch is a pre-created shell.
    *
-   * v1: pulls from the first source cider. Multi-source blends and the TTB
-   * volume ledger entry are follow-ups.
+   * Follow-up: TTB volume-ledger entries.
    */
   performTransfer: createRbacProcedure("update", "batch")
-    .input(
-      z.object({
-        taskId: z.string().uuid(),
-        destinationVesselId: z.string().uuid(),
-        volumeL: z.number().positive(),
-      }),
-    )
+    .input(z.object({ taskId: z.string().uuid(), destinationVesselId: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       return await db.transaction(async (tx) => {
         const task = await loadTask(tx, input.taskId);
@@ -395,113 +409,127 @@ export const recipeExecutionRouter = router({
           .from(batchRecipeExecutions)
           .where(eq(batchRecipeExecutions.id, task.executionId))
           .limit(1);
-        const refs = (exec?.sourceRefs ?? {}) as { parentBatchIds?: string[] };
-        const sourceBatchId = refs.parentBatchIds?.[0];
-        if (!sourceBatchId) {
+        const refs = (exec?.sourceRefs ?? {}) as {
+          parentBatches?: { batchId: string; volumeL: number }[];
+          parentBatchIds?: string[];
+        };
+        // Legacy executions (pre per-cider amounts) split the planned batch
+        // volume evenly across their source ciders.
+        const legacyIds = refs.parentBatchIds ?? [];
+        const plannedTotal =
+          parseFloat(exec?.bottleVolumeL || "0") + parseFloat(exec?.kegVolumeL || "0");
+        const draws = refs.parentBatches?.length
+          ? refs.parentBatches
+          : legacyIds.map((batchId) => ({ batchId, volumeL: plannedTotal / (legacyIds.length || 1) }));
+        if (draws.length === 0) {
           throw new TRPCError({ code: "BAD_REQUEST", message: "No source cider recorded for this batch." });
         }
-        const [source] = await tx.select().from(batches).where(eq(batches.id, sourceBatchId)).limit(1);
-        if (!source) throw new TRPCError({ code: "NOT_FOUND", message: "Source batch not found." });
-        if (!source.vesselId) {
-          throw new TRPCError({ code: "BAD_REQUEST", message: "Source cider isn't in a vessel." });
+        const totalL = draws.reduce((s, d) => s + d.volumeL, 0);
+        if (totalL <= 0) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "No transfer volume recorded for the source cider(s)." });
         }
-        const sourceVesselId = source.vesselId;
 
-        const sourceVol = parseFloat(source.currentVolumeLiters || source.currentVolume || "0");
-        if (input.volumeL > sourceVol + 0.001) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: `Source cider only has ${sourceVol.toFixed(1)} L; can't transfer ${input.volumeL} L.`,
-          });
-        }
+        // Destination room: capacity − what's already in it.
         const [destVessel] = await tx.select().from(vessels).where(eq(vessels.id, input.destinationVesselId)).limit(1);
         if (!destVessel) throw new TRPCError({ code: "NOT_FOUND", message: "Destination vessel not found." });
-
-        // Destination must have room: capacity − what's already in it.
         const destCapacityL =
           (destVessel.capacityUnit === "gal" ? 3.785411784 : 1) * parseFloat(destVessel.capacity || "0");
         const [{ used }] = await tx
           .select({ used: sql<string>`COALESCE(SUM(CAST(${batches.currentVolumeLiters} AS DECIMAL)), 0)` })
           .from(batches)
           .where(and(eq(batches.vesselId, destVessel.id), isNull(batches.deletedAt)));
-        const usedL = parseFloat(used) || 0;
-        const spaceL = destCapacityL - usedL;
-        if (input.volumeL > spaceL + 0.001) {
+        const spaceL = destCapacityL - (parseFloat(used) || 0);
+        if (totalL > spaceL + 0.001) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: `${destVessel.name} only has ${spaceL.toFixed(1)} L of space (capacity ${destCapacityL.toFixed(
-              0,
-            )} L, ${usedL.toFixed(1)} L in use).`,
+            message: `${destVessel.name} only has ${spaceL.toFixed(1)} L of space; the blend is ${totalL.toFixed(1)} L.`,
           });
         }
 
-        // Debit the source.
-        const newSourceVol = sourceVol - input.volumeL;
-        await tx
-          .update(batches)
-          .set({
-            currentVolume: newSourceVol.toString(),
-            currentVolumeLiters: newSourceVol.toString(),
-            currentVolumeUnit: "L",
-            updatedAt: new Date(),
-          })
-          .where(eq(batches.id, source.id));
+        // Validate, debit, and record lineage for each source. Blend ABV/OG.
+        let abvWeighted = 0;
+        let ogWeighted = 0;
+        let ogWeight = 0;
+        for (const draw of draws) {
+          const [src] = await tx.select().from(batches).where(eq(batches.id, draw.batchId)).limit(1);
+          if (!src) throw new TRPCError({ code: "NOT_FOUND", message: "Source batch not found." });
+          if (!src.vesselId) {
+            throw new TRPCError({ code: "BAD_REQUEST", message: `${src.customName || src.name} isn't in a vessel.` });
+          }
+          const srcVol = parseFloat(src.currentVolumeLiters || src.currentVolume || "0");
+          if (draw.volumeL > srcVol + 0.001) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `${src.customName || src.name} only has ${srcVol.toFixed(1)} L; can't draw ${draw.volumeL} L.`,
+            });
+          }
+          const srcAbv = parseFloat(src.actualAbv || src.estimatedAbv || "0");
+          abvWeighted += srcAbv * draw.volumeL;
+          if (src.originalGravity) {
+            ogWeighted += parseFloat(src.originalGravity) * draw.volumeL;
+            ogWeight += draw.volumeL;
+          }
+          const newSrcVol = srcVol - draw.volumeL;
+          await tx
+            .update(batches)
+            .set({
+              currentVolume: newSrcVol.toString(),
+              currentVolumeLiters: newSrcVol.toString(),
+              currentVolumeUnit: "L",
+              updatedAt: new Date(),
+            })
+            .where(eq(batches.id, src.id));
+          await tx.insert(batchMergeHistory).values({
+            targetBatchId: task.batchId,
+            sourceBatchId: src.id,
+            sourceType: "batch_transfer",
+            volumeAdded: draw.volumeL.toString(),
+            volumeAddedUnit: "L",
+            targetVolumeBefore: "0",
+            targetVolumeBeforeUnit: "L",
+            targetVolumeAfter: totalL.toString(),
+            targetVolumeAfterUnit: "L",
+            mergedAt: new Date(),
+            mergedBy: ctx.user.id,
+            createdAt: new Date(),
+          });
+          await tx.insert(batchTransfers).values({
+            sourceBatchId: src.id,
+            sourceVesselId: src.vesselId,
+            destinationBatchId: task.batchId,
+            destinationVesselId: input.destinationVesselId,
+            volumeTransferred: draw.volumeL.toString(),
+            volumeTransferredUnit: "L",
+            totalVolumeProcessed: draw.volumeL.toString(),
+            totalVolumeProcessedUnit: "L",
+            loss: "0",
+            lossUnit: "L",
+            transferredAt: new Date(),
+            transferredBy: ctx.user.id,
+            notes: `Recipe blend: ${draw.volumeL} L from ${src.customName || src.name} → ${destVessel.name}`,
+            createdAt: new Date(),
+          });
+        }
 
-        // Fill this batch + assign the destination vessel.
-        await tx
-          .update(batches)
-          .set({
-            vesselId: input.destinationVesselId,
-            currentVolume: input.volumeL.toString(),
-            currentVolumeLiters: input.volumeL.toString(),
-            currentVolumeUnit: "L",
-            updatedAt: new Date(),
-          })
-          .where(eq(batches.id, task.batchId));
+        // Fill this batch + assign vessel + blended ABV/OG.
+        const fill: Record<string, unknown> = {
+          vesselId: input.destinationVesselId,
+          currentVolume: totalL.toString(),
+          currentVolumeLiters: totalL.toString(),
+          currentVolumeUnit: "L",
+          updatedAt: new Date(),
+        };
+        if (abvWeighted > 0) fill.estimatedAbv = (abvWeighted / totalL).toFixed(2);
+        if (ogWeight > 0) fill.originalGravity = (ogWeighted / ogWeight).toFixed(4);
+        await tx.update(batches).set(fill).where(eq(batches.id, task.batchId));
 
-        // Lineage: merge history (before treated as empty) + transfer record.
-        await tx.insert(batchMergeHistory).values({
-          targetBatchId: task.batchId,
-          sourceBatchId: source.id,
-          sourceType: "batch_transfer",
-          volumeAdded: input.volumeL.toString(),
-          volumeAddedUnit: "L",
-          targetVolumeBefore: "0",
-          targetVolumeBeforeUnit: "L",
-          targetVolumeAfter: input.volumeL.toString(),
-          targetVolumeAfterUnit: "L",
-          mergedAt: new Date(),
-          mergedBy: ctx.user.id,
-          createdAt: new Date(),
-        });
-        await tx.insert(batchTransfers).values({
-          sourceBatchId: source.id,
-          sourceVesselId,
-          destinationBatchId: task.batchId,
-          destinationVesselId: input.destinationVesselId,
-          volumeTransferred: input.volumeL.toString(),
-          volumeTransferredUnit: "L",
-          totalVolumeProcessed: input.volumeL.toString(),
-          totalVolumeProcessedUnit: "L",
-          loss: "0",
-          lossUnit: "L",
-          transferredAt: new Date(),
-          transferredBy: ctx.user.id,
-          notes: `Recipe transfer: ${input.volumeL} L from ${source.customName || source.name} → ${destVessel.name}`,
-          createdAt: new Date(),
-        });
-
-        // Mark the task done + record actuals, then reschedule.
+        // Mark done + reschedule.
         await tx
           .update(batchStepTasks)
           .set({
             status: "done",
             completedAt: new Date(),
-            actualData: {
-              sourceBatchId: source.id,
-              destinationVesselId: input.destinationVesselId,
-              volumeL: input.volumeL,
-            },
+            actualData: { destinationVesselId: input.destinationVesselId, sources: draws, totalL },
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -454,7 +454,9 @@ export const recipeExecutionRouter = router({
         const destCapacityL =
           (destVessel.capacityUnit === "gal" ? 3.785411784 : 1) * parseFloat(destVessel.capacity || "0");
         const [{ used }] = await tx
-          .select({ used: sql<string>`COALESCE(SUM(CAST(${batches.currentVolumeLiters} AS DECIMAL)), 0)` })
+          .select({
+            used: sql<string>`COALESCE(SUM(COALESCE(CAST(${batches.currentVolumeLiters} AS DECIMAL), CAST(${batches.currentVolume} AS DECIMAL), 0)), 0)`,
+          })
           .from(batches)
           .where(and(eq(batches.vesselId, destVessel.id), isNull(batches.deletedAt)));
         const spaceL = destCapacityL - (parseFloat(used) || 0);
@@ -465,8 +467,11 @@ export const recipeExecutionRouter = router({
           });
         }
 
-        // Validate, debit, and record lineage for each source. Blend ABV/OG.
+        // Validate, debit, and record lineage for each source. Blend ABV/OG —
+        // each weighted only over the sources that actually have that value, so
+        // a source missing ABV/OG doesn't dilute the result.
         let abvWeighted = 0;
+        let abvWeight = 0;
         let ogWeighted = 0;
         let ogWeight = 0;
         for (const draw of draws) {
@@ -483,7 +488,10 @@ export const recipeExecutionRouter = router({
             });
           }
           const srcAbv = parseFloat(src.actualAbv || src.estimatedAbv || "0");
-          abvWeighted += srcAbv * draw.volumeL;
+          if (srcAbv > 0) {
+            abvWeighted += srcAbv * draw.volumeL;
+            abvWeight += draw.volumeL;
+          }
           if (src.originalGravity) {
             ogWeighted += parseFloat(src.originalGravity) * draw.volumeL;
             ogWeight += draw.volumeL;
@@ -538,7 +546,7 @@ export const recipeExecutionRouter = router({
           currentVolumeUnit: "L",
           updatedAt: new Date(),
         };
-        if (abvWeighted > 0) fill.estimatedAbv = (abvWeighted / totalL).toFixed(2);
+        if (abvWeight > 0) fill.estimatedAbv = (abvWeighted / abvWeight).toFixed(2);
         if (ogWeight > 0) fill.originalGravity = (ogWeighted / ogWeight).toFixed(4);
         await tx.update(batches).set(fill).where(eq(batches.id, task.batchId));
 

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -25,6 +25,7 @@ import {
   vessels,
   recipes,
   recipeSteps,
+  recipeInputs,
   batchRecipeExecutions,
   batchStepTasks,
   batchMergeHistory,
@@ -323,7 +324,25 @@ export const recipeExecutionRouter = router({
         plannedVolumeL: parentBatches.find((p) => p.batchId === s.id)?.volumeL ?? null,
       }));
 
-      return { execution, tasks, sources };
+      // Recipe ingredients (for prefilling the add-additive form per step).
+      const ingredients = await db
+        .select({
+          label: recipeInputs.label,
+          additiveType: recipeInputs.additiveType,
+          additiveName: recipeInputs.additiveName,
+          additiveVarietyId: recipeInputs.additiveVarietyId,
+          rateValue: recipeInputs.rateValue,
+          rateUnit: recipeInputs.rateUnit,
+        })
+        .from(recipeInputs)
+        .where(
+          and(
+            eq(recipeInputs.recipeId, execution.recipeId),
+            eq(recipeInputs.kind, "ingredient"),
+          ),
+        );
+
+      return { execution, tasks, sources, ingredients };
     }),
 
   /** Cross-batch work queue: every open task across all active executions. */

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -22,6 +22,7 @@ import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import {
   db,
   batches,
+  vessels,
   recipes,
   recipeSteps,
   batchRecipeExecutions,
@@ -280,7 +281,26 @@ export const recipeExecutionRouter = router({
         .where(eq(batchStepTasks.executionId, execution.id))
         .orderBy(asc(batchStepTasks.sequence));
 
-      return { execution, tasks };
+      // Resolve the source cider batch(es) + their vessel, so a transfer step
+      // can show "the base cider is in TANK-X".
+      const refs = (execution.sourceRefs ?? {}) as { parentBatchIds?: string[] };
+      const parentIds = refs.parentBatchIds ?? [];
+      const sources = parentIds.length
+        ? await db
+            .select({
+              id: batches.id,
+              name: batches.name,
+              customName: batches.customName,
+              vesselName: vessels.name,
+              currentVolume: batches.currentVolume,
+              currentVolumeUnit: batches.currentVolumeUnit,
+            })
+            .from(batches)
+            .leftJoin(vessels, eq(batches.vesselId, vessels.id))
+            .where(inArray(batches.id, parentIds))
+        : [];
+
+      return { execution, tasks, sources };
     }),
 
   /** Cross-batch work queue: every open task across all active executions. */
@@ -325,6 +345,7 @@ export const recipeExecutionRouter = router({
         completedAt: z.coerce.date().optional(),
         actualHours: z.number().nonnegative().nullish(),
         notes: z.string().nullish(),
+        actualData: z.record(z.string(), z.unknown()).nullish(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -337,6 +358,7 @@ export const recipeExecutionRouter = router({
             completedAt: input.completedAt ?? new Date(),
             actualHours: input.actualHours != null ? input.actualHours.toString() : task.actualHours,
             notes: input.notes ?? task.notes,
+            actualData: input.actualData ?? task.actualData,
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -27,6 +27,8 @@ import {
   recipeSteps,
   batchRecipeExecutions,
   batchStepTasks,
+  batchMergeHistory,
+  batchTransfers,
 } from "db";
 import { buildStepSchedule, rescheduleWithActuals } from "lib";
 import { router, createRbacProcedure } from "../trpc";
@@ -359,6 +361,129 @@ export const recipeExecutionRouter = router({
             actualHours: input.actualHours != null ? input.actualHours.toString() : task.actualHours,
             notes: input.notes ?? task.notes,
             actualData: input.actualData ?? task.actualData,
+            updatedAt: new Date(),
+          })
+          .where(eq(batchStepTasks.id, task.id));
+        await recomputeSchedule(tx, task.executionId);
+        return { tasks: await tasksForExecution(tx, task.executionId) };
+      });
+    }),
+
+  /**
+   * Perform the "transfer base cider into the mixing vessel" step: move the
+   * chosen volume from the source cider into the destination vessel, assign that
+   * vessel to this batch, debit the source, record lineage, and mark the task
+   * done. Custom because the recipe batch is a pre-created shell (the manual
+   * rack/transfer flow creates its own destination batch).
+   *
+   * v1: pulls from the first source cider. Multi-source blends and the TTB
+   * volume ledger entry are follow-ups.
+   */
+  performTransfer: createRbacProcedure("update", "batch")
+    .input(
+      z.object({
+        taskId: z.string().uuid(),
+        destinationVesselId: z.string().uuid(),
+        volumeL: z.number().positive(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      return await db.transaction(async (tx) => {
+        const task = await loadTask(tx, input.taskId);
+        const [exec] = await tx
+          .select()
+          .from(batchRecipeExecutions)
+          .where(eq(batchRecipeExecutions.id, task.executionId))
+          .limit(1);
+        const refs = (exec?.sourceRefs ?? {}) as { parentBatchIds?: string[] };
+        const sourceBatchId = refs.parentBatchIds?.[0];
+        if (!sourceBatchId) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "No source cider recorded for this batch." });
+        }
+        const [source] = await tx.select().from(batches).where(eq(batches.id, sourceBatchId)).limit(1);
+        if (!source) throw new TRPCError({ code: "NOT_FOUND", message: "Source batch not found." });
+        if (!source.vesselId) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Source cider isn't in a vessel." });
+        }
+        const sourceVesselId = source.vesselId;
+
+        const sourceVol = parseFloat(source.currentVolumeLiters || source.currentVolume || "0");
+        if (input.volumeL > sourceVol + 0.001) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Source cider only has ${sourceVol.toFixed(1)} L; can't transfer ${input.volumeL} L.`,
+          });
+        }
+        const [destVessel] = await tx.select().from(vessels).where(eq(vessels.id, input.destinationVesselId)).limit(1);
+        if (!destVessel) throw new TRPCError({ code: "NOT_FOUND", message: "Destination vessel not found." });
+
+        // Debit the source.
+        const newSourceVol = sourceVol - input.volumeL;
+        await tx
+          .update(batches)
+          .set({
+            currentVolume: newSourceVol.toString(),
+            currentVolumeLiters: newSourceVol.toString(),
+            currentVolumeUnit: "L",
+            updatedAt: new Date(),
+          })
+          .where(eq(batches.id, source.id));
+
+        // Fill this batch + assign the destination vessel.
+        await tx
+          .update(batches)
+          .set({
+            vesselId: input.destinationVesselId,
+            currentVolume: input.volumeL.toString(),
+            currentVolumeLiters: input.volumeL.toString(),
+            currentVolumeUnit: "L",
+            updatedAt: new Date(),
+          })
+          .where(eq(batches.id, task.batchId));
+
+        // Lineage: merge history (before treated as empty) + transfer record.
+        await tx.insert(batchMergeHistory).values({
+          targetBatchId: task.batchId,
+          sourceBatchId: source.id,
+          sourceType: "batch_transfer",
+          volumeAdded: input.volumeL.toString(),
+          volumeAddedUnit: "L",
+          targetVolumeBefore: "0",
+          targetVolumeBeforeUnit: "L",
+          targetVolumeAfter: input.volumeL.toString(),
+          targetVolumeAfterUnit: "L",
+          mergedAt: new Date(),
+          mergedBy: ctx.user.id,
+          createdAt: new Date(),
+        });
+        await tx.insert(batchTransfers).values({
+          sourceBatchId: source.id,
+          sourceVesselId,
+          destinationBatchId: task.batchId,
+          destinationVesselId: input.destinationVesselId,
+          volumeTransferred: input.volumeL.toString(),
+          volumeTransferredUnit: "L",
+          totalVolumeProcessed: input.volumeL.toString(),
+          totalVolumeProcessedUnit: "L",
+          loss: "0",
+          lossUnit: "L",
+          transferredAt: new Date(),
+          transferredBy: ctx.user.id,
+          notes: `Recipe transfer: ${input.volumeL} L from ${source.customName || source.name} → ${destVessel.name}`,
+          createdAt: new Date(),
+        });
+
+        // Mark the task done + record actuals, then reschedule.
+        await tx
+          .update(batchStepTasks)
+          .set({
+            status: "done",
+            completedAt: new Date(),
+            actualData: {
+              sourceBatchId: source.id,
+              destinationVesselId: input.destinationVesselId,
+              volumeL: input.volumeL,
+            },
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -417,6 +417,24 @@ export const recipeExecutionRouter = router({
         const [destVessel] = await tx.select().from(vessels).where(eq(vessels.id, input.destinationVesselId)).limit(1);
         if (!destVessel) throw new TRPCError({ code: "NOT_FOUND", message: "Destination vessel not found." });
 
+        // Destination must have room: capacity − what's already in it.
+        const destCapacityL =
+          (destVessel.capacityUnit === "gal" ? 3.785411784 : 1) * parseFloat(destVessel.capacity || "0");
+        const [{ used }] = await tx
+          .select({ used: sql<string>`COALESCE(SUM(CAST(${batches.currentVolumeLiters} AS DECIMAL)), 0)` })
+          .from(batches)
+          .where(and(eq(batches.vesselId, destVessel.id), isNull(batches.deletedAt)));
+        const usedL = parseFloat(used) || 0;
+        const spaceL = destCapacityL - usedL;
+        if (input.volumeL > spaceL + 0.001) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `${destVessel.name} only has ${spaceL.toFixed(1)} L of space (capacity ${destCapacityL.toFixed(
+              0,
+            )} L, ${usedL.toFixed(1)} L in use).`,
+          });
+        }
+
         // Debit the source.
         const newSourceVol = sourceVol - input.volumeL;
         await tx

--- a/packages/db/migrations/0139_batch_step_task_actuals.sql
+++ b/packages/db/migrations/0139_batch_step_task_actuals.sql
@@ -1,0 +1,5 @@
+-- Captured actuals on a recipe-execution task: what the operator actually did
+-- (amount, destination vessel, readings, …) vs the plan. Capture-first; real
+-- operations wired in later.
+ALTER TABLE batch_step_tasks
+  ADD COLUMN IF NOT EXISTS actual_data JSONB;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2000,6 +2000,10 @@ export const batchStepTasks = pgTable(
     assignedWorkerId: uuid("assigned_worker_id").references(() => workers.id),
     // {type, id} of the operation row created when this task ran (e.g. batchAdditive).
     resultRef: jsonb("result_ref"),
+    // Captured actuals when the step was performed — what the operator actually
+    // did vs the plan (e.g. { actualAmount, actualUnit, destinationVesselId,
+    // readings }). Drives deviation tracking; real operations wired in later.
+    actualData: jsonb("actual_data"),
     estimatedHours: decimal("estimated_hours", { precision: 6, scale: 2 }),
     actualHours: decimal("actual_hours", { precision: 6, scale: 2 }),
     notes: text("notes"),


### PR DESCRIPTION
## Summary
Milestone 3 of recipe execution: every step in a batch's recipe checklist now **opens its real operation** (the same modals/forms as the manual cellar flow), pre-filled from the recipe, and completing it both records the real operation **and** marks the step done (rescheduling the rest). 8 commits.

## What a step click now does
| Step | Opens | Prefilled from recipe |
|------|-------|-----------------------|
| Transfer base cider | custom transfer → assigns vessel, debits source(s), blends ABV/OG | source ciders + per-cider draw |
| Add additive / pitch yeast | real **AddBatchAdditiveForm** (inventory drawdown) | type, variety (matched lot), rate, computed amount |
| Measure | real **AddBatchMeasurementForm** | — |
| Filter | real **FilterModal** | filter type (coarse/fine) |
| Carbonate | real **CarbonateModal** | target CO₂ + method |
| Package | real packaging modal (bottle/keg per path) | container size (size only) |
| Pasteurize | real **PasteurizeModal** (on the latest bottle run) | — |
| Label | real **LabelModal** (on the latest bottle run) | — |
| QA gate / wait / note | capture-first panel (notes + done) — a sign-off, not an operation | — |

## Highlights
- **Multi-source blends**: instantiate with several base ciders + per-cider amounts; the transfer debits each, blends ABV/OG, and moves the total into one vessel (space-checked, empty vessels highlighted).
- **Vessel availability**: destination picker shows real contents + free space, disables vessels that can't fit.
- **Dependency guards**: vessel actions nudge "do the Transfer first"; pasteurize/label nudge "package first".
- **Branch-aware + dynamic scheduling** carried over from M2.

## Data
- Migration `0139` (batch_step_tasks.actual_data) — already applied to dev DB.
- New `onSuccess` hooks added (backward-compatible) to FilterModal / BottleModal / FillKegModal / UnifiedPackagingModal; prefill props added to AddBatchAdditiveForm / CarbonateModal / FilterModal.

## Verification
86 lib recipe tests pass; web/api/db typecheck clean; exercised on a real batch end-to-end.

## Known follow-ups (post-M3)
- Transfer doesn't yet write the TTB volume-ledger entry.
- Package step's container prefill is size-only (form picks purchase lots; recipe stores varieties).
- Measurement prefill (which measures) not done — minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
