### PR TITLE
Recipe checklist fixes: additive unit prefill + locked-step indicator

### DIFF
--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -170,10 +170,12 @@ export function AddBatchAdditiveForm({
   prefillUnit,
 }: AddBatchAdditiveFormProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
-  const [selectedAdditiveType, setSelectedAdditiveType] = useState("");
+  // Seed initial state from recipe prefill (more robust than a post-mount
+  // effect, which races with the form's own type/inventory logic on a Select).
+  const [selectedAdditiveType, setSelectedAdditiveType] = useState(prefillAdditiveType ?? "");
   const [selectedInventoryItem, setSelectedInventoryItem] = useState<any>(null);
-  const [amount, setAmount] = useState("");
-  const [unit, setUnit] = useState("");
+  const [amount, setAmount] = useState(prefillAmount != null ? String(prefillAmount) : "");
+  const [unit, setUnit] = useState(prefillUnit ?? "");
   const [notes, setNotes] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [open, setOpen] = useState(false);
@@ -181,8 +183,8 @@ export function AddBatchAdditiveForm({
     return formatDateTimeForInput(new Date());
   });
   const [dateWarning, setDateWarning] = useState<string | null>(null);
-  const [dosageRate, setDosageRate] = useState("");
-  const [dosageRateUnit, setDosageRateUnit] = useState("mL/L");
+  const [dosageRate, setDosageRate] = useState(prefillDosageRate != null ? String(prefillDosageRate) : "");
+  const [dosageRateUnit, setDosageRateUnit] = useState(prefillDosageRateUnit ?? "mL/L");
   const [isApplePearFruit, setIsApplePearFruit] = useState(false);
   /**
    * Liters this addition contributes to the batch volume. Defaults from the
@@ -225,17 +227,6 @@ export function AddBatchAdditiveForm({
         enabled: !!selectedAdditiveType,
       },
     );
-
-  // Prefill from a recipe step (run once on mount): planned type, dosage rate,
-  // and computed amount. The operator confirms or adjusts.
-  React.useEffect(() => {
-    if (prefillAdditiveType) setSelectedAdditiveType(prefillAdditiveType);
-    if (prefillDosageRate != null) setDosageRate(String(prefillDosageRate));
-    if (prefillDosageRateUnit) setDosageRateUnit(prefillDosageRateUnit);
-    if (prefillAmount != null) setAmount(String(prefillAmount));
-    if (prefillUnit) setUnit(prefillUnit);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Once the type's inventory loads, auto-select the lot matching the recipe
   // variety — only when there's exactly one, to avoid guessing.

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -36,7 +36,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Check, SkipForward, RotateCcw } from "lucide-react";
+import { Check, SkipForward, RotateCcw, Lock } from "lucide-react";
 
 const STATUS_STYLE: Record<string, string> = {
   pending: "border-gray-300 text-gray-600",
@@ -120,6 +120,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
     }
     setOpenTask(t);
   };
+  // Why a step can't run yet (shown as a lock on the row).
+  const blockedReason = (t: Task): string | null => {
+    if (t.status === "done" || t.status === "skipped") return null;
+    if (VESSEL_KINDS.has(t.kind) && !batchData?.vesselId) return "needs Transfer first";
+    if (RUN_KINDS.has(t.kind) && !latestRun) return "needs Package first";
+    return null;
+  };
 
   if (isLoading) {
     return (
@@ -202,6 +209,11 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                   <TableCell>
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <span className={t.status === "done" ? "line-through" : ""}>{t.label}</span>
+                      {blockedReason(t) && (
+                        <span className="inline-flex items-center gap-1 text-[11px] text-amber-600" title={blockedReason(t)!}>
+                          <Lock className="w-3 h-3" /> {blockedReason(t)}
+                        </span>
+                      )}
                       {t.packagingPath !== "all" && (
                         <Badge variant="outline" className="text-[10px]">
                           {t.packagingPath === "bottle" ? "Bottle only" : "Keg only"}

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -207,9 +207,10 @@ export function StepDetailModal({
 
         {useRealForm ? (
           task.kind === "measurement" ? (
-            <AddBatchMeasurementForm batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
+            <AddBatchMeasurementForm key={task.id} batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
           ) : (
             <AddBatchAdditiveForm
+              key={task.id}
               batchId={batchId}
               onSuccess={onRealSuccess}
               onCancel={onClose}


### PR DESCRIPTION
- Additive prefill: seed unit/type/amount from the form's initial state instead of a post-mount effect (Radix Select value was racing), so the unit reliably populates.
- Locked-step indicator: filter/carbonate/package (need a vessel) and pasteurize/label (need a packaging run) now show a persistent amber 🔒 "needs Transfer/Package first" instead of only a missable toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)