### PR TITLE
Activity forms: show last activity next to date inputs

### DIFF
--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -22,6 +22,7 @@ import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
+import { LastActivityHint } from "@/components/ui/LastActivityHint";
 import {
   Gauge,
   Thermometer,
@@ -556,6 +557,7 @@ export function CarbonateModal({
                 {...register("startedAt" as any)}
               />
               <DateWarning warning={dateWarning} />
+              <LastActivityHint batchId={batch.id} date={startedAt} />
               {(errors as any).startedAt && (
                 <p className="text-sm text-destructive mt-1">
                   {(errors as any).startedAt.message}

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -20,6 +20,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
+import { LastActivityHint } from "@/components/ui/LastActivityHint";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, Package, AlertTriangle, Calculator } from "lucide-react";
 import { SO2Calculator } from "./SO2Calculator";
@@ -995,6 +996,7 @@ export function AddBatchAdditiveForm({
           required
         />
         <DateWarning warning={dateWarning} />
+        <LastActivityHint batchId={batchId} date={addedDate} />
       </div>
 
       <div className="space-y-2">

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -17,6 +17,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
+import { LastActivityHint } from "@/components/ui/LastActivityHint";
 import { Loader2, Info, CheckCircle2, AlertTriangle } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
 
@@ -225,6 +226,7 @@ export function AddBatchMeasurementForm({
             className="w-full"
           />
           <DateWarning warning={dateWarning} />
+          <LastActivityHint batchId={batchId} date={measurementDateTime} />
         </div>
 
         {/* Measurement Method - only for SG-focused products */}

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
+import { LastActivityHint } from "@/components/ui/LastActivityHint";
 import { Filter, AlertTriangle } from "lucide-react";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
 import { convertVolume } from "lib";
@@ -238,6 +239,7 @@ export function FilterModal({
               className="w-full mt-1"
             />
             <DateWarning warning={dateWarning} />
+            <LastActivityHint batchId={batchId} date={filteredAt} />
             {errors.filteredAt && (
               <p className="text-sm text-red-600 mt-1">
                 {errors.filteredAt.message}

--- a/apps/web/src/components/cellar/RackingModal.tsx
+++ b/apps/web/src/components/cellar/RackingModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
+import { LastActivityHint } from "@/components/ui/LastActivityHint";
 import { FlaskConical, AlertTriangle, Loader2, Info, Search } from "lucide-react";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
 import { convertVolume } from "lib";
@@ -275,6 +276,7 @@ export function RackingModal({
               className="w-full"
             />
             <DateWarning warning={dateWarning} />
+            <LastActivityHint batchId={batchId} date={rackedAt} />
             {errors.rackedAt && (
               <p className="text-sm text-red-500">{errors.rackedAt.message}</p>
             )}

--- a/apps/web/src/components/ui/LastActivityHint.tsx
+++ b/apps/web/src/components/ui/LastActivityHint.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Clock, AlertTriangle } from "lucide-react";
+import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
+
+interface LastActivityHintProps {
+  /** Batch to look up the most recent activity for. */
+  batchId?: string;
+  /** The date/time currently entered in the form (to flag out-of-order entries). */
+  date?: Date | string | null;
+  className?: string;
+}
+
+/**
+ * Shows the batch's most recent activity (label + date/time) right next to a
+ * date input, so the operator can tell whether the date they're entering comes
+ * after the previous step — especially useful when backdating several entries.
+ * Renders nothing until the batch has at least one prior activity.
+ */
+export function LastActivityHint({ batchId, date, className }: LastActivityHintProps) {
+  const { lastActivity } = useBatchDateValidation(batchId);
+  if (!lastActivity) return null;
+
+  const entered =
+    date != null ? (typeof date === "string" ? new Date(date) : date) : null;
+  const isBefore =
+    entered != null && !isNaN(entered.getTime()) && entered < lastActivity.date;
+
+  const when = lastActivity.date.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  return (
+    <p
+      className={`text-xs mt-1 flex items-center gap-1 ${
+        isBefore ? "text-orange-600" : "text-muted-foreground"
+      } ${className ?? ""}`}
+    >
+      {isBefore ? (
+        <AlertTriangle className="h-3 w-3 shrink-0" />
+      ) : (
+        <Clock className="h-3 w-3 shrink-0" />
+      )}
+      <span>
+        Last activity: {lastActivity.label} — {when}
+        {isBefore ? " · your date is earlier than this" : ""}
+      </span>
+    </p>
+  );
+}

--- a/apps/web/src/hooks/useBatchDateValidation.ts
+++ b/apps/web/src/hooks/useBatchDateValidation.ts
@@ -182,10 +182,18 @@ export function useBatchDateValidation(
     return new Date(context.earliestValidDate);
   }, [context]);
 
+  // Most recent dated activity on the batch (date + short label), or null.
+  const lastActivity = useMemo(() => {
+    const la = context && "lastActivity" in context ? context.lastActivity : null;
+    if (!la) return null;
+    return { date: new Date(la.date), label: la.label };
+  }, [context]);
+
   return {
     context,
     isLoading,
     validateDate,
     earliestValidDate,
+    lastActivity,
   };
 }

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -920,6 +920,36 @@ export const batchRouter = router({
           batchNameDate
         );
 
+        // Most recent dated activity on this batch — surfaced next to date
+        // inputs so the operator can tell whether the date they're entering is
+        // after the previous step (important when backdating several at once).
+        const lastActivityResult = await db.execute<{ event_date: Date; label: string }>(sql`
+          SELECT event_date, label FROM (
+            SELECT measurement_date AS event_date, 'Measurement' AS label FROM batch_measurements WHERE batch_id = ${batchId} AND deleted_at IS NULL
+            UNION ALL
+            SELECT added_at, 'Additive' FROM batch_additives WHERE batch_id = ${batchId} AND deleted_at IS NULL
+            UNION ALL
+            SELECT transferred_at, 'Transfer' FROM batch_transfers WHERE (source_batch_id = ${batchId} OR destination_batch_id = ${batchId}) AND deleted_at IS NULL
+            UNION ALL
+            SELECT filtered_at, 'Filter' FROM batch_filter_operations WHERE batch_id = ${batchId} AND deleted_at IS NULL
+            UNION ALL
+            SELECT racked_at, 'Racking' FROM batch_racking_operations WHERE batch_id = ${batchId} AND deleted_at IS NULL
+            UNION ALL
+            SELECT started_at, 'Carbonation' FROM batch_carbonation_operations WHERE batch_id = ${batchId} AND deleted_at IS NULL
+            UNION ALL
+            SELECT packaged_at, 'Packaging' FROM bottle_runs WHERE batch_id = ${batchId}
+          ) AS events
+          WHERE event_date IS NOT NULL
+          ORDER BY event_date DESC
+          LIMIT 1
+        `);
+        const lastRow = ((lastActivityResult as any).rows ?? [])[0] as
+          | { event_date: Date; label: string }
+          | undefined;
+        const lastActivity = lastRow
+          ? { date: lastRow.event_date, label: lastRow.label }
+          : null;
+
         // Base response
         const baseResponse = {
           batchId: batch.id,
@@ -929,6 +959,7 @@ export const batchRouter = router({
           transferDate,
           batchNameDate,
           earliestValidDate,
+          lastActivity,
         };
 
         // If bottleRunId provided, fetch packaging context for phase validation


### PR DESCRIPTION
When recording a batch activity, the date field now shows the batch's most recent prior activity (label + date/time) underneath, and turns orange when the date being entered is **earlier** than it — so you don't have to cross-check the activity log, especially when backdating several entries.

Shared `LastActivityHint` component + a `lastActivity` field added to the cached `getDateValidationContext` query (one extra indexed UNION across the batch's event tables). Wired into: filter, additive, measurement, racking, carbonation. Easy to drop into the remaining forms (packaging, transfer, edits) on request.