### PR TITLE
Activity history: clean up blend/creation events

### DIFF
--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -4193,6 +4193,25 @@ export const batchRouter = router({
           });
         });
 
+        // A blend writes BOTH a batch_merge_history row and a batch_transfers
+        // row for the same action (merge row for lineage, transfer row for
+        // volume tracking). Collect the merge keys so the transfers loop can
+        // drop the duplicate "blended in" event and show the blend just once.
+        // Key on source + volume + second (the two rows share an instant, but
+        // legacy data can be a few ms apart, so we bucket to the second).
+        const blendKey = (sourceId: string, volume: unknown, ts: unknown) =>
+          `${sourceId}|${parseFloat(String(volume ?? "0")).toFixed(2)}|${Math.floor(
+            new Date(ts as any).getTime() / 1000,
+          )}`;
+        const mergeKeys = new Set<string>();
+        merges.forEach((m) => {
+          const isBatchMerge =
+            (m.sourceType === "batch_transfer" || m.sourceType === "batch") && m.sourceBatchId;
+          if (isBatchMerge && m.sourceBatchId) {
+            mergeKeys.add(blendKey(m.sourceBatchId, m.volumeAdded, m.mergedAt));
+          }
+        });
+
         // Process transfers (filter by split timestamp for ancestors)
         // Only include transfers where:
         // 1. This batch is directly involved (source or destination), OR
@@ -4248,6 +4267,15 @@ export const batchRouter = router({
 
             // For incoming blend transfers, show as "blend" type for clarity
             const isBlendIn = thisIsDestination && sourceIsAncestor;
+            // Skip the transfer-derived blend event when a matching merge_history
+            // record already represents this same blend (same source + instant);
+            // otherwise the timeline shows the one blend twice.
+            if (
+              isBlendIn &&
+              mergeKeys.has(blendKey(t.sourceBatchId, t.volumeTransferred, t.transferredAt))
+            ) {
+              return;
+            }
             activities.push({
               id: `transfer-${t.id}`,
               type: isBlendIn ? "merge" : "transfer",

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -3517,6 +3517,7 @@ export const batchRouter = router({
         const ancestorChainResult = await db.execute<{
           batch_id: string;
           batch_name: string;
+          batch_custom_name: string | null;
           split_timestamp: Date;
           start_date: Date | null;
           depth: number;
@@ -3526,6 +3527,7 @@ export const batchRouter = router({
             SELECT
               bt.source_batch_id as batch_id,
               b.name as batch_name,
+              b.custom_name as batch_custom_name,
               bt.transferred_at as split_timestamp,
               b.start_date as start_date,
               1 as depth
@@ -3541,6 +3543,7 @@ export const batchRouter = router({
             SELECT
               bmh.source_batch_id as batch_id,
               b.name as batch_name,
+              b.custom_name as batch_custom_name,
               bmh.merged_at as split_timestamp,
               b.start_date as start_date,
               1 as depth
@@ -3557,6 +3560,7 @@ export const batchRouter = router({
             SELECT
               COALESCE(bt.source_batch_id, bmh.source_batch_id) as batch_id,
               b.name,
+              b.custom_name,
               COALESCE(bt.transferred_at, bmh.merged_at) as split_timestamp,
               b.start_date,
               a.depth + 1
@@ -3579,6 +3583,7 @@ export const batchRouter = router({
         const ancestorChain = (ancestorChainResult.rows || []) as Array<{
           batch_id: string;
           batch_name: string;
+          batch_custom_name: string | null;
           split_timestamp: Date;
           start_date: Date | null;
           depth: number;
@@ -4032,10 +4037,17 @@ export const batchRouter = router({
         if (directParents.length > 1) {
           isBlendedBatch = true;
           creationDescription = `Blend created from ${directParents.length} batches`;
+        } else if (directParents.length === 1) {
+          // Single-source: name the DIRECT parent (the cider this batch was made
+          // from) plus the tank it came from — not a deeper ancestor. The
+          // ancestor query orders by batch_id, so ancestorChain[0] is arbitrary;
+          // the depth=1 row is the real source.
+          const sourceName = directParents[0].batch_custom_name || directParents[0].batch_name;
+          creationDescription = creationVessel
+            ? `Created from ${sourceName} (${creationVessel})`
+            : `Created from ${sourceName}`;
         } else if (ancestorChain.length > 0) {
-          // Single-parent transfer
-          const parentBatch = ancestorChain[0];
-          creationDescription = `Transferred from ${parentBatch.batch_name}`;
+          creationDescription = `Transferred from ${ancestorChain[0].batch_name}`;
         }
 
         activities.push({
@@ -4172,14 +4184,19 @@ export const batchRouter = router({
             };
           }
 
+          // When this blend went into the current batch, name the tank it landed
+          // in ("…into TANK-500-1") so the timeline reads as a move to a vessel.
+          const intoThisBatch = m.targetBatchId === input.batchId;
+          const destSuffix = intoThisBatch && batch[0].vesselName ? ` into ${batch[0].vesselName}` : "";
+
           const inheritedInfo = getInheritedInfo(m.targetBatchId);
           activities.push({
             id: `merge-${m.id}`,
             type: "merge",
             timestamp: m.mergedAt,
             description: isExpandable
-              ? `Blended with ${sourceDescription}`
-              : `Merged with juice from ${sourceDescription}`,
+              ? `Blended with ${sourceDescription}${destSuffix}`
+              : `Merged with juice from ${sourceDescription}${destSuffix}`,
             details: {
               volumeAdded: `${m.volumeAdded}${m.volumeAddedUnit || 'L'}`,
               volumeChange: `${m.targetVolumeBefore}${m.targetVolumeBeforeUnit || 'L'} → ${m.targetVolumeAfter}${m.targetVolumeAfterUnit || 'L'}`,

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -506,6 +506,9 @@ export const recipeExecutionRouter = router({
               updatedAt: new Date(),
             })
             .where(eq(batches.id, src.id));
+          // One instant shared by the merge_history and transfer rows for this
+          // source, so the activity timeline can pair and de-duplicate them.
+          const blendedAt = new Date();
           await tx.insert(batchMergeHistory).values({
             targetBatchId: task.batchId,
             sourceBatchId: src.id,
@@ -516,7 +519,7 @@ export const recipeExecutionRouter = router({
             targetVolumeBeforeUnit: "L",
             targetVolumeAfter: totalL.toString(),
             targetVolumeAfterUnit: "L",
-            mergedAt: new Date(),
+            mergedAt: blendedAt,
             mergedBy: ctx.user.id,
             createdAt: new Date(),
           });
@@ -531,7 +534,7 @@ export const recipeExecutionRouter = router({
             totalVolumeProcessedUnit: "L",
             loss: "0",
             lossUnit: "L",
-            transferredAt: new Date(),
+            transferredAt: blendedAt,
             transferredBy: ctx.user.id,
             notes: `Recipe blend: ${draw.volumeL} L from ${src.customName || src.name} → ${destVessel.name}`,
             createdAt: new Date(),


### PR DESCRIPTION
Reworks the batch activity timeline for recipe-instantiated (and other transfer/blend) batches so a single source reads cleanly:

**Before** (3 events for one action): creation 'Transferred from <wrong deep ancestor>' + 'Blended with Summer Community Blend 4' + 'Blended 325L from Batch #<raw name>'.

**After** (2 events):
- `Created from Summer Community Blend 4 (TANK-1000-1)` — names the *direct* source (depth=1 parent) by its friendly custom name, plus the tank it came from.
- `Blended with Summer Community Blend 4 into TANK-500-1` — the single move event, now naming the destination tank.

Changes:
1. **Dedup** — a blend writes both a merge_history row and a transfer row; `getHistory` keys them by source+volume+second and drops the duplicate transfer-derived event.
2. **Creation name** — use the depth=1 direct parent (not `ancestorChain[0]`, which was ordered by UUID) and its `custom_name` + source tank. Adds `custom_name` to the ancestor CTE.
3. **Destination tank** — the kept blend event names the vessel it landed in.
4. **Shared timestamp** — `recipeExecution.performTransfer` stamps the merge and transfer rows with one instant instead of two `new Date()` calls.

All read-time; applies to existing batches immediately, no migration.