### PR TITLE
Recipe view: ingredient rates to one decimal

### DIFF
--- a/apps/web/src/app/recipes/[id]/page.tsx
+++ b/apps/web/src/app/recipes/[id]/page.tsx
@@ -397,7 +397,7 @@ export default function RecipeDetailPage() {
                       {ing.rateValue !== null && ing.rateUnit && (
                         <>
                           <p className="text-sm text-muted-foreground">
-                            {ing.rateValue} {ing.rateUnit}
+                            {Number(ing.rateValue).toFixed(1)} {ing.rateUnit}
                           </p>
                           {scaled && (
                             <p className="text-base font-semibold">
@@ -439,7 +439,7 @@ export default function RecipeDetailPage() {
                     {p.rateValue !== null && p.rateUnit && (
                       <div className="text-right">
                         <p className="text-sm text-muted-foreground">
-                          {p.rateValue} {p.rateUnit}
+                          {Number(p.rateValue).toFixed(1)} {p.rateUnit}
                         </p>
                         {p.rateUnit === "L/L" && (
                           <p className="text-sm font-semibold">


### PR DESCRIPTION
Rates rendered the raw scale-4 value (12.0000 g/L); now one decimal (12.0 g/L) for ingredients and parent requirements.