### PR TITLE
Allow conditioning batches in transfer, packaging, and filter

### DIFF
--- a/apps/web/src/components/cellar/VesselMap.tsx
+++ b/apps/web/src/components/cellar/VesselMap.tsx
@@ -837,11 +837,15 @@ const updateBatchStatusMutation = trpc.batch.update.useMutation({
 
     const batchStatus = liquidMapVessel?.batchStatus;
 
-    // Check if batch is in fermentation or aging status
-    if (batchStatus !== "fermentation" && batchStatus !== "aging") {
+    // Check if batch is in an active status (fermentation, aging, conditioning)
+    if (
+      batchStatus !== "fermentation" &&
+      batchStatus !== "aging" &&
+      batchStatus !== "conditioning"
+    ) {
       toast({
         title: "Cannot Filter",
-        description: "Filtering is only available for batches in fermentation or aging status.",
+        description: "Filtering is only available for batches in fermentation, aging, or conditioning status.",
         variant: "destructive",
       });
       return;

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -2528,7 +2528,7 @@ export const appRouter = router({
               .where(
                 and(
                   eq(batches.vesselId, input.newVesselId),
-                  inArray(batches.status, ["fermentation", "aging"]),
+                  inArray(batches.status, ["fermentation", "aging", "conditioning"]),
                   isNull(batches.deletedAt),
                 ),
               )
@@ -3212,7 +3212,7 @@ export const appRouter = router({
           .innerJoin(batches, and(
             eq(batches.vesselId, vessels.id),
             isNull(batches.deletedAt),
-            inArray(batches.status, ["fermentation", "aging"]),
+            inArray(batches.status, ["fermentation", "aging", "conditioning"]),
           ))
           .where(isNull(vessels.deletedAt));
 
@@ -3717,7 +3717,7 @@ export const appRouter = router({
                 .where(
                   and(
                     eq(batches.vesselId, input.fromVesselId),
-                    inArray(batches.status, ["fermentation", "aging"]),
+                    inArray(batches.status, ["fermentation", "aging", "conditioning"]),
                     isNull(batches.deletedAt),
                   ),
                 )
@@ -3840,7 +3840,7 @@ export const appRouter = router({
               .where(
                 and(
                   eq(batches.vesselId, input.toVesselId),
-                  inArray(batches.status, ["fermentation", "aging"]),
+                  inArray(batches.status, ["fermentation", "aging", "conditioning"]),
                   isNull(batches.deletedAt),
                 ),
               )
@@ -3893,7 +3893,7 @@ export const appRouter = router({
               .where(
                 and(
                   eq(batches.vesselId, input.fromVesselId),
-                  inArray(batches.status, ["fermentation", "aging"]),
+                  inArray(batches.status, ["fermentation", "aging", "conditioning"]),
                   isNull(batches.deletedAt),
                 ),
               )
@@ -3902,7 +3902,7 @@ export const appRouter = router({
             if (!sourceBatch.length) {
               throw new TRPCError({
                 code: "NOT_FOUND",
-                message: "No active batch found in source vessel (must be in fermentation or aging status)",
+                message: "No active batch found in source vessel (must be in fermentation, aging, or conditioning status)",
               });
             }
 

--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -318,11 +318,16 @@ export const packagingRouter = router({
 
             batch = batchData[0];
 
-            // Check batch status - fermentation or aging batches can be packaged
-            if (batch.status !== "aging" && batch.status !== "fermentation") {
+            // Check batch status - fermentation, aging, or conditioning batches
+            // can be packaged (conditioning is the post-filter/pre-package stage).
+            if (
+              batch.status !== "aging" &&
+              batch.status !== "fermentation" &&
+              batch.status !== "conditioning"
+            ) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
-                message: `Batch must be in fermentation or aging stage to package. Current status: ${batch.status}`,
+                message: `Batch must be in fermentation, aging, or conditioning stage to package. Current status: ${batch.status}`,
               });
             }
             currentVolumeL = parseFloat(


### PR DESCRIPTION
**Bug:** transferring (and packaging/filtering) the Lavender Salal batch failed with *"No active batch found in source vessel (must be in fermentation or aging status)"* because the batch is in **conditioning** status — the stage recipe batches land in after filtering — and these gates only allowed fermentation/aging.

The rest of the app already treats conditioning as active (dashboard, upcoming tasks, etc.). This adds `conditioning` to: the 5 source/destination batch checks in the transfer + rack mutations (`index.ts`), the packaging status gate (`packaging.ts`), and the cellar filter UI guard (`VesselMap.tsx`).