### PR TITLE
Reconciliation Phase 3: de-plug the TTB form — true variance

### DIFF
--- a/apps/web/src/app/reports/ttb/page.tsx
+++ b/apps/web/src/app/reports/ttb/page.tsx
@@ -151,6 +151,8 @@ export default function TTBReportsPage() {
       periodType,
       periodStart: startDateStr,
       periodEnd: endDateStr,
+      // Phase 3 C7: a filed period records what was unexplained at filing time
+      varianceAnalysis: formData.formData.varianceAnalysis,
       data: {
         beginningInventoryBulkGallons: formData.formData.beginningInventory.bulk,
         beginningInventoryBottledGallons: formData.formData.beginningInventory.bottled,

--- a/apps/web/src/components/admin/TTBReconciliationSummary.tsx
+++ b/apps/web/src/components/admin/TTBReconciliationSummary.tsx
@@ -1059,11 +1059,11 @@ export function TTBReconciliationSummary() {
                     <TableHead className="text-right font-semibold text-xs text-red-700">-Sales</TableHead>
                     <TableHead className="text-right font-semibold bg-gray-100">=Calc End</TableHead>
                     <TableHead className="text-right font-semibold bg-gray-100">Physical</TableHead>
-                    <TableHead className="text-right font-semibold">Variance</TableHead>
+                    <TableHead className="text-right font-semibold">Unexplained</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {data.waterfall.byTaxClass.map((w: { taxClass: string; label: string; opening: number; production: number; transfersIn: number; transfersOut: number; losses: number; distillation: number; sales: number; calculatedEnding: number; physical: number; variance: number }) => {
+                  {data.waterfall.byTaxClass.map((w: { taxClass: string; label: string; opening: number; production: number; transfersIn: number; transfersOut: number; losses: number; distillation: number; sales: number; calculatedEnding: number; physical: number; unexplainedVariance: number }) => {
                     return (
                       <TableRow key={w.taxClass}>
                         <TableCell className="font-medium text-sm whitespace-nowrap">{w.label}</TableCell>
@@ -1094,11 +1094,11 @@ export function TTBReconciliationSummary() {
                         </TableCell>
                         <TableCell className={cn(
                           "text-right font-mono text-sm font-semibold",
-                          w.variance > 0.5 && "text-amber-600",
-                          w.variance < -0.5 && "text-red-600",
-                          Math.abs(w.variance) <= 0.5 && "text-green-600"
+                          w.unexplainedVariance < -0.5 && "text-amber-600",
+                          w.unexplainedVariance > 0.5 && "text-red-600",
+                          Math.abs(w.unexplainedVariance) <= 0.5 && "text-green-600"
                         )}>
-                          {w.variance > 0 ? "+" : ""}{w.variance.toFixed(1)}
+                          {w.unexplainedVariance > 0 ? "+" : ""}{w.unexplainedVariance.toFixed(1)}
                         </TableCell>
                       </TableRow>
                     );
@@ -1119,11 +1119,11 @@ export function TTBReconciliationSummary() {
                     <TableCell className="text-right font-mono font-bold bg-gray-200">{data.waterfall.totals.physical.toFixed(1)}</TableCell>
                     <TableCell className={cn(
                       "text-right font-mono font-bold",
-                      data.waterfall.totals.variance > 0.5 && "text-amber-600",
-                      data.waterfall.totals.variance < -0.5 && "text-red-600",
-                      Math.abs(data.waterfall.totals.variance) <= 0.5 && "text-green-600"
+                      data.waterfall.totals.unexplainedVariance < -0.5 && "text-amber-600",
+                      data.waterfall.totals.unexplainedVariance > 0.5 && "text-red-600",
+                      Math.abs(data.waterfall.totals.unexplainedVariance) <= 0.5 && "text-green-600"
                     )}>
-                      {data.waterfall.totals.variance > 0 ? "+" : ""}{data.waterfall.totals.variance.toFixed(1)}
+                      {data.waterfall.totals.unexplainedVariance > 0 ? "+" : ""}{data.waterfall.totals.unexplainedVariance.toFixed(1)}
                     </TableCell>
                   </TableRow>
                 </TableBody>
@@ -1133,7 +1133,7 @@ export function TTBReconciliationSummary() {
               {data.waterfall.hasLastReconciliation
                 ? "Opening = Last reconciliation ending. "
                 : "Opening = Configured TTB opening balances. "}
-              Variance = Calculated - Physical (positive = missing inventory).
+              Unexplained = Physical - Calculated (negative = missing inventory, positive = unexplained gain).
             </p>
           </div>
         )}

--- a/apps/web/src/components/reports/BatchReconciliation.tsx
+++ b/apps/web/src/components/reports/BatchReconciliation.tsx
@@ -820,10 +820,10 @@ export function BatchReconciliation() {
     { enabled: reconciliationData !== undefined && !isOpeningYear },
   );
 
-  // TTB Balance card metrics — ALL values from per-batch SBD (single source of truth).
-  // Using a single accounting system (computeReconciliationFromBatches) for the entire
-  // waterfall guarantees ~0 variance by the SBD identity. Mixing aggregate and per-batch
-  // sources creates structural variance because they scope batches differently.
+  // TTB Balance card metrics — derived from the de-plugged Form 5120.17 (Phase 3 C2).
+  // The residual below is the form's honest arithmetic gap (ending vs formula), which
+  // is a REAL, reported quantity — not forced to zero. It measures the same-class
+  // scope mismatch / backlog the balancing plugs used to hide.
   type TtbTotals = {
     ttbOpeningBalance: number;
     systemCalculatedOnHand: number;
@@ -903,7 +903,6 @@ export function BatchReconciliation() {
       systemCalculated: ending,
       variance: residual,
       systemVariance: residual,
-      waterfallAdjustments: [],
       useFormData: true,
     };
   }, [reconciliationData, formData512017]);
@@ -1227,7 +1226,7 @@ export function BatchReconciliation() {
       lines.push(`Losses,${yearMetrics.losses}`);
       lines.push(`Distillation,${yearMetrics.distillation}`);
       lines.push(`Ending (On Premises),${yearMetrics.ending}`);
-      if (Math.abs(yearMetrics.variance) > 1) lines.push(`Residual,${yearMetrics.variance}`);
+      if (Math.abs(yearMetrics.variance) >= 0.05) lines.push(`Unexplained variance,${yearMetrics.variance}`);
       lines.push("");
     }
 
@@ -1675,15 +1674,20 @@ export function BatchReconciliation() {
               : "?";
             bannerStyle = "bg-amber-50 border-amber-200";
             icon = <AlertTriangle className="w-5 h-5 text-amber-600" />;
-            title = `${yearFilter} — ${Math.abs(yearMetrics.systemVariance).toFixed(0)} gal variance (${variancePct}%) between TTB and system`;
+            title = `${yearFilter} — ${Math.abs(yearMetrics.systemVariance).toFixed(0)} gal unexplained (${variancePct}%) — review before filing`;
           } else if (statusCounts.verified === statusCounts.total && statusCounts.total > 0) {
             bannerStyle = "bg-green-50 border-green-200";
             icon = <ShieldCheck className="w-5 h-5 text-green-600" />;
-            title = `${yearFilter} — Fully Reconciled`;
+            // State the tolerated residual rather than swallowing it silently.
+            title = yearMetrics && Math.abs(yearMetrics.systemVariance) >= 0.05
+              ? `${yearFilter} — Reconciled — ${Math.abs(yearMetrics.systemVariance).toFixed(1)} gal unexplained, within tolerance`
+              : `${yearFilter} — Fully Reconciled`;
           } else {
             bannerStyle = "bg-green-50 border-green-200";
             icon = <CheckCircle className="w-5 h-5 text-green-600" />;
-            title = `${yearFilter} — All checks passing`;
+            title = yearMetrics && Math.abs(yearMetrics.systemVariance) >= 0.05
+              ? `${yearFilter} — All checks passing — ${Math.abs(yearMetrics.systemVariance).toFixed(1)} gal unexplained, within tolerance`
+              : `${yearFilter} — All checks passing`;
           }
 
           return (
@@ -1748,9 +1752,9 @@ export function BatchReconciliation() {
                           <td className="pr-2 pt-1">= Ending (On Premises)</td>
                           <td className="text-right pt-1">{yearMetrics.ending.toLocaleString()} gal</td>
                         </tr>
-                        {Math.abs(yearMetrics.variance) > 1.0 && (
+                        {Math.abs(yearMetrics.variance) >= 0.05 && (
                           <tr className={`text-xs ${Math.abs(yearMetrics.variance) < 10 ? "text-amber-600" : "text-red-600"}`}>
-                            <td className="pr-2 pt-1">Residual</td>
+                            <td className="pr-2 pt-1">Unexplained variance</td>
                             <td className="text-right pt-1">{yearMetrics.variance > 0 ? "+" : ""}{yearMetrics.variance.toFixed(1)} gal</td>
                           </tr>
                         )}

--- a/apps/web/src/components/reports/TTBFormPreview.tsx
+++ b/apps/web/src/components/reports/TTBFormPreview.tsx
@@ -77,6 +77,65 @@ const sectionBorder = "border-x-2 border-b-2 border-gray-600";
 const reservedText = "px-3 py-2 text-xs text-gray-400 italic";
 
 // ---------------------------------------------------------------------------
+// Variance state (Phase 3 C2 — plugs removed, variance is real)
+// ---------------------------------------------------------------------------
+
+// Human-readable tax-class labels for the variance breakdown.
+const TAX_CLASS_LABELS: Record<string, string> = {
+  hardCider: "Hard Cider",
+  wineUnder16: "Wine ≤16%",
+  wine16To21: "Wine 16–21%",
+  wine21To24: "Wine 21–24%",
+  carbonatedWine: "Carbonated Wine",
+  sparklingWine: "Sparkling Wine",
+};
+
+// 3-state classification: within tolerance is "balanced"; a real signed gap is
+// "unexplained" (amber — review, don't hide); only null/NaN is "broken" (red).
+type VarianceState = "balanced" | "unexplained" | "broken";
+const getVarianceState = (v: number | null | undefined, threshold: number): VarianceState => {
+  if (v == null || Number.isNaN(v)) return "broken";
+  return Math.abs(v) <= threshold ? "balanced" : "unexplained";
+};
+
+// Discrepancy cell color for the cider/brandy reconciliation (0.5-gal tolerance).
+const discCellClass = (v: number): string => {
+  const s = getVarianceState(v, 0.5);
+  return s === "balanced" ? "text-green-700"
+    : s === "unexplained" ? "text-amber-600 font-semibold"
+    : "text-red-600 font-semibold";
+};
+
+// Per-class breakdown of the honest unexplained variance (recorded losses,
+// signed unexplained gallons, and the itemized components behind it).
+function VarianceBreakdown({ analysis }: { analysis: TTBForm512017Data["varianceAnalysis"] }) {
+  if (!analysis) return null;
+  const rows = Object.entries(analysis.byTaxClass).filter(
+    ([, c]) => Math.abs(c.unexplained) >= 0.1 || c.components.length > 0
+  );
+  if (rows.length === 0) return null;
+  return (
+    <div className="border border-amber-300 bg-amber-50 rounded p-2 text-[10px] text-amber-900 space-y-1.5">
+      <p className="font-semibold uppercase text-amber-800">Unexplained variance by tax class</p>
+      {rows.map(([cls, c]) => (
+        <div key={cls} className="space-y-0.5">
+          <div className="flex justify-between font-semibold">
+            <span>{TAX_CLASS_LABELS[cls] ?? cls}</span>
+            <span className="tabular-nums">{fmtAlways(c.unexplained)} gal unexplained</span>
+          </div>
+          <div className="text-amber-700">Recorded losses: {fmtAlways(c.recordedLosses)} gal</div>
+          {c.components.map((comp, i) => (
+            <div key={i} className="text-amber-700 pl-2">
+              • {comp.note} ({fmtAlways(comp.amount)} gal)
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -247,19 +306,42 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
             <span className="text-gray-500">through</span>
             <span className="font-mono">{periodTo}</span>
             <span className="ml-4 text-gray-500">({periodLabel})</span>
-            {/* Balance badge */}
-            <span className="ml-auto">
-              {formData.reconciliation.balanced ? (
-                <Badge variant="default" className="bg-green-600 text-[10px] py-0">
-                  <CheckCircle className="w-3 h-3 mr-1" />Balanced
-                </Badge>
-              ) : (
-                <Badge variant="destructive" className="text-[10px] py-0">
-                  <AlertTriangle className="w-3 h-3 mr-1" />
-                  Variance: {fmtAlways(formData.reconciliation.variance)} gal
-                </Badge>
-              )}
-            </span>
+            {/* Balance badge — 3 state: balanced / unexplained (amber) / broken (red) */}
+            {(() => {
+              const state = getVarianceState(formData.reconciliation.variance, 1);
+              if (state === "balanced") {
+                return (
+                  <span className="ml-auto">
+                    <Badge variant="default" className="bg-green-600 text-[10px] py-0">
+                      <CheckCircle className="w-3 h-3 mr-1" />Balanced
+                    </Badge>
+                  </span>
+                );
+              }
+              if (state === "broken") {
+                return (
+                  <span className="ml-auto">
+                    <Badge variant="destructive" className="text-[10px] py-0">
+                      <AlertTriangle className="w-3 h-3 mr-1" />Reconciliation error
+                    </Badge>
+                  </span>
+                );
+              }
+              // Unexplained variance — amber, with expandable per-class breakdown.
+              return (
+                <details className="ml-auto relative">
+                  <summary className="list-none cursor-pointer">
+                    <Badge variant="outline" className="border-amber-500 bg-amber-50 text-amber-700 text-[10px] py-0">
+                      <AlertTriangle className="w-3 h-3 mr-1" />
+                      Unexplained variance: {fmtAlways(formData.reconciliation.variance)} gal — review before filing
+                    </Badge>
+                  </summary>
+                  <div className="absolute right-0 top-full z-10 mt-1 w-72">
+                    <VarianceBreakdown analysis={formData.varianceAnalysis} />
+                  </div>
+                </details>
+              );
+            })()}
           </div>
         </div>
       </div>
@@ -647,19 +729,37 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
                   <td className={`${cellLeft} font-medium`}>Total Accounted For (Removals + Ending Inventory)</td>
                   <td className={`${cellRight} w-32 font-semibold`}>{fmtAlways(formData.reconciliation.totalAccountedFor)}</td>
                 </tr>
-                <tr className={formData.reconciliation.balanced ? "bg-green-50" : "bg-red-50"}>
-                  <td className={`${cellLeft} font-bold`}>
-                    VARIANCE
-                    {formData.reconciliation.balanced && (
-                      <span className="ml-2 text-green-700 font-normal">(Books balance)</span>
-                    )}
-                  </td>
-                  <td className={`${cellRight} w-32 font-bold ${formData.reconciliation.balanced ? "text-green-700" : "text-red-700"}`}>
-                    {fmtAlways(formData.reconciliation.variance)}
-                  </td>
-                </tr>
+                {(() => {
+                  const state = getVarianceState(formData.reconciliation.variance, 0.5);
+                  const rowBg = state === "balanced" ? "bg-green-50" : state === "unexplained" ? "bg-amber-50" : "bg-red-50";
+                  const textColor = state === "balanced" ? "text-green-700" : state === "unexplained" ? "text-amber-700" : "text-red-700";
+                  return (
+                    <tr className={rowBg}>
+                      <td className={`${cellLeft} font-bold`}>
+                        VARIANCE
+                        {state === "balanced" && (
+                          <span className="ml-2 text-green-700 font-normal">(Books balance)</span>
+                        )}
+                        {state === "unexplained" && (
+                          <span className="ml-2 text-amber-700 font-normal">(Unexplained — review before filing)</span>
+                        )}
+                        {state === "broken" && (
+                          <span className="ml-2 text-red-700 font-normal">(Reconciliation error)</span>
+                        )}
+                      </td>
+                      <td className={`${cellRight} w-32 font-bold ${textColor}`}>
+                        {fmtAlways(formData.reconciliation.variance)}
+                      </td>
+                    </tr>
+                  );
+                })()}
               </tbody>
             </table>
+            {getVarianceState(formData.reconciliation.variance, 0.5) === "unexplained" && (
+              <div className="mt-2">
+                <VarianceBreakdown analysis={formData.varianceAnalysis} />
+              </div>
+            )}
           </div>
 
           {/* Cider/Brandy Reconciliation */}
@@ -680,7 +780,7 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
                     <td className={`${cellLeft} font-medium`}>Cider</td>
                     <td className={cellRight}>{fmtAlways(formData.ciderBrandyReconciliation.cider.expectedEnding)}</td>
                     <td className={cellRight}>{fmtAlways(formData.ciderBrandyReconciliation.cider.actualEnding)}</td>
-                    <td className={`${cellRight} ${formData.ciderBrandyReconciliation.cider.discrepancy !== 0 ? "text-red-600 font-semibold" : "text-green-700"}`}>
+                    <td className={`${cellRight} ${discCellClass(formData.ciderBrandyReconciliation.cider.discrepancy)}`}>
                       {fmtAlways(formData.ciderBrandyReconciliation.cider.discrepancy)}
                     </td>
                   </tr>
@@ -688,7 +788,7 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
                     <td className={`${cellLeft} font-medium`}>Brandy</td>
                     <td className={cellRight}>{fmtAlways(formData.ciderBrandyReconciliation.brandy.expectedEnding)}</td>
                     <td className={cellRight}>{fmtAlways(formData.ciderBrandyReconciliation.brandy.actualEnding)}</td>
-                    <td className={`${cellRight} ${formData.ciderBrandyReconciliation.brandy.discrepancy !== 0 ? "text-red-600 font-semibold" : "text-green-700"}`}>
+                    <td className={`${cellRight} ${discCellClass(formData.ciderBrandyReconciliation.brandy.discrepancy)}`}>
                       {fmtAlways(formData.ciderBrandyReconciliation.brandy.discrepancy)}
                     </td>
                   </tr>
@@ -696,7 +796,7 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
                     <td className={`${cellLeft} font-bold`}>TOTAL</td>
                     <td className={`${cellRight} font-bold`}>{fmtAlways(formData.ciderBrandyReconciliation.total.expectedEnding)}</td>
                     <td className={`${cellRight} font-bold`}>{fmtAlways(formData.ciderBrandyReconciliation.total.actualEnding)}</td>
-                    <td className={`${cellRight} font-bold ${formData.ciderBrandyReconciliation.total.discrepancy !== 0 ? "text-red-600" : "text-green-700"}`}>
+                    <td className={`${cellRight} font-bold ${discCellClass(formData.ciderBrandyReconciliation.total.discrepancy)}`}>
                       {fmtAlways(formData.ciderBrandyReconciliation.total.discrepancy)}
                     </td>
                   </tr>

--- a/docs/reconciliation-robustness-plan.md
+++ b/docs/reconciliation-robustness-plan.md
@@ -115,6 +115,21 @@ Not a problem (verified correct): juice is excluded until it becomes cider/pomme
 - **This phase unblocks the reverted transfer-delete/correction** — a safe delete/reversal falls out once recompute is authoritative and manual-correction is respected. See `project_transfer_volume_tracking` memory.
 
 ### Phase 3 — Replace TTB plugs with real derivations + a TRUE variance
+> **STATUS: DONE 2026-07-21** (branch `recon/phase3-deplug`, commits C0–C8). Every plug is dead:
+> Line-29 = recorded losses only; Line-9 flips deleted; section-balancing loops deleted (gaps
+> measured, not absorbed); `reconAdj` deleted (waterfall carries honest `unexplainedVariance`);
+> `ttbWaterfallAdjustments` applied server-side (explain variance; Phase 6 writes through this);
+> negative-value clamps removed (signed conversions, per-batch `negativeBatchEnding` components);
+> carbonatedWine/sparklingWine got real bulk columns. The form now reports TRUE variance:
+> 2024 −576.7 gal (non-event-sourced year), 2025 1,136.3 gal (the owner-accepted backlog, named),
+> 2026 347.2 gal (carbonation-reclassification gap, visible in its own column). 3-state UI
+> (green/amber-with-itemization/red) on TTBFormPreview, BatchReconciliation, TTBReconciliationSummary.
+> Filed snapshots persist their varianceAnalysis (migration 0146). Day-boundary fix landed LAST and
+> measured **−4.997 gal** (one real Dec-31 event) vs the ±1,300-gal phantom it produced pre-de-plug —
+> the sequencing thesis verified. Out-of-scope-inflow attribution PROVEN a no-op (same-class boundary
+> transfers cancel in unexplained; emitting components would have rebuilt a plug). Follow-ups: the 2026
+> waterfall −261.5 = packaged/carbonation-reclassification residual (decompose in Phase 4/6);
+> +20.85 carbonated bulk-vs-bottled asymmetry; getPeriodDateRange server-TZ boundary instant.
 - Promote `sbdTotalDriftL` to the headline reconciliation metric; stop reporting the plugged `variance ≈ 0`.
 - Replace the Line 29 loss plug, Line 9 gains flip, and `reconAdj` with itemized derivations. Where a residual genuinely remains, label it "unexplained variance" and alert — never hide it.
 - Apply `ttbWaterfallAdjustments` server-side (§2.13).

--- a/packages/api/scripts/phase0-recon-diagnostic.ts
+++ b/packages/api/scripts/phase0-recon-diagnostic.ts
@@ -183,6 +183,29 @@ for (const year of YEARS) {
     yearOut.formTopLevelKeys = Object.keys(form);
     yearOut.form = form;
     console.log(`generateForm512017 OK — keys: ${Object.keys(form).join(", ")}`);
+
+    // --- Phase 3 C0: plug instrumentation ------------------------------
+    // Quantifies what each plug/flip/clamp currently absorbs so every
+    // de-plug commit can be measured against this baseline.
+    const plug: any = { byClass: {} };
+    const recorded = form.reconciliation?.recordedLosses?.byTaxClass ?? {};
+    for (const [cls, lines] of Object.entries<any>(form.bulkWinesByTaxClass ?? {})) {
+      const line29 = Number(lines.line29_losses ?? 0);
+      const line9 = Number(lines.line9_inventoryGains ?? 0);
+      const rec = Number(recorded[cls] ?? 0);
+      if (Math.abs(line29) > 0.05 || Math.abs(line9) > 0.05 || Math.abs(rec) > 0.05) {
+        plug.byClass[cls] = {
+          line29_plugged: r1(line29),
+          recordedLosses: r1(rec),
+          line29_plugExcess: r1(line29 - rec), // what the plug absorbs beyond real losses
+          line9_gainsFlip: r1(line9),
+        };
+      }
+    }
+    plug.formVariance = form.reconciliation?.variance ?? null;
+    plug.clampedVolume = null; // filled from recon summary below if exposed
+    yearOut.plugInstrumentation = plug;
+    console.log("plug instrumentation:", JSON.stringify(plug, null, 1));
   } catch (e: any) {
     yearOut.formError = e.message;
     console.log(`generateForm512017 FAILED: ${e.message}`);
@@ -207,6 +230,28 @@ for (const year of YEARS) {
     console.log(`getReconciliationSummary OK — keys: ${Object.keys(recon).join(", ")}`);
     console.log("totals:", JSON.stringify(recon.totals, null, 2));
     if (yearOut.parityWarnings) console.log("parityWarnings:", JSON.stringify(yearOut.parityWarnings, null, 2));
+
+    // --- Phase 3 C0: waterfall plug instrumentation --------------------
+    if (yearOut.plugInstrumentation) {
+      const p = yearOut.plugInstrumentation;
+      p.clampedVolume = recon.clampedVolume ?? null;
+      const wf = recon.waterfall?.byTaxClass ?? recon.waterfall ?? null;
+      p.reconAdjByClass = {};
+      if (wf) {
+        for (const [cls, row] of Object.entries<any>(wf)) {
+          const adj = Number(row?.reconAdj ?? 0);
+          if (Math.abs(adj) > 0.05) p.reconAdjByClass[cls] = r1(adj);
+        }
+      }
+      p.waterfallAdjustmentRows = Array.isArray(recon.waterfallAdjustments)
+        ? recon.waterfallAdjustments.length
+        : null;
+      console.log("waterfall plug instrumentation:", JSON.stringify({
+        clampedVolume: p.clampedVolume,
+        reconAdjByClass: p.reconAdjByClass,
+        waterfallAdjustmentRows: p.waterfallAdjustmentRows,
+      }, null, 1));
+    }
   } catch (e: any) {
     yearOut.reconError = e.message;
     console.log(`getReconciliationSummary FAILED: ${e.message}`);

--- a/packages/api/scripts/phase0-recon-diagnostic.ts
+++ b/packages/api/scripts/phase0-recon-diagnostic.ts
@@ -239,7 +239,7 @@ for (const year of YEARS) {
       p.reconAdjByClass = {};
       if (wf) {
         for (const [cls, row] of Object.entries<any>(wf)) {
-          const adj = Number(row?.reconAdj ?? 0);
+          const adj = Number(row?.unexplainedVariance ?? row?.reconAdj ?? 0);
           if (Math.abs(adj) > 0.05) p.reconAdjByClass[cls] = r1(adj);
         }
       }

--- a/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
+++ b/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
@@ -480,6 +480,9 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
         return;
       }
 
+      // Phase 3 C3: honest identity — the formula components sum to calculatedEnding
+      // (no reconAdj plug term). calculatedEnding is the pure formula value, NOT forced
+      // equal to physical; the physical gap is reported as unexplainedVariance.
       // opening + production + transfersIn - transfersOut + positiveAdj
       //   - losses - distillation - sales = calculatedEnding
       const expectedEnding =
@@ -487,8 +490,7 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
         (w.production ?? 0) +
         (w.transfersIn ?? 0) -
         (w.transfersOut ?? 0) +
-        (w.positiveAdj ?? 0) +
-        (w.reconAdj ?? 0) -
+        (w.positiveAdj ?? 0) -
         (w.losses ?? 0) -
         (w.distillation ?? 0) -
         (w.sales ?? 0);
@@ -497,9 +499,10 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
       const diff = Math.abs(expectedEnding - calculatedEnding);
 
       console.log(`[GOLDEN] Waterfall: opening=${w.opening}, production=${w.production}, ` +
-        `transfers=${w.transfersIn}-${w.transfersOut}, adj=${w.positiveAdj}, reconAdj=${w.reconAdj}, ` +
+        `transfers=${w.transfersIn}-${w.transfersOut}, adj=${w.positiveAdj}, ` +
         `losses=${w.losses}, distill=${w.distillation}, sales=${w.sales}, ` +
-        `calcEnding=${calculatedEnding}, derived=${expectedEnding.toFixed(1)}, diff=${diff.toFixed(2)}`);
+        `calcEnding=${calculatedEnding}, derived=${expectedEnding.toFixed(1)}, diff=${diff.toFixed(2)}, ` +
+        `unexplained=${w.unexplainedVariance}`);
 
       expect(diff, `Waterfall identity gap: ${diff.toFixed(2)}`).toBeLessThan(1.0);
     });
@@ -509,13 +512,14 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
       for (const tc of byClass) {
         const tcKey = tc.taxClass ?? tc.key;
         if (!tcKey) continue;
+        // Phase 3 C3: honest identity, no reconAdj term (calculatedEnding is the pure
+        // formula value; the physical gap is reported as tc.unexplainedVariance).
         const expected =
           (tc.opening ?? 0) +
           (tc.production ?? 0) +
           (tc.transfersIn ?? 0) -
           (tc.transfersOut ?? 0) +
-          (tc.positiveAdj ?? 0) +
-          (tc.reconAdj ?? 0) -
+          (tc.positiveAdj ?? 0) -
           (tc.losses ?? 0) -
           (tc.distillation ?? 0) -
           (tc.sales ?? 0);
@@ -545,18 +549,22 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
     });
   });
 
-  describe("Variance", () => {
-    it("should have documented waterfall variance (known SBD drift)", () => {
-      // The reconciliation summary's waterfall uses different aggregate queries than the
-      // TTB form — production, losses, and distributions aren't fully aligned with the
-      // form's corrected queries (juice subtraction, racking derivative filters, etc.).
-      // The ~288 gal variance is a known structural issue from SBD reconstruction drift.
-      // TODO: Align reconciliation summary queries with form queries to reduce variance.
+  describe("Unexplained Variance", () => {
+    it("should have documented waterfall unexplained variance (Phase 3 C3, no plug)", () => {
+      // Phase 3 C3: the reconAdj plug is deleted. unexplainedVariance = physical −
+      // formula ending, reported honestly instead of absorbed. For 2025 it is small
+      // (≈ −2.6 gal total, the C0 plug baseline) because the waterfall uses SBD-derived
+      // physical inventory that nearly matches the per-batch formula ending.
       const w = reconResult.waterfall?.totals;
-      if (w?.variance !== undefined) {
-        console.log(`[GOLDEN] Waterfall variance: ${w.variance}`);
-        expect(Math.abs(w.variance), `Variance = ${w.variance}`).toBeLessThan(300);
-      }
+      expect(w?.unexplainedVariance, "waterfall.totals.unexplainedVariance present").not.toBeUndefined();
+      console.log(`[GOLDEN] Waterfall unexplained variance: ${w.unexplainedVariance} (expected ≈ -2.6)`);
+      expect(Math.abs(w.unexplainedVariance), `Unexplained = ${w.unexplainedVariance}`).toBeLessThan(10);
+      // totals.variance is now the same real quantity (no longer hardcoded 0)
+      expect(reconResult.totals?.totalUnexplained, "totals.totalUnexplained present").not.toBeUndefined();
+      expect(
+        Math.abs((reconResult.totals.totalUnexplained ?? 0) - w.unexplainedVariance),
+        "totals.totalUnexplained matches waterfall totals",
+      ).toBeLessThan(0.5);
     });
   });
 
@@ -825,7 +833,7 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
           `xfOut=${tc.transfersOut?.toFixed(1)}, adj=${tc.positiveAdj?.toFixed(1)}, ` +
           `losses=${tc.losses?.toFixed(1)}, distill=${tc.distillation?.toFixed(1)}, ` +
           `sales=${tc.sales?.toFixed(1)}, calcEnd=${tc.calculatedEnding?.toFixed(1)}, ` +
-          `physical=${tc.physical?.toFixed(1)}, variance=${tc.variance?.toFixed(1)}`);
+          `physical=${tc.physical?.toFixed(1)}, unexplained=${tc.unexplainedVariance?.toFixed(1)}`);
       }
       // This test always passes — it's for audit logging
       expect(byClass.length).toBeGreaterThan(0);

--- a/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
+++ b/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
@@ -417,7 +417,12 @@ describe("TTB Golden 2025 — Form 5120.17", () => {
       // physically still on hand at year-end but not booked until early 2026, so
       // the 2025 period reads as if that volume left unaccounted. Pinned to the
       // measured value — surfaced honestly (balanced=false), never forced green.
-      const KNOWN_2025_UNEXPLAINED = 1154.0; // measured: HC ~1096 + W<16 ~27 + W16-21 ~45 + carbonated ~-14
+      // Phase 3 C6: carbonated/sparkling now carry REAL bulk columns (were empty).
+      // Their line12−line32 gaps (carbonated −27.5, sparkling −5.0) join the form
+      // variance and totalUnexplained like every other class, netted through the
+      // bottled section: 1154.0 − 17.7 = 1136.3. (The move is the full carb/sparkling
+      // column gap, not just their 14.5 recorded losses.)
+      const KNOWN_2025_UNEXPLAINED = 1136.3; // HC ~1096 + W<16 ~27 + W16-21 ~45 + carbonated -27.5 + sparkling -5.0
       const recon = formResult.reconciliation;
       expect(recon).toBeDefined();
       const variance = recon?.variance ?? 0;

--- a/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
+++ b/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
@@ -139,14 +139,21 @@ const PDF = {
 // drifts, the ENGINE changed (investigate) — the data explanation did not.
 const KNOWN_DELTA: Record<string, number> = {
   // Hard Cider — the backlog lands here. Recompute counts fall-2025 volume as
-  // still-on-hand (booked 2026) rather than lost/ended in 2025, inflating Line
-  // 29 losses and deflating Line 31 ending by the same ~1.15k gal.
-  "HC Line 29 Losses": 1111.6, // actual 1349.8 vs filed 238.2
+  // still-on-hand (booked 2026) rather than lost/ended in 2025, deflating Line
+  // 31 ending by ~1.15k gal.
+  // Phase 3 C2 (de-plug): Line 29 is now the REAL recorded operational losses,
+  // no longer the balance-forcing plug. The old +1111.6 delta was the plugged
+  // backlog it absorbed; that discrepancy is now surfaced as the honest
+  // unexplained variance (~1096 gal, see the "gap vs unexplained" balance test),
+  // NOT hidden in losses. Delta is now just the small recorded-loss difference.
+  "HC Line 29 Losses": 15.4, // actual 253.6 (recorded losses) vs filed 238.2
   "HC Line 31 Ending": -1156.1, // actual 2936.2 vs filed 4092.3
   "HC Line 12 Total In": 1.6, // actual 5875.3 vs filed 5873.7 (rounding of backlog inflows)
   // Wine <16% — plum/quince packaging booked 2026, so less packaged/ending in 2025.
   "W<16 Line 13 Packaged": -35.5, // actual 592.7 vs filed 628.2
-  "W<16 Line 29 Losses": 18.0, // actual 64.6 vs filed 46.6
+  // Phase 3 C2 (de-plug): Line 29 = real recorded losses (37.1), not the plug.
+  // The former +18.0 plugged amount is now honest unexplained variance (~27.5).
+  "W<16 Line 29 Losses": -9.5, // actual 37.1 (recorded losses) vs filed 46.6
   "W<16 Line 31 Ending": -5.0, // actual 12.9 vs filed 17.9
   "W<16 Line 12 Total In": -22.4, // actual 675.2 vs filed 697.6
   "W<16-B Line 2 Bottled": -35.5, // actual 592.7 vs filed 628.2 (same event as Line 13)
@@ -217,11 +224,17 @@ describe("TTB Golden 2025 — Form 5120.17", () => {
       expectClose(ending, PDF.sectionA.hardCider.line31_ending, "HC Line 31 Ending");
     });
 
-    it("should balance: Total In = Total Out", () => {
+    it("Line 12 − Line 32 gap equals the honest unexplained variance", () => {
       const hc = formResult.bulkWinesByTaxClass?.hardCider ?? formResult.sectionA?.hardCider;
       const totalIn = hc?.line12_total ?? 0;
       const totalOut = hc?.line32_total ?? 0;
-      expectClose(totalIn, totalOut, "HC Line 12 = Line 32", TIGHT_TOLERANCE);
+      // Phase 3 C2 (de-plug): line 12 no longer force-equals line 32. The gap IS
+      // the class's honest unexplained variance (surfaced in varianceAnalysis,
+      // not plugged into line 9/29). Assert the form gap and the reported
+      // unexplained figure agree.
+      const unexplained = Math.abs(formResult.varianceAnalysis?.byTaxClass?.hardCider?.unexplained ?? 0);
+      const gap = Math.abs(totalIn - totalOut);
+      expect(Math.abs(gap - unexplained), `HC gap=${gap.toFixed(2)} vs |unexplained|=${unexplained.toFixed(2)}`).toBeLessThanOrEqual(TIGHT_TOLERANCE);
       expectClose(totalIn, PDF.sectionA.hardCider.line12_totalIn, "HC Line 12 Total In");
     });
   });
@@ -257,11 +270,14 @@ describe("TTB Golden 2025 — Form 5120.17", () => {
       expectClose(ending, PDF.sectionA.wineUnder16.line31_ending, "W<16 Line 31 Ending");
     });
 
-    it("should balance: Total In = Total Out", () => {
+    it("Line 12 − Line 32 gap equals the honest unexplained variance", () => {
       const w = formResult.bulkWinesByTaxClass?.wineUnder16 ?? formResult.sectionA?.wineUnder16;
       const totalIn = w?.line12_total ?? 0;
       const totalOut = w?.line32_total ?? 0;
-      expectClose(totalIn, totalOut, "W<16 Line 12 = Line 32", TIGHT_TOLERANCE);
+      // Phase 3 C2 (de-plug): the gap IS the class's honest unexplained variance.
+      const unexplained = Math.abs(formResult.varianceAnalysis?.byTaxClass?.wineUnder16?.unexplained ?? 0);
+      const gap = Math.abs(totalIn - totalOut);
+      expect(Math.abs(gap - unexplained), `W<16 gap=${gap.toFixed(2)} vs |unexplained|=${unexplained.toFixed(2)}`).toBeLessThanOrEqual(TIGHT_TOLERANCE);
       expectClose(totalIn, PDF.sectionA.wineUnder16.line12_totalIn, "W<16 Line 12 Total In");
     });
   });
@@ -291,11 +307,14 @@ describe("TTB Golden 2025 — Form 5120.17", () => {
       expectClose(ending, PDF.sectionA.wine16To21.line31_ending, "W16-21 Line 31 Ending");
     });
 
-    it("should balance: Total In = Total Out", () => {
+    it("Line 12 − Line 32 gap equals the honest unexplained variance", () => {
       const p = formResult.bulkWinesByTaxClass?.wine16To21 ?? formResult.sectionA?.wine16To21;
       const totalIn = p?.line12_total ?? 0;
       const totalOut = p?.line32_total ?? 0;
-      expectClose(totalIn, totalOut, "W16-21 Line 12 = Line 32", TIGHT_TOLERANCE);
+      // Phase 3 C2 (de-plug): the gap IS the class's honest unexplained variance.
+      const unexplained = Math.abs(formResult.varianceAnalysis?.byTaxClass?.wine16To21?.unexplained ?? 0);
+      const gap = Math.abs(totalIn - totalOut);
+      expect(Math.abs(gap - unexplained), `W16-21 gap=${gap.toFixed(2)} vs |unexplained|=${unexplained.toFixed(2)}`).toBeLessThanOrEqual(TIGHT_TOLERANCE);
       expectClose(totalIn, PDF.sectionA.wine16To21.line12_totalIn, "W16-21 Line 12 Total In");
     });
   });
@@ -391,29 +410,39 @@ describe("TTB Golden 2025 — Form 5120.17", () => {
   // ============================================
 
   describe("Form Integrity", () => {
-    it("should have overall reconciliation balanced (variance < 2 gal)", () => {
-      // Form-level variance is a cross-column rounding artifact: each per-class column
-      // self-balances (line12=line32), but summing independently-rounded columns across
-      // 3 tax classes × 30+ line items produces a residual. Observed 14.8 gal — larger
-      // than pure rounding because the fall-2025 backlog (booked to 2026) leaves the
-      // 2025 period's independently-computed columns slightly out of cross-column sync.
-      // Threshold set just above the observed value; this is an internal-consistency
-      // signal, NOT forced green with a fake filed delta.
+    it("surfaces the documented 2025 unexplained variance (fall-2025 backlog)", () => {
+      // Phase 3 C2 (de-plug): the form no longer plugs to ~0. reconciliation.variance
+      // is now the REAL available-minus-accounted gap. For 2025 this is the
+      // documented fall-2025 data-entry backlog: ~1.1k gal of hard-cider volume
+      // physically still on hand at year-end but not booked until early 2026, so
+      // the 2025 period reads as if that volume left unaccounted. Pinned to the
+      // measured value — surfaced honestly (balanced=false), never forced green.
+      const KNOWN_2025_UNEXPLAINED = 1154.0; // measured: HC ~1096 + W<16 ~27 + W16-21 ~45 + carbonated ~-14
       const recon = formResult.reconciliation;
-      if (recon) {
-        const variance = Math.abs(recon.variance ?? 0);
-        expect(variance, `Form variance = ${variance}`).toBeLessThan(15.0);
-      }
+      expect(recon).toBeDefined();
+      const variance = recon?.variance ?? 0;
+      expect(
+        Math.abs(variance - KNOWN_2025_UNEXPLAINED),
+        `Form variance = ${variance}, expected ~${KNOWN_2025_UNEXPLAINED}`
+      ).toBeLessThan(2.0);
+      expect(recon?.balanced, "2025 must be flagged unbalanced, not hidden").toBe(false);
     });
 
-    it("should have each bulk tax class line12 = line32", () => {
+    it("each bulk tax class line12 − line32 gap equals its unexplained variance", () => {
+      // Phase 3 C2 (de-plug): columns are no longer force-balanced. Each class's
+      // line12−line32 gap must equal the honest unexplained variance reported for it.
       const classes = formResult.bulkWinesByTaxClass ?? {};
+      const va = formResult.varianceAnalysis?.byTaxClass ?? {};
       for (const [cls, section] of Object.entries(classes) as [string, any][]) {
         const line12 = section.line12_total ?? 0;
         const line32 = section.line32_total ?? 0;
         if (line12 > 0 || line32 > 0) {
           const gap = Math.abs(line12 - line32);
-          expect(gap, `${cls} bulk: line12=${line12.toFixed(1)}, line32=${line32.toFixed(1)}, gap=${gap.toFixed(2)}`).toBeLessThan(TIGHT_TOLERANCE);
+          const unexplained = Math.abs(va[cls]?.unexplained ?? 0);
+          expect(
+            Math.abs(gap - unexplained),
+            `${cls} bulk gap=${gap.toFixed(2)} vs |unexplained|=${unexplained.toFixed(2)}`
+          ).toBeLessThan(TIGHT_TOLERANCE);
         }
       }
     });

--- a/packages/api/src/routers/__tests__/ttb-parity.test.ts
+++ b/packages/api/src/routers/__tests__/ttb-parity.test.ts
@@ -716,28 +716,35 @@ describe("TTB Parity Regression Tests", () => {
   // Fix #2 (P0-3): Waterfall identity check
   // ------------------------------------------
   describe("Fix #2 (P0-3): Waterfall uses raw losses and aggregate inventory", () => {
-    it("waterfall totals should satisfy identity: opening + production + transfersIn - transfersOut + positiveAdj + reconAdj - sales - losses - distillation ≈ calculatedEnding", async () => {
+    it("waterfall totals should satisfy honest identity: opening + production + transfersIn - transfersOut + positiveAdj - sales - losses - distillation ≈ calculatedEnding (no reconAdj plug)", async () => {
       const result = await getReconciliation();
       const t = result.waterfall.totals;
 
+      // Phase 3 C3: the reconAdj plug is deleted. calculatedEnding is the pure formula
+      // value (NOT forced equal to physical); the physical gap is reported separately as
+      // unexplainedVariance, not folded into this identity.
       const expected = t.opening + t.production + (t.transfersIn ?? 0) - t.transfersOut
-        + (t.positiveAdj ?? 0) + ((t as any).reconAdj ?? 0) - t.sales - t.losses - t.distillation;
+        + (t.positiveAdj ?? 0) - t.sales - t.losses - t.distillation;
 
       const gap = Math.abs(expected - t.calculatedEnding);
       // Allow tolerance for floating-point arithmetic
       expect(gap).toBeLessThan(0.5);
+      // The honest discrepancy is reported, never zero-by-construction.
+      expect((t as any).unexplainedVariance).not.toBeUndefined();
     }, 30000);
 
-    it("per-tax-class waterfall entries should each satisfy identity", async () => {
+    it("per-tax-class waterfall entries should each satisfy honest identity (no reconAdj plug)", async () => {
       const result = await getReconciliation();
 
       for (const entry of result.waterfall.byTaxClass) {
         const expected = entry.opening + entry.production + (entry.transfersIn ?? 0)
-          - entry.transfersOut + (entry.positiveAdj ?? 0) + ((entry as any).reconAdj ?? 0)
+          - entry.transfersOut + (entry.positiveAdj ?? 0)
           - entry.sales - entry.losses - entry.distillation;
         const gap = Math.abs(expected - entry.calculatedEnding);
 
         expect(gap).toBeLessThan(0.05);
+        // unexplainedVariance is the reported physical gap for the class.
+        expect((entry as any).unexplainedVariance).not.toBeUndefined();
       }
     }, 30000);
 

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -1683,6 +1683,11 @@ export const ttbRouter = router({
         let beginningInventorySource: "snapshot" | "ttb_opening_balance" | "calculated" = "calculated";
         let beginningPommeauBulkGallons = 0;
         let beginningWineUnder16BulkGallons = 0;
+        // Phase 3 C6: carbonated/sparkling beginning bulk, extracted so their bulk
+        // columns balance and so hardCider's beginning (derived by subtraction from
+        // the bulk total) no longer silently absorbs them.
+        let beginningCarbonatedBulkGallons = 0;
+        let beginningSparklingBulkGallons = 0;
         let brandyOpening = 0; // Spirits opening balance (excluded from wine beginningInventory)
         const beginningBottledByClass: Record<string, number> = {};
 
@@ -1707,6 +1712,8 @@ export const ttbRouter = router({
         let beginningPommeauBulkLiters = 0;
         let beginningWineUnder16BulkLiters = 0;
         let beginningBrandyBulkLiters = 0;
+        let beginningCarbonatedBulkLiters = 0;
+        let beginningSparklingBulkLiters = 0;
 
         if (previousSnapshot) {
           // Use previous snapshot's ending inventory (sum of all tax class columns)
@@ -1737,6 +1744,12 @@ export const ttbRouter = router({
           );
           beginningWineUnder16BulkGallons = roundGallons(
             parseFloat(previousSnapshot.bulkWineUnder16 || "0")
+          );
+          beginningCarbonatedBulkGallons = roundGallons(
+            parseFloat(previousSnapshot.bulkCarbonatedWine || "0")
+          );
+          beginningSparklingBulkGallons = roundGallons(
+            parseFloat(previousSnapshot.bulkSparklingWine || "0")
           );
           // Extract spirits opening from snapshot
           brandyOpening = parseFloat(previousSnapshot.spiritsAppleBrandy || "0");
@@ -1801,6 +1814,12 @@ export const ttbRouter = router({
             beginningWineUnder16BulkGallons = roundGallons(
               Number(balances.bulk?.wineUnder16 || 0)
             );
+            beginningCarbonatedBulkGallons = roundGallons(
+              Number(balances.bulk?.carbonatedWine || 0)
+            );
+            beginningSparklingBulkGallons = roundGallons(
+              Number(balances.bulk?.sparklingWine || 0)
+            );
             // Extract spirits opening (not included in wine bulk/bottled totals)
             brandyOpening = Number(balances.spirits?.appleBrandy || 0);
             // Extract per-class beginning bottled inventory
@@ -1850,6 +1869,8 @@ export const ttbRouter = router({
               beginningPommeauBulkLiters = begByClass["wine16To21"] || 0;
               beginningWineUnder16BulkLiters = begByClass["wineUnder16"] || 0;
               beginningBrandyBulkLiters = begByClass["appleBrandy"] || 0;
+              beginningCarbonatedBulkLiters = begByClass["carbonatedWine"] || 0;
+              beginningSparklingBulkLiters = begByClass["sparklingWine"] || 0;
             }
 
             beginningPommeauBulkGallons = roundGallons(
@@ -1857,6 +1878,12 @@ export const ttbRouter = router({
             );
             beginningWineUnder16BulkGallons = roundGallons(
               litersToWineGallons(beginningWineUnder16BulkLiters)
+            );
+            beginningCarbonatedBulkGallons = roundGallons(
+              litersToWineGallons(beginningCarbonatedBulkLiters)
+            );
+            beginningSparklingBulkGallons = roundGallons(
+              litersToWineGallons(beginningSparklingBulkLiters)
             );
 
             // Bottled inventory as of dayBeforeStart (batched)
@@ -2573,6 +2600,10 @@ export const ttbRouter = router({
         let endingPommeauBulkLiters = 0;
         let endingWineUnder16BulkLiters = 0;
         let endingBrandyBulkLiters = 0;
+        // Phase 3 C6: carbonated/sparkling bulk endings — small (these classes are
+        // mostly packaged), but extracted so their bulk columns can balance.
+        let endingCarbonatedBulkLiters = 0;
+        let endingSparklingBulkLiters = 0;
 
         // SBD is used for past-year ending inventory and to surface any batch that
         // reconstructs to a negative period-end volume (a data-quality signal now
@@ -2589,6 +2620,8 @@ export const ttbRouter = router({
             endingPommeauBulkLiters = endByClass["wine16To21"] || 0;
             endingWineUnder16BulkLiters = endByClass["wineUnder16"] || 0;
             endingBrandyBulkLiters = endByClass["appleBrandy"] || 0;
+            endingCarbonatedBulkLiters = endByClass["carbonatedWine"] || 0;
+            endingSparklingBulkLiters = endByClass["sparklingWine"] || 0;
           } else {
             // Current year: use live currentVolumeLiters (reflects physical inventory now)
             const endingLiveByClass: Record<string, number> = {};
@@ -2603,6 +2636,8 @@ export const ttbRouter = router({
             endingPommeauBulkLiters = endingLiveByClass["wine16To21"] || 0;
             endingWineUnder16BulkLiters = endingLiveByClass["wineUnder16"] || 0;
             endingBrandyBulkLiters = endingLiveByClass["appleBrandy"] || 0;
+            endingCarbonatedBulkLiters = endingLiveByClass["carbonatedWine"] || 0;
+            endingSparklingBulkLiters = endingLiveByClass["sparklingWine"] || 0;
           }
           // Per-batch negative period-end reconstructions, grouped by tax class.
           // These are itemized (not absorbed) as negativeBatchEnding variance
@@ -2751,6 +2786,8 @@ export const ttbRouter = router({
         const endingPommeauBulkGallons = roundGallons(litersToWineGallons(endingPommeauBulkLiters));
         const endingWineUnder16BulkGallons = roundGallons(litersToWineGallons(endingWineUnder16BulkLiters));
         const endingCiderBulkGallons = roundGallons(litersToWineGallons(endingBulkLiters));
+        const endingCarbonatedBulkGallons = roundGallons(litersToWineGallons(endingCarbonatedBulkLiters));
+        const endingSparklingBulkGallons = roundGallons(litersToWineGallons(endingSparklingBulkLiters));
         const endingBottledGallons = roundGallons(
           mlToWineGallons(endingBottledML) + litersToWineGallons(kegsInStockLiters + orphanBottleLiters)
         );
@@ -3452,7 +3489,13 @@ export const ttbRouter = router({
 
         // Build per-tax-class bulk wines columns
         // Hard cider column: excludes pommeau, wineUnder16, and brandy volumes
-        const ciderBeginning = roundGallons(beginningInventory.bulk - beginningPommeauBulkGallons - beginningWineUnder16BulkGallons);
+        // hardCider beginning = total bulk minus every other class's beginning bulk.
+        // Phase 3 C6: subtract carbonated/sparkling too (were 0 for 2024/2025, so no
+        // golden shift; matters once those classes carry a bulk opening).
+        const ciderBeginning = roundGallons(
+          beginningInventory.bulk - beginningPommeauBulkGallons - beginningWineUnder16BulkGallons
+          - beginningCarbonatedBulkGallons - beginningSparklingBulkGallons
+        );
         const ciderGains = roundGallons(gainsByTaxClass["hardCider"] || 0);
         const ciderBottled = roundGallons(bottledByTaxClass["hardCider"] || 0);
         const ciderKegFilled = roundGallons(kegFilledByTaxClass["hardCider"] || 0);
@@ -3630,13 +3673,59 @@ export const ttbRouter = router({
           line32_total: 0,
         };
 
+        // Carbonated / Sparkling bulk columns (Phase 3 C6). These classes are mostly
+        // PACKAGED (their volume lives in Part I Section B); their bulk column is small
+        // but real. Built from the same per-tax-class aggregates the other classes use
+        // (all dynamically keyed, so carbonatedWine/sparklingWine entries already exist):
+        // gains, bottled/keg/bottlingLoss, distillation, change-of-class, recorded losses.
+        // No direct bulk production path for these classes -> line2/line4 = 0 (their
+        // volume arrives via change-of-class in from cider / carbonation).
+        function buildEffervescentBulkColumn(
+          cls: "carbonatedWine" | "sparklingWine",
+          beginning: number,
+          ending: number,
+        ): { section: BulkWinesSection; lossesRaw: number; recorded: number } {
+          const changeIn = roundGallons(changeOfClassIn[cls] || 0);
+          const changeOut = roundGallons(changeOfClassOut[cls] || 0);
+          const gains = roundGallons(gainsByTaxClass[cls] || 0);
+          const bottled = roundGallons(bottledByTaxClass[cls] || 0);
+          const kegFilled = roundGallons(kegFilledByTaxClass[cls] || 0);
+          const bottlingLoss = roundGallons(bottlingLossByTaxClass[cls] || 0);
+          const packed = roundGallons(bottled + kegFilled - bottlingLoss);
+          const distillation = roundGallons(distillationByTaxClass[cls] || 0);
+          const recorded = roundGallons(lossesByTaxClass[cls] || 0);
+          const line12 = roundGallons(beginning + changeIn + gains);
+          const lossesRaw = roundGallons(line12 - packed - distillation - changeOut - ending);
+          const line32 = roundGallons(packed + distillation + changeOut + recorded + ending);
+          const section: BulkWinesSection = {
+            ...emptyBulkWines,
+            line1_onHandBeginning: beginning,
+            line9_inventoryGains: gains,
+            line10_writeIn: changeIn,
+            line10_writeInDesc: changeIn > 0 ? "CHANGE OF CLASS IN" : undefined,
+            line12_total: line12,
+            line13_bottled: packed,
+            line16_distillingMaterial: distillation,
+            line24_writeIn1: changeOut,
+            line24_writeIn1Desc: changeOut > 0 ? "CHANGE OF CLASS OUT" : undefined,
+            line29_losses: recorded,
+            line31_onHandEnd: ending,
+            line32_total: line32,
+          };
+          return { section, lossesRaw, recorded };
+        }
+        const carbonatedCol = buildEffervescentBulkColumn(
+          "carbonatedWine", beginningCarbonatedBulkGallons, endingCarbonatedBulkGallons);
+        const sparklingCol = buildEffervescentBulkColumn(
+          "sparklingWine", beginningSparklingBulkGallons, endingSparklingBulkGallons);
+
         const bulkWinesByTaxClass: Record<string, BulkWinesSection> = {
           hardCider: ciderBulkWines,
           wineUnder16: wineUnder16BulkWines,
           wine16To21: pommeauBulkWines,
           wine21To24: { ...emptyBulkWines },
-          carbonatedWine: { ...emptyBulkWines },
-          sparklingWine: { ...emptyBulkWines },
+          carbonatedWine: carbonatedCol.section,
+          sparklingWine: sparklingCol.section,
         };
 
         // ============================================
@@ -3739,6 +3828,11 @@ export const ttbRouter = router({
           ["hardCider", ciderLossesRaw, ciderRecordedLosses],
           ["wineUnder16", wineUnder16LossesRaw, wineUnder16RecordedLosses],
           ["wine16To21", pommeauLossesRaw, pommeauRecordedLosses],
+          // Phase 3 C6: carbonated/sparkling now carry real bulk columns, so their
+          // unexplained (line12-line32 beyond recorded losses) joins totalUnexplained
+          // exactly like every other class instead of hiding in an empty column.
+          ["carbonatedWine", carbonatedCol.lossesRaw, carbonatedCol.recorded],
+          ["sparklingWine", sparklingCol.lossesRaw, sparklingCol.recorded],
         ];
         for (const [cls, lossesRaw, recorded] of classRawInputs) {
           // unexplained = what Line 29 would absorb beyond real losses

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -7035,7 +7035,37 @@ export const ttbRouter = router({
       // Signed sum of per-class (physical − formula ending). This is the honest,
       // REPORTED discrepancy that the deleted reconAdj plug used to absorb.
       // ============================================
-      const totalUnexplained = waterfallData.reduce((s, w) => s + w.unexplainedVariance, 0);
+      // Query waterfall adjustments for the period year
+      const periodYear = reconciliationDateObj.getFullYear();
+      const waterfallAdjs = await db
+        .select({
+          id: ttbWaterfallAdjustments.id,
+          waterfallLine: ttbWaterfallAdjustments.waterfallLine,
+          amountGallons: ttbWaterfallAdjustments.amountGallons,
+          reason: ttbWaterfallAdjustments.reason,
+          notes: ttbWaterfallAdjustments.notes,
+          adjustedAt: ttbWaterfallAdjustments.adjustedAt,
+        })
+        .from(ttbWaterfallAdjustments)
+        .where(
+          and(
+            eq(ttbWaterfallAdjustments.periodYear, periodYear),
+            isNull(ttbWaterfallAdjustments.deletedAt),
+          ),
+        )
+        .orderBy(asc(ttbWaterfallAdjustments.adjustedAt));
+
+      // Phase 3 C4: apply manual adjustments SERVER-SIDE. Each row adjusts a
+      // waterfall line; its effect on the calculated ending is +amount for
+      // opening/production/other and -amount for losses/distillation. Applied
+      // adjustments EXPLAIN variance: unexplained = physical - (formula + effect).
+      const manualAdjustmentsGal = waterfallAdjs.reduce((s, a) => {
+        const amt = parseFloat(a.amountGallons || "0") || 0;
+        return a.waterfallLine === "losses" || a.waterfallLine === "distillation" ? s - amt : s + amt;
+      }, 0);
+
+      const totalUnexplainedRaw = waterfallData.reduce((s, w) => s + w.unexplainedVariance, 0);
+      const totalUnexplained = totalUnexplainedRaw - manualAdjustmentsGal;
       if (Math.abs(totalUnexplained) > 1.0) {
         const perClassDetail: Record<string, number> = {};
         for (const w of waterfallData) {
@@ -7346,25 +7376,8 @@ export const ttbRouter = router({
         ? new Date(finalizedPeriods[finalizedPeriods.length - 1].periodEnd).toISOString().split("T")[0]
         : null;
 
-      // Query waterfall adjustments for the period year
-      const periodYear = reconciliationDateObj.getFullYear();
-      const waterfallAdjs = await db
-        .select({
-          id: ttbWaterfallAdjustments.id,
-          waterfallLine: ttbWaterfallAdjustments.waterfallLine,
-          amountGallons: ttbWaterfallAdjustments.amountGallons,
-          reason: ttbWaterfallAdjustments.reason,
-          notes: ttbWaterfallAdjustments.notes,
-          adjustedAt: ttbWaterfallAdjustments.adjustedAt,
-        })
-        .from(ttbWaterfallAdjustments)
-        .where(
-          and(
-            eq(ttbWaterfallAdjustments.periodYear, periodYear),
-            isNull(ttbWaterfallAdjustments.deletedAt),
-          ),
-        )
-        .orderBy(asc(ttbWaterfallAdjustments.adjustedAt));
+      // (waterfall adjustments are queried earlier — Phase 3 C4 applies them
+      // server-side before the unexplained-variance computation)
 
       // ============================================
       // TOP-LEVEL IDENTITY ASSERTION
@@ -7470,6 +7483,8 @@ export const ttbRouter = router({
           // Honest unexplained variance (physical − per-batch formula ending) and the
           // SBD per-batch reconstruction drift — both surfaced for the reconciliation UI.
           totalUnexplained: parseFloat(totalUnexplained.toFixed(2)),
+          totalUnexplainedRaw: parseFloat(totalUnexplainedRaw.toFixed(2)),
+          manualAdjustmentsGal: parseFloat(manualAdjustmentsGal.toFixed(2)),
           sbdDriftGal: parseFloat(sbdTotalDriftGal.toFixed(2)),
           // Legacy fields for backwards compatibility
           ttbBalance: parseFloat(totalTtb.toFixed(1)),

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -268,6 +268,11 @@ const saveReportSnapshotInput = z.object({
     smallProducerCreditAmount: z.number().optional(),
     taxOwed: z.number().optional(),
   }),
+  // Phase 3 C7: persist the variance itemization with the snapshot
+  varianceAnalysis: z
+    .object({ byTaxClass: z.record(z.string(), z.any()), totalUnexplained: z.number() })
+    .passthrough()
+    .optional(),
   notes: z.string().optional(),
 });
 
@@ -4166,6 +4171,7 @@ export const ttbRouter = router({
             smallProducerCreditAmount:
               input.data.smallProducerCreditAmount?.toString(),
             taxOwed: input.data.taxOwed?.toString(),
+            varianceAnalysis: input.varianceAnalysis ?? null,
             notes: input.notes,
             generatedBy: ctx.user.id,
             status: "draft",

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -76,6 +76,8 @@ import {
   WINE_GALLONS_PER_LITER,
   LITERS_PER_WINE_GALLON,
   type TTBForm512017Data,
+  type TTBVarianceClassAnalysis,
+  type TTBVarianceComponent,
   type InventoryBreakdown,
   type TaxPaidRemovals,
   type OtherRemovals,
@@ -3476,6 +3478,10 @@ export const ttbRouter = router({
         const ciderLine12 = roundGallons(
           ciderBeginning + ciderProducedGallons + ciderChangeIn + ciderGains
         );
+        // Real recorded HC losses (same derivation the other classes already had)
+        const ciderRecordedLosses = roundGallons(
+          (lossesByTaxClass["hardCider"] || 0) - (clampedByTaxClass["hardCider"] || 0)
+        );
         // Losses (line 29) = available - documented outflows - ending.
         // Per TTB instructions: if negative (more accounted for than available),
         // put the abs value on line 9 (Inventory Gains) and set losses to 0.
@@ -3752,6 +3758,40 @@ export const ttbRouter = router({
         };
 
         // ============================================
+        // Phase 3 C1: variance itemization — quantify, under honest names,
+        // every gallon the balancing mechanisms below absorb. The plugs are
+        // still ACTIVE in this commit; this layer measures them so the
+        // de-plug commits (C2+) are verifiable against it.
+        // ============================================
+        const varianceByClass: Record<string, TTBVarianceClassAnalysis> = {};
+        const classRawInputs: Array<[string, number, number]> = [
+          // [class, lossesRaw (signed plug/flip input), recordedLosses]
+          ["hardCider", ciderLossesRaw, ciderRecordedLosses],
+          ["wineUnder16", wineUnder16LossesRaw, wineUnder16RecordedLosses],
+          ["wine16To21", pommeauLossesRaw, pommeauRecordedLosses],
+        ];
+        for (const [cls, lossesRaw, recorded] of classRawInputs) {
+          // unexplained = what Line 29 would absorb beyond real losses
+          // (positive), or what the Line 9 flip would fabricate as gains
+          // (negative). recorded losses themselves are NOT variance.
+          const unexplained = roundGallons(lossesRaw - recorded);
+          varianceByClass[cls] = {
+            unexplained,
+            recordedLosses: recorded,
+            manualAdjustments: 0, // applied server-side in C4
+            components: [],
+          };
+          const clamped = roundGallons(clampedByTaxClass[cls] || 0);
+          if (Math.abs(clamped) >= 0.1) {
+            varianceByClass[cls].components.push({
+              kind: "negativeBatchEnding",
+              amount: clamped,
+              note: "Negative reconstructed batch endings clamped inside SBD (removed in C5)",
+            });
+          }
+        }
+
+        // ============================================
         // Section Balancing — TTB requires line 12 = line 32 and line 7 = line 21
         // Any unexplained discrepancy goes into inventory gains/losses
         // (standard accounting treatment for TTB Form 5120.17)
@@ -3761,6 +3801,9 @@ export const ttbRouter = router({
         for (const [taxClass, section] of Object.entries(bottledWinesByTaxClass)) {
           const gap = roundGallons(section.line7_total - section.line21_total);
           if (Math.abs(gap) >= 0.1) {
+            // C1 instrumentation: record what this balancing write-in absorbs
+            (varianceByClass[taxClass] ??= { unexplained: 0, recordedLosses: 0, manualAdjustments: 0, components: [] })
+              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bottled section line7-line21 gap force-balanced (${gap > 0 ? "shortage" : "write-in"})` } satisfies TTBVarianceComponent);
             if (gap < 0) {
               section.line5_writeIn = roundGallons(section.line5_writeIn + Math.abs(gap));
               section.line5_writeInDesc = "INVENTORY ADJUSTMENTS";
@@ -3785,6 +3828,9 @@ export const ttbRouter = router({
         for (const [taxClass, section] of Object.entries(bulkWinesByTaxClass)) {
           const gap = roundGallons(section.line12_total - section.line32_total);
           if (Math.abs(gap) >= 0.1) {
+            // C1 instrumentation: record what this balancing write absorbs
+            (varianceByClass[taxClass] ??= { unexplained: 0, recordedLosses: 0, manualAdjustments: 0, components: [] })
+              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bulk section line12-line32 gap force-balanced (${gap > 0 ? "into line 29" : "into line 9"})` } satisfies TTBVarianceComponent);
             if (gap < 0) {
               section.line9_inventoryGains = roundGallons(section.line9_inventoryGains + Math.abs(gap));
               section.line12_total = roundGallons(section.line12_total + Math.abs(gap));
@@ -3855,6 +3901,15 @@ export const ttbRouter = router({
               Object.entries(lossesByTaxClass).map(([k, v]) => [k, roundGallons(v - (clampedByTaxClass[k] || 0))])
             ),
           },
+        };
+
+        // Phase 3 C1: finalize the variance itemization (plugs still active —
+        // this REPORTS what they absorb; C2+ makes it THE variance).
+        const varianceAnalysis = {
+          byTaxClass: varianceByClass,
+          totalUnexplained: roundGallons(
+            Object.values(varianceByClass).reduce((s, c) => s + c.unexplained, 0)
+          ),
         };
 
         // ============================================
@@ -3972,6 +4027,7 @@ export const ttbRouter = router({
           bottledWines,
           materials,
           fermenters,
+          varianceAnalysis,
           beginningInventory,
           wineProduced: {
             total: wineProducedGallons, // Press runs + juice purchases (pommeau juice already included)

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -5005,7 +5005,7 @@ export const ttbRouter = router({
               sales: 0,
               calculatedEnding: 0,
               physical: 0,
-              variance: 0,
+              unexplainedVariance: 0,
             },
           },
           batchReconciliation: {
@@ -6830,14 +6830,13 @@ export const ttbRouter = router({
         transfersIn: number;
         transfersOut: number;
         positiveAdj: number;
-        reconAdj: number;
         packaging: number;
         losses: number;
         distillation: number;
         sales: number;
         calculatedEnding: number;
         physical: number;
-        variance: number;
+        unexplainedVariance: number;
         bulk: number;
         packaged: number;
         bulkEnding: number;
@@ -6904,14 +6903,14 @@ export const ttbRouter = router({
       }
 
       // Use Phase 1 byTaxClass aggregation from computeReconciliationFromBatches
-      // for consistent physical inventory (eliminates reconAdj gap between SBD impls)
+      // for consistent physical inventory (keeps unexplained variance small between SBD impls)
       const batchReconByTaxClass = batchRecon.byTaxClass;
 
       for (const key of waterfallTaxClasses) {
         const sbdTc = sbdWaterfallByTaxClass[key];
         const reconTc = batchReconByTaxClass[key];
         // ALL waterfall values are SBD-derived from per-batch reconstruction.
-        // Physical inventory also uses SBD ending + packaged, ensuring reconAdj ≈ 0.
+        // Physical inventory also uses SBD ending + packaged, keeping unexplained variance small.
         const opening = sbdTc?.opening || 0;
         const production = sbdTc?.production || 0;
         // Transfers + merges: when summed by tax class, same-class flows cancel
@@ -6940,17 +6939,17 @@ export const ttbRouter = router({
         const endPkg = packagedByTaxClass[key] || 0;
         const physical = sbdBulkEnding + Math.max(0, endPkg);
 
-        // Formula: opening(total) + inflows - outflows = ending(total)
-        // reconAdj absorbs any residual from rounding, cross-period packaging flows, etc.
-        const formulaWithoutAdj = openingTotal + production + transfersIn - transfersOut
+        // Formula: opening(total) + inflows - outflows = ending(total).
+        // Phase 3 C3: no reconAdj plug. calculatedEnding is the PURE formula value
+        // and is NO LONGER forced equal to physical inventory.
+        const calculatedEnding = openingTotal + production + transfersIn - transfersOut
           + positiveAdj - losses - distillation - actualSales;
-        const reconAdj = physical - formulaWithoutAdj;
 
-        // TTB Calculated Ending: universal identity that accounts for all volume flows
-        const calculatedEnding = formulaWithoutAdj + reconAdj; // = physical by construction
-
-        // Variance = 0 by construction (reconAdj absorbs any orphan residual)
-        const variance = calculatedEnding - physical;
+        // Unexplained variance = physical inventory − formula ending, reported under
+        // its honest name (never absorbed). Non-zero means the per-batch reconstruction
+        // doesn't fully account for physical on-hand volume (positive = unexplained
+        // inflow / inventory gain; negative = unexplained shortage).
+        const unexplainedVariance = physical - calculatedEnding;
 
         // Include tax classes with any activity (including negative ending from losses/sales)
         const hasActivity = openingTotal !== 0 || production > 0 || transfersIn > 0 || physical > 0 ||
@@ -6973,14 +6972,13 @@ export const ttbRouter = router({
             transfersIn: parseFloat(transfersIn.toFixed(2)),
             transfersOut: parseFloat(transfersOut.toFixed(2)),
             positiveAdj: parseFloat(positiveAdj.toFixed(2)),
-            reconAdj: parseFloat(reconAdj.toFixed(2)),
             packaging: parseFloat(pkg.toFixed(2)),
             losses: parseFloat(losses.toFixed(2)),
             distillation: parseFloat(distillation.toFixed(2)),
             sales: parseFloat(actualSales.toFixed(2)),
             calculatedEnding: parseFloat(calculatedEnding.toFixed(2)),
             physical: parseFloat(physical.toFixed(2)),
-            variance: parseFloat(variance.toFixed(2)),
+            unexplainedVariance: parseFloat(unexplainedVariance.toFixed(2)),
             bulk: parseFloat((bulkByTaxClass[key] || 0).toFixed(2)),
             packaged: parseFloat((packagedByTaxClass[key] || 0).toFixed(2)),
             bulkEnding: parseFloat(bulkEnding.toFixed(2)),
@@ -7002,8 +7000,11 @@ export const ttbRouter = router({
       }> = [];
 
       for (const entry of waterfallData) {
+        // Honest identity: the formula components must sum to calculatedEnding
+        // (a self-consistency / rounding check). unexplainedVariance is a REPORTED
+        // quantity below, not a balancing term here.
         const expectedEnding = entry.opening + entry.production + entry.transfersIn
-          - entry.transfersOut + entry.positiveAdj + entry.reconAdj - entry.losses - entry.distillation - entry.sales;
+          - entry.transfersOut + entry.positiveAdj - entry.losses - entry.distillation - entry.sales;
         const identityGap = Math.abs(expectedEnding - entry.calculatedEnding);
         if (identityGap > 0.05) {
           const msg = `Waterfall identity violation for ${entry.label}: gap ${identityGap.toFixed(2)} gal`;
@@ -7027,6 +7028,32 @@ export const ttbRouter = router({
             },
           });
         }
+      }
+
+      // ============================================
+      // UNEXPLAINED VARIANCE (Phase 3 C3)
+      // Signed sum of per-class (physical − formula ending). This is the honest,
+      // REPORTED discrepancy that the deleted reconAdj plug used to absorb.
+      // ============================================
+      const totalUnexplained = waterfallData.reduce((s, w) => s + w.unexplainedVariance, 0);
+      if (Math.abs(totalUnexplained) > 1.0) {
+        const perClassDetail: Record<string, number> = {};
+        for (const w of waterfallData) {
+          if (Math.abs(w.unexplainedVariance) > 0.05) {
+            perClassDetail[w.taxClass] = parseFloat(w.unexplainedVariance.toFixed(2));
+          }
+        }
+        const msg = `Unexplained variance ${totalUnexplained.toFixed(1)} gal: physical inventory differs from the per-batch formula ending across ${Object.keys(perClassDetail).length} tax class(es)`;
+        console.warn(`[TTB Parity] ${msg}`);
+        parityWarnings.push({
+          level: "warning",
+          category: "unexplainedVariance",
+          message: msg,
+          detail: {
+            ...perClassDetail,
+            total: parseFloat(totalUnexplained.toFixed(2)),
+          },
+        });
       }
 
       // 5. Build reconciliation by tax class
@@ -7352,13 +7379,12 @@ export const ttbRouter = router({
       const wfTotalTransfersIn = waterfallData.reduce((s, w) => s + w.transfersIn, 0);
       const wfTotalTransfersOut = waterfallData.reduce((s, w) => s + w.transfersOut, 0);
       const wfTotalPositiveAdj = waterfallData.reduce((s, w) => s + w.positiveAdj, 0);
-      const wfTotalReconAdj = waterfallData.reduce((s, w: any) => s + (w.reconAdj || 0), 0);
       const wfTotalSales = waterfallData.reduce((s, w) => s + w.sales, 0);
       const wfTotalLosses = waterfallData.reduce((s, w) => s + w.losses, 0);
       const wfTotalDistillation = waterfallData.reduce((s, w) => s + w.distillation, 0);
       const wfTotalCalcEnding = waterfallData.reduce((s, w) => s + w.calculatedEnding, 0);
       const topExpectedEnding = wfTotalOpening + wfTotalProduction + wfTotalTransfersIn - wfTotalTransfersOut
-        + wfTotalPositiveAdj + wfTotalReconAdj - wfTotalLosses - wfTotalDistillation - wfTotalSales;
+        + wfTotalPositiveAdj - wfTotalLosses - wfTotalDistillation - wfTotalSales;
       const topIdentityGap = Math.abs(topExpectedEnding - wfTotalCalcEnding);
       if (topIdentityGap > 0.5) {
         const msg = `Top-level identity failure: expected ending ${topExpectedEnding.toFixed(1)} vs calculated ${wfTotalCalcEnding.toFixed(1)} (gap ${topIdentityGap.toFixed(2)} gal)`;
@@ -7438,9 +7464,13 @@ export const ttbRouter = router({
           systemCalculatedOnHand: parseFloat(systemCalculatedOnHand.toFixed(1)),
           // Batch reconstruction (for data quality review)
           systemReconstructedOnHand: parseFloat(systemReconstructedOnHand.toFixed(1)),
-          // Variance: aggregate calculated ending vs physical inventory
-          // Non-zero means the waterfall identity doesn't match what's physically in tanks.
-          variance: 0, // Computed per-tax-class in waterfall; total shown here for legacy compat
+          // Variance: signed sum of per-class unexplained variance (physical − formula
+          // ending). Phase 3 C3: this is the REAL discrepancy, no longer hardcoded 0.
+          variance: parseFloat(totalUnexplained.toFixed(1)),
+          // Honest unexplained variance (physical − per-batch formula ending) and the
+          // SBD per-batch reconstruction drift — both surfaced for the reconciliation UI.
+          totalUnexplained: parseFloat(totalUnexplained.toFixed(2)),
+          sbdDriftGal: parseFloat(sbdTotalDriftGal.toFixed(2)),
           // Legacy fields for backwards compatibility
           ttbBalance: parseFloat(totalTtb.toFixed(1)),
           currentInventory: parseFloat(totalInventoryByTaxClass.toFixed(1)),
@@ -7562,14 +7592,13 @@ export const ttbRouter = router({
             transfersIn: parseFloat(waterfallData.reduce((sum, w) => sum + w.transfersIn, 0).toFixed(2)),
             transfersOut: parseFloat(waterfallData.reduce((sum, w) => sum + w.transfersOut, 0).toFixed(2)),
             positiveAdj: parseFloat(waterfallData.reduce((sum, w) => sum + w.positiveAdj, 0).toFixed(2)),
-            reconAdj: parseFloat(waterfallData.reduce((sum, w: any) => sum + (w.reconAdj || 0), 0).toFixed(2)),
             packaging: parseFloat(waterfallData.reduce((sum, w) => sum + w.packaging, 0).toFixed(2)),
             losses: parseFloat(waterfallData.reduce((sum, w) => sum + w.losses, 0).toFixed(2)),
             distillation: parseFloat(waterfallData.reduce((sum, w) => sum + w.distillation, 0).toFixed(2)),
             sales: parseFloat(waterfallData.reduce((sum, w) => sum + w.sales, 0).toFixed(2)),
             calculatedEnding: parseFloat(waterfallData.reduce((sum, w) => sum + w.calculatedEnding, 0).toFixed(2)),
             physical: parseFloat(waterfallData.reduce((sum, w) => sum + w.physical, 0).toFixed(2)),
-            variance: parseFloat(waterfallData.reduce((sum, w) => sum + w.variance, 0).toFixed(2)),
+            unexplainedVariance: parseFloat(waterfallData.reduce((sum, w) => sum + w.unexplainedVariance, 0).toFixed(2)),
           },
         },
         // DEBUG: Trace variance source

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -3422,14 +3422,16 @@ export const ttbRouter = router({
         );
         // Recorded losses from operational data (racking, filtering, bottling, etc.)
         const recordedLosses = otherRemovals.processLosses;
-        // Line 29 = balancing figure: Total In - all other removals - ending
-        // This absorbs all unrecorded losses (lees, evaporation, sampling, etc.)
-        // Standard TTB practice: Line 29 is the "plug" that makes the form balance.
-        const bulkLosses = roundGallons(
-          bulkLine12 - totalPackedGallons - ciderSentToDspGallons -
-          totalChangeOfClassOut - totalBottlingLoss - endingInventory.bulk
+        // Phase 3 C2: Line 29 = the REAL recorded operational losses, no longer a
+        // balance-forcing plug. Line 32 is the true arithmetic sum of the outflow
+        // lines + ending; it is now ALLOWED to differ from Line 12. Any gap is the
+        // honest unexplained variance and is reported (varianceAnalysis /
+        // reconciliation), never absorbed here.
+        const bulkLosses = recordedLosses;
+        const bulkLine32 = roundGallons(
+          totalPackedGallons + ciderSentToDspGallons +
+          totalChangeOfClassOut + totalBottlingLoss + bulkLosses + endingInventory.bulk
         );
-        const bulkLine32 = bulkLine12; // Form must balance
 
         const bulkWines: BulkWinesSection = {
           line1_onHandBeginning: beginningInventory.bulk,
@@ -3482,23 +3484,17 @@ export const ttbRouter = router({
         const ciderRecordedLosses = roundGallons(
           (lossesByTaxClass["hardCider"] || 0) - (clampedByTaxClass["hardCider"] || 0)
         );
-        // Losses (line 29) = available - documented outflows - ending.
-        // Per TTB instructions: if negative (more accounted for than available),
-        // put the abs value on line 9 (Inventory Gains) and set losses to 0.
-        // This happens when volume enters from batches outside the reconciliation scope
-        // via same-class blending operations.
+        // Phase 3 C2: no plug/flip. Line 29 = the class's real recorded losses,
+        // Line 9 = its real positive adjustments, Line 12 stays un-inflated, and
+        // Line 32 is the true arithmetic sum of outflow lines + ending (allowed to
+        // differ from Line 12). ciderLossesRaw is retained only to derive the
+        // reported unexplained variance (varianceAnalysis).
         const ciderLossesRaw = roundGallons(
           ciderLine12 - ciderPacked - ciderDistillation - ciderChangeOut - endingCiderBulkGallons
         );
-        const ciderLosses = Math.max(0, ciderLossesRaw);
-        const ciderInventoryGains = ciderLossesRaw < 0
-          ? roundGallons(ciderGains + Math.abs(ciderLossesRaw))
-          : ciderGains;
-        // If gains absorbed negative losses, line 12 increases to maintain balance
-        const ciderLine12Final = ciderLossesRaw < 0
-          ? roundGallons(ciderLine12 + Math.abs(ciderLossesRaw))
-          : ciderLine12;
-        const ciderLine32 = ciderLine12Final;
+        const ciderLine32 = roundGallons(
+          ciderPacked + ciderDistillation + ciderChangeOut + ciderRecordedLosses + endingCiderBulkGallons
+        );
         const ciderBulkWines: BulkWinesSection = {
           line1_onHandBeginning: ciderBeginning,
           line2_produced: ciderProducedGallons,
@@ -3508,10 +3504,10 @@ export const ttbRouter = router({
           line6_amelioration: 0,
           line7_receivedInBond: 0,
           line8_dumpedToBulk: 0,
-          line9_inventoryGains: ciderInventoryGains,
+          line9_inventoryGains: ciderGains,
           line10_writeIn: ciderChangeIn,
           line10_writeInDesc: ciderChangeIn > 0 ? "CHANGE OF CLASS IN" : undefined,
-          line12_total: ciderLine12Final,
+          line12_total: ciderLine12,
           line13_bottled: ciderPacked,
           line14_removedTaxpaid: 0,
           line15_transfersInBond: 0,
@@ -3526,7 +3522,7 @@ export const ttbRouter = router({
           line24_writeIn1: ciderChangeOut,
           line24_writeIn1Desc: ciderChangeOut > 0 ? "CHANGE OF CLASS OUT" : undefined,
           line25_writeIn2: 0,
-          line29_losses: ciderLosses,
+          line29_losses: ciderRecordedLosses,
           line30_inventoryLosses: 0,
           line31_onHandEnd: endingCiderBulkGallons,
           line32_total: ciderLine32,
@@ -3542,18 +3538,13 @@ export const ttbRouter = router({
         const wineUnder16Packed = roundGallons(wineUnder16Bottled + wineUnder16KegFilled - wineUnder16BottlingLoss);
         const wineUnder16RecordedLosses = roundGallons((lossesByTaxClass["wineUnder16"] || 0) - (clampedByTaxClass["wineUnder16"] || 0));
         const wineUnder16Line12 = roundGallons(beginningWineUnder16BulkGallons + fruitWineProducedGallons + wineUnder16ChangeIn + wineUnder16Gains);
-        // Losses/Gains split — same pattern as HC
+        // Phase 3 C2: no plug/flip — Line 29 = recorded losses, Line 32 = true sum.
         const wineUnder16LossesRaw = roundGallons(
           wineUnder16Line12 - wineUnder16Packed - wineUnder16ChangeOut - endingWineUnder16BulkGallons
         );
-        const wineUnder16Losses = Math.max(0, wineUnder16LossesRaw);
-        const wineUnder16InventoryGains = wineUnder16LossesRaw < 0
-          ? roundGallons(wineUnder16Gains + Math.abs(wineUnder16LossesRaw))
-          : wineUnder16Gains;
-        const wineUnder16Line12Final = wineUnder16LossesRaw < 0
-          ? roundGallons(wineUnder16Line12 + Math.abs(wineUnder16LossesRaw))
-          : wineUnder16Line12;
-        const wineUnder16Line32 = wineUnder16Line12Final;
+        const wineUnder16Line32 = roundGallons(
+          wineUnder16Packed + wineUnder16ChangeOut + wineUnder16RecordedLosses + endingWineUnder16BulkGallons
+        );
         const wineUnder16BulkWines: BulkWinesSection = {
           line1_onHandBeginning: beginningWineUnder16BulkGallons,
           line2_produced: fruitWineProducedGallons,
@@ -3563,10 +3554,10 @@ export const ttbRouter = router({
           line6_amelioration: 0,
           line7_receivedInBond: 0,
           line8_dumpedToBulk: 0,
-          line9_inventoryGains: wineUnder16InventoryGains,
+          line9_inventoryGains: wineUnder16Gains,
           line10_writeIn: wineUnder16ChangeIn,
           line10_writeInDesc: wineUnder16ChangeIn > 0 ? "CHANGE OF CLASS IN" : undefined,
-          line12_total: wineUnder16Line12Final,
+          line12_total: wineUnder16Line12,
           line13_bottled: wineUnder16Packed,
           line14_removedTaxpaid: 0,
           line15_transfersInBond: 0,
@@ -3581,7 +3572,7 @@ export const ttbRouter = router({
           line24_writeIn1: wineUnder16ChangeOut,
           line24_writeIn1Desc: wineUnder16ChangeOut > 0 ? "CHANGE OF CLASS OUT" : undefined,
           line25_writeIn2: 0,
-          line29_losses: wineUnder16Losses,
+          line29_losses: wineUnder16RecordedLosses,
           line30_inventoryLosses: 0,
           line31_onHandEnd: endingWineUnder16BulkGallons,
           line32_total: wineUnder16Line32,
@@ -3601,18 +3592,13 @@ export const ttbRouter = router({
         const pommeauDistillation = roundGallons(distillationByTaxClass["wine16To21"] || 0);
         const pommeauRecordedLosses = roundGallons((lossesByTaxClass["wine16To21"] || 0) - (clampedByTaxClass["wine16To21"] || 0));
         const pommeauLine12 = roundGallons(beginningPommeauBulkGallons + pommeauProducedGallons + pommeauChangeIn + pommeauGains);
-        // Losses/Gains split — same pattern as HC
+        // Phase 3 C2: no plug/flip — Line 29 = recorded losses, Line 32 = true sum.
         const pommeauLossesRaw = roundGallons(
           pommeauLine12 - pommeauPacked - pommeauDistillation - pommeauChangeOut - endingPommeauBulkGallons
         );
-        const pommeauLosses = Math.max(0, pommeauLossesRaw);
-        const pommeauInventoryGains = pommeauLossesRaw < 0
-          ? roundGallons(pommeauGains + Math.abs(pommeauLossesRaw))
-          : pommeauGains;
-        const pommeauLine12Final = pommeauLossesRaw < 0
-          ? roundGallons(pommeauLine12 + Math.abs(pommeauLossesRaw))
-          : pommeauLine12;
-        const pommeauLine32 = pommeauLine12Final;
+        const pommeauLine32 = roundGallons(
+          pommeauPacked + pommeauDistillation + pommeauChangeOut + pommeauRecordedLosses + endingPommeauBulkGallons
+        );
         const pommeauBulkWines: BulkWinesSection = {
           line1_onHandBeginning: beginningPommeauBulkGallons,
           line2_produced: 0,
@@ -3622,10 +3608,10 @@ export const ttbRouter = router({
           line6_amelioration: 0,
           line7_receivedInBond: 0,
           line8_dumpedToBulk: 0,
-          line9_inventoryGains: pommeauInventoryGains,
+          line9_inventoryGains: pommeauGains,
           line10_writeIn: pommeauChangeIn,
           line10_writeInDesc: pommeauChangeIn > 0 ? "CHANGE OF CLASS IN" : undefined,
-          line12_total: pommeauLine12Final,
+          line12_total: pommeauLine12,
           line13_bottled: pommeauPacked,
           line14_removedTaxpaid: 0,
           line15_transfersInBond: 0,
@@ -3640,7 +3626,7 @@ export const ttbRouter = router({
           line24_writeIn1: pommeauChangeOut,
           line24_writeIn1Desc: pommeauChangeOut > 0 ? "CHANGE OF CLASS OUT" : undefined,
           line25_writeIn2: 0,
-          line29_losses: pommeauLosses,
+          line29_losses: pommeauRecordedLosses,
           line30_inventoryLosses: 0,
           line31_onHandEnd: endingPommeauBulkGallons,
           line32_total: pommeauLine32,
@@ -3758,10 +3744,10 @@ export const ttbRouter = router({
         };
 
         // ============================================
-        // Phase 3 C1: variance itemization — quantify, under honest names,
-        // every gallon the balancing mechanisms below absorb. The plugs are
-        // still ACTIVE in this commit; this layer measures them so the
-        // de-plug commits (C2+) are verifiable against it.
+        // Variance itemization — quantify, under honest names, every gallon of
+        // discrepancy per class. Phase 3 C2 removed the plugs, so this is now the
+        // REAL unexplained variance (no longer just a measurement of what plugs
+        // would have absorbed). unexplained = lossesRaw - recordedLosses per class.
         // ============================================
         const varianceByClass: Record<string, TTBVarianceClassAnalysis> = {};
         const classRawInputs: Array<[string, number, number]> = [
@@ -3792,30 +3778,24 @@ export const ttbRouter = router({
         }
 
         // ============================================
-        // Section Balancing — TTB requires line 12 = line 32 and line 7 = line 21
-        // Any unexplained discrepancy goes into inventory gains/losses
-        // (standard accounting treatment for TTB Form 5120.17)
+        // Phase 3 C2: Section gaps are MEASURED, not absorbed. TTB Form 5120.17
+        // ideally has line 12 = line 32 and line 7 = line 21, but forcing that
+        // balance hides the real discrepancy. Each class's gap is recorded as an
+        // honest `sectionBalancing` variance component; the form lines are left
+        // un-mutated (the aggregate total column below is a pure summation of the
+        // per-class columns).
         // ============================================
 
-        // Balance Bottled Section (Part I-B) — each tax class column balanced independently
+        // Measure Bottled Section (Part I-B) line7-line21 gap per tax class
         for (const [taxClass, section] of Object.entries(bottledWinesByTaxClass)) {
           const gap = roundGallons(section.line7_total - section.line21_total);
           if (Math.abs(gap) >= 0.1) {
-            // C1 instrumentation: record what this balancing write-in absorbs
             (varianceByClass[taxClass] ??= { unexplained: 0, recordedLosses: 0, manualAdjustments: 0, components: [] })
-              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bottled section line7-line21 gap force-balanced (${gap > 0 ? "shortage" : "write-in"})` } satisfies TTBVarianceComponent);
-            if (gap < 0) {
-              section.line5_writeIn = roundGallons(section.line5_writeIn + Math.abs(gap));
-              section.line5_writeInDesc = "INVENTORY ADJUSTMENTS";
-              section.line7_total = roundGallons(section.line7_total + Math.abs(gap));
-            } else {
-              section.line19_inventoryShortage = roundGallons(section.line19_inventoryShortage + gap);
-              section.line21_total = roundGallons(section.line21_total + gap);
-            }
+              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bottled section line7-line21 gap (unbalanced, not absorbed)` } satisfies TTBVarianceComponent);
           }
         }
 
-        // Recompute aggregate bottled totals from balanced per-class values
+        // Recompute aggregate bottled totals as a pure sum of the per-class columns
         const balancedBottledCols = Object.values(bottledWinesByTaxClass);
         bottledWines.line5_writeIn = roundGallons(balancedBottledCols.reduce((s, c) => s + c.line5_writeIn, 0));
         bottledWines.line5_writeInDesc = bottledWines.line5_writeIn > 0 ? "INVENTORY ADJUSTMENTS" : undefined;
@@ -3823,25 +3803,18 @@ export const ttbRouter = router({
         bottledWines.line19_inventoryShortage = roundGallons(balancedBottledCols.reduce((s, c) => s + c.line19_inventoryShortage, 0));
         bottledWines.line21_total = roundGallons(balancedBottledCols.reduce((s, c) => s + c.line21_total, 0));
 
-        // Balance Bulk Section (Part I-A) — each tax class column balanced independently
-        // TTB requires line 12 = line 32; any gap goes to inventory gains (line 9) or losses (line 29)
+        // Measure Bulk Section (Part I-A) line12-line32 gap per tax class.
+        // This gap IS the honest unexplained variance for the class; it is recorded,
+        // not force-balanced into line 9 (gains) or line 29 (losses).
         for (const [taxClass, section] of Object.entries(bulkWinesByTaxClass)) {
           const gap = roundGallons(section.line12_total - section.line32_total);
           if (Math.abs(gap) >= 0.1) {
-            // C1 instrumentation: record what this balancing write absorbs
             (varianceByClass[taxClass] ??= { unexplained: 0, recordedLosses: 0, manualAdjustments: 0, components: [] })
-              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bulk section line12-line32 gap force-balanced (${gap > 0 ? "into line 29" : "into line 9"})` } satisfies TTBVarianceComponent);
-            if (gap < 0) {
-              section.line9_inventoryGains = roundGallons(section.line9_inventoryGains + Math.abs(gap));
-              section.line12_total = roundGallons(section.line12_total + Math.abs(gap));
-            } else {
-              section.line29_losses = roundGallons(section.line29_losses + gap);
-              section.line32_total = roundGallons(section.line32_total + gap);
-            }
+              .components.push({ kind: "sectionBalancing", amount: gap, note: `Bulk section line12-line32 gap (unbalanced, not absorbed)` } satisfies TTBVarianceComponent);
           }
         }
 
-        // Recompute ALL total column lines as sums of balanced per-class values.
+        // Recompute ALL total column lines as sums of the per-class values.
         // This ensures Total column = sum of per-class columns for every line,
         // so Line 12 = sum of Lines 1-11 on the Total column.
         const allBulkCols = Object.values(bulkWinesByTaxClass);
@@ -3857,8 +3830,9 @@ export const ttbRouter = router({
         bulkWines.line10_writeInDesc = bulkWines.line10_writeIn > 0 ? "CHANGE OF CLASS IN" : undefined;
         bulkWines.line24_writeIn1Desc = bulkWines.line24_writeIn1 > 0 ? "CHANGE OF CLASS OUT" : undefined;
 
-        // Derive reconciliation FROM the balanced form sections
-        // This ensures the reconciliation always matches what's shown on the form
+        // Derive reconciliation FROM the (un-plugged) form sections.
+        // Phase 3 C2: line 29 = recorded losses and line 32 = a true sum, so this
+        // variance is the REAL available-minus-accounted gap, not a plugged ~0.
         const formTotalAvailable = roundGallons(
           // Bulk inputs (lines 1-11, all wine entering system)
           bulkWines.line1_onHandBeginning + bulkWines.line2_produced +
@@ -3893,7 +3867,7 @@ export const ttbRouter = router({
           totalAvailable: formTotalAvailable,
           totalAccountedFor: formTotalAccountedFor,
           variance: roundGallons(formTotalAvailable - formTotalAccountedFor),
-          balanced: Math.abs(roundGallons(formTotalAvailable - formTotalAccountedFor)) < 0.1,
+          balanced: Math.abs(roundGallons(formTotalAvailable - formTotalAccountedFor)) < 1.0,
           // Recorded operational losses vs balancing figure for diagnostic comparison
           recordedLosses: {
             total: recordedLosses,
@@ -3903,8 +3877,8 @@ export const ttbRouter = router({
           },
         };
 
-        // Phase 3 C1: finalize the variance itemization (plugs still active —
-        // this REPORTS what they absorb; C2+ makes it THE variance).
+        // Phase 3 C2: finalize the variance itemization — this IS the form's real
+        // unexplained variance now that the plugs are gone.
         const varianceAnalysis = {
           byTaxClass: varianceByClass,
           totalUnexplained: roundGallons(

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -1672,6 +1672,15 @@ export const ttbRouter = router({
           periodNumber
         );
 
+        // Phase 3 C8: getPeriodDateRange returns endDate = 00:00 of the period's
+        // last day, so a `lte(timestampCol, endDate)` (or raw `<= endDate`) silently
+        // drops every event on that final calendar day. endExclusive = the next
+        // day's midnight; use `lt(col, endExclusive)` / `>= endExclusive` on
+        // TIMESTAMP columns only. (::date casts and date-string comparisons are
+        // already day-granular and must NOT use this.)
+        const endExclusive = new Date(endDate);
+        endExclusive.setDate(endExclusive.getDate() + 1);
+
         // Calculate day before start date for beginning inventory
         const dayBeforeStart = new Date(startDate);
         dayBeforeStart.setDate(dayBeforeStart.getDate() - 1);
@@ -2036,7 +2045,7 @@ export const ttbRouter = router({
               sql`COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded')`,
               eq(batches.productType, "juice"),
               gte(batches.startDate, startDate),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
         const juiceOnlyLiters = Number(juiceOnlyData[0]?.totalLiters || 0);
@@ -2053,7 +2062,7 @@ export const ttbRouter = router({
               isNull(batchTransfers.deletedAt),
               eq(batches.productType, "juice"),
               gte(batchTransfers.transferredAt, startDate),
-              lte(batchTransfers.transferredAt, endDate)
+              lt(batchTransfers.transferredAt, endExclusive)
             )
           );
         const xferIntoJuiceLiters = Number(xferIntoJuiceData[0]?.totalLiters || 0);
@@ -2077,7 +2086,7 @@ export const ttbRouter = router({
               eq(batches.productType, "pommeau"),
               sql`CAST(${batches.initialVolumeLiters} AS DECIMAL) > 0`,
               gte(batches.startDate, startDate),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
         let juiceToPommeauLiters = 0;
@@ -2117,11 +2126,11 @@ export const ttbRouter = router({
               sql`dest_batch.deleted_at IS NULL`,
               // Only new pommeau batches created in the period
               sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) >= ${startDate}`,
-              sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) <= ${endDate}`,
+              sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) < ${endExclusive}`,
               // Exclude brandy and pommeau-to-pommeau transfers (racking between pommeau vessels)
               sql`source_batch.product_type NOT IN ('brandy', 'pommeau')`,
               gte(batchTransfers.transferredAt, startDate),
-              lte(batchTransfers.transferredAt, endDate)
+              lt(batchTransfers.transferredAt, endExclusive)
             )
           );
         juiceToPommeauLiters += Number(nonBrandyToPommeauData[0]?.totalLiters || 0);
@@ -2151,7 +2160,7 @@ export const ttbRouter = router({
               ),
               sql`CAST(${batches.initialVolumeLiters} AS DECIMAL) > 0`,
               gte(batches.startDate, startDate),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
         // Pommeau batches built via transfers (initial = 0): sum incoming transfers as production
@@ -2178,10 +2187,10 @@ export const ttbRouter = router({
               sql`CAST(dest_batch.initial_volume_liters AS DECIMAL) = 0`,
               // Only count transfers to pommeau batches created in this period
               sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) >= ${startDate}`,
-              sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) <= ${endDate}`,
+              sql`(CASE WHEN dest_batch.ttb_origin_year >= 2025 AND dest_batch.ttb_origin_year < EXTRACT(YEAR FROM dest_batch.start_date) THEN make_date(dest_batch.ttb_origin_year, 12, 31)::timestamp ELSE dest_batch.start_date END) < ${endExclusive}`,
               sql`source_batch.product_type != 'pommeau'`,
               gte(batchTransfers.transferredAt, startDate),
-              lte(batchTransfers.transferredAt, endDate)
+              lt(batchTransfers.transferredAt, endExclusive)
             )
           );
         const pommeauProducedLiters = Number(pommeauWithInitialSum[0]?.totalLiters || 0) +
@@ -2209,7 +2218,7 @@ export const ttbRouter = router({
               // the system via the source batch's press run, not as separate production.
               isNull(batches.parentBatchId),
               gte(batches.startDate, startDate),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
         const fruitWineProducedLiters = Number(fruitWineProductionData[0]?.totalLiters || 0);
@@ -2248,7 +2257,7 @@ export const ttbRouter = router({
               isNull(batches.deletedAt),
               sql`${bottleRuns.status} IN ('distributed', 'completed')`,
               gte(bottleRuns.distributedAt, startDate),
-              lte(bottleRuns.distributedAt, endDate)
+              lt(bottleRuns.distributedAt, endExclusive)
             )
           )
           .groupBy(salesChannels.code);
@@ -2277,7 +2286,7 @@ export const ttbRouter = router({
               isNull(kegFills.deletedAt),
               isNull(batches.deletedAt),
               gte(kegFills.distributedAt, startDate),
-              lte(kegFills.distributedAt, endDate)
+              lt(kegFills.distributedAt, endExclusive)
             )
           )
           .groupBy(salesChannels.code);
@@ -2360,7 +2369,7 @@ export const ttbRouter = router({
               isNull(batches.deletedAt),
               sql`COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded')`,
               gte(inventoryAdjustments.adjustedAt, startDate),
-              lte(inventoryAdjustments.adjustedAt, endDate),
+              lt(inventoryAdjustments.adjustedAt, endExclusive),
               sql`${inventoryAdjustments.quantityChange} < 0` // Only removals
             )
           )
@@ -2406,7 +2415,7 @@ export const ttbRouter = router({
               isNull(batchFilterOperations.deletedAt),
               isNull(batches.deletedAt),
               gte(batchFilterOperations.filteredAt, startDate),
-              lte(batchFilterOperations.filteredAt, endDate)
+              lt(batchFilterOperations.filteredAt, endExclusive)
             )
           )
           .groupBy(batchFilterOperations.batchId);
@@ -2423,7 +2432,7 @@ export const ttbRouter = router({
               isNull(batchRackingOperations.deletedAt),
               isNull(batches.deletedAt),
               gte(batchRackingOperations.rackedAt, startDate),
-              lte(batchRackingOperations.rackedAt, endDate),
+              lt(batchRackingOperations.rackedAt, endExclusive),
               sql`${batchRackingOperations.isHistoricalRecord} = false`
             )
           )
@@ -2441,7 +2450,7 @@ export const ttbRouter = router({
               isNull(bottleRuns.voidedAt),
               isNull(batches.deletedAt),
               gte(bottleRuns.packagedAt, startDate),
-              lte(bottleRuns.packagedAt, endDate)
+              lt(bottleRuns.packagedAt, endExclusive)
             )
           )
           .groupBy(bottleRuns.batchId);
@@ -2459,7 +2468,7 @@ export const ttbRouter = router({
               isNull(batchTransfers.deletedAt),
               isNull(batches.deletedAt),
               gte(batchTransfers.transferredAt, startDate),
-              lte(batchTransfers.transferredAt, endDate)
+              lt(batchTransfers.transferredAt, endExclusive)
             )
           )
           .groupBy(batchTransfers.sourceBatchId);
@@ -2477,7 +2486,7 @@ export const ttbRouter = router({
               isNull(batches.deletedAt),
               sql`CAST(${batchVolumeAdjustments.adjustmentAmount} AS DECIMAL) < 0`,
               gte(batchVolumeAdjustments.adjustmentDate, startDate),
-              lte(batchVolumeAdjustments.adjustmentDate, endDate)
+              lt(batchVolumeAdjustments.adjustmentDate, endExclusive)
             )
           )
           .groupBy(batchVolumeAdjustments.batchId);
@@ -2495,7 +2504,7 @@ export const ttbRouter = router({
               isNull(kegFills.deletedAt),
               isNull(batches.deletedAt),
               gte(kegFills.filledAt, startDate),
-              lte(kegFills.filledAt, endDate)
+              lt(kegFills.filledAt, endExclusive)
             )
           )
           .groupBy(kegFills.batchId);
@@ -2516,7 +2525,7 @@ export const ttbRouter = router({
               isNotNull(batches.transferLossL),
               sql`CAST(${batches.transferLossL} AS DECIMAL) > 0`,
               gte(batches.startDate, startDate),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
 
@@ -2579,12 +2588,12 @@ export const ttbRouter = router({
               sql`COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded')`,
               // Exclude juice batches — they are not taxable inventory
               sql`COALESCE(${batches.productType}, 'cider') != 'juice'`,
-              sql`${ttbMembershipTs} <= ${endDate}`,
+              sql`${ttbMembershipTs} < ${endExclusive}`,
               // Exclude batches that ended before the period end
               or(isNull(batches.endDate), gte(batches.endDate, endDate)),
               // Exclude discarded/completed batches that were finished before endDate
               // (they would have 0 volume at endDate)
-              sql`NOT (${batches.status} = 'discarded' AND ${batches.updatedAt} <= ${endDate})`
+              sql`NOT (${batches.status} = 'discarded' AND ${batches.updatedAt} < ${endExclusive})`
             )
           );
 
@@ -2670,7 +2679,7 @@ export const ttbRouter = router({
           .from(inventoryItems)
           .where(
             and(
-              lte(inventoryItems.createdAt, endDate),
+              lt(inventoryItems.createdAt, endExclusive),
               isNull(inventoryItems.deletedAt)
             )
           );
@@ -2685,10 +2694,10 @@ export const ttbRouter = router({
           const [distsAfterEnd, adjsAfterEnd] = await Promise.all([
             db.execute(sql`SELECT inventory_item_id as item_id, COALESCE(SUM(quantity_distributed), 0) as total
               FROM inventory_distributions WHERE inventory_item_id IN (${itemIdList})
-              AND distribution_date > ${endDate} GROUP BY inventory_item_id`),
+              AND distribution_date >= ${endExclusive} GROUP BY inventory_item_id`),
             db.execute(sql`SELECT inventory_item_id as item_id, COALESCE(SUM(quantity_change), 0) as total
               FROM inventory_adjustments WHERE inventory_item_id IN (${itemIdList})
-              AND adjusted_at > ${endDate} GROUP BY inventory_item_id`),
+              AND adjusted_at >= ${endExclusive} GROUP BY inventory_item_id`),
           ]);
 
           const makeItemMap = (rows: Record<string, unknown>[]) => {
@@ -2728,10 +2737,10 @@ export const ttbRouter = router({
               isNull(batches.deletedAt),
               // Do NOT filter by reconciliationStatus — kegs from duplicate/excluded batches
               // still physically exist in inventory and must be counted
-              lte(kegFills.filledAt, endDate),
+              lt(kegFills.filledAt, endExclusive),
               or(
                 isNull(kegFills.distributedAt),
-                sql`${kegFills.distributedAt} > ${endDate}`
+                sql`${kegFills.distributedAt} >= ${endExclusive}`
               )
             )
           )
@@ -2763,10 +2772,10 @@ export const ttbRouter = router({
             and(
               isNull(bottleRuns.voidedAt),
               isNull(batches.deletedAt),
-              lte(bottleRuns.packagedAt, endDate),
+              lt(bottleRuns.packagedAt, endExclusive),
               or(
                 isNull(bottleRuns.distributedAt),
-                sql`${bottleRuns.distributedAt} > ${endDate}`
+                sql`${bottleRuns.distributedAt} >= ${endExclusive}`
               ),
               sql`NOT EXISTS (
                 SELECT 1 FROM inventory_items ii
@@ -2841,7 +2850,7 @@ export const ttbRouter = router({
             and(
               isNull(distillationRecords.deletedAt),
               gte(distillationRecords.sentAt, startDate),
-              lte(distillationRecords.sentAt, endDate)
+              lt(distillationRecords.sentAt, endExclusive)
             )
           )
           .groupBy(distillationRecords.sourceBatchId);
@@ -2880,7 +2889,7 @@ export const ttbRouter = router({
               // not physical wine gains, and should not appear on TTB Line 9.
               sql`COALESCE(${batchVolumeAdjustments.reason}, '') NOT ILIKE '%reconciliation%'`,
               gte(batchVolumeAdjustments.adjustmentDate, startDate),
-              lte(batchVolumeAdjustments.adjustmentDate, endDate)
+              lt(batchVolumeAdjustments.adjustmentDate, endExclusive)
             )
           )
           .groupBy(batchVolumeAdjustments.batchId);
@@ -2905,7 +2914,7 @@ export const ttbRouter = router({
           JOIN inventory_items ii ON ii.id = ia.inventory_item_id
           WHERE ia.quantity_change > 0
             AND ia.adjusted_at >= ${startDate}
-            AND ia.adjusted_at <= ${endDate}
+            AND ia.adjusted_at < ${endExclusive}
         `);
         const positiveBottledAdjGallons = roundGallons(
           mlToWineGallons(Number(positiveBottledAdjustments.rows[0]?.total_ml || 0))
@@ -2921,7 +2930,7 @@ export const ttbRouter = router({
           JOIN inventory_items ii ON ii.id = ia.inventory_item_id
           WHERE ia.quantity_change < 0
             AND ia.adjusted_at >= ${startDate}
-            AND ia.adjusted_at <= ${endDate}
+            AND ia.adjusted_at < ${endExclusive}
         `);
         const negativeBottledAdjGallons = roundGallons(
           mlToWineGallons(Number(negativeBottledAdjustments.rows[0]?.total_ml || 0))
@@ -2941,7 +2950,7 @@ export const ttbRouter = router({
               isNull(distillationRecords.deletedAt),
               isNotNull(distillationRecords.receivedAt),
               gte(distillationRecords.receivedAt, startDate),
-              lte(distillationRecords.receivedAt, endDate)
+              lt(distillationRecords.receivedAt, endExclusive)
             )
           );
 
@@ -2967,7 +2976,7 @@ export const ttbRouter = router({
           WHERE kf.distributed_at IS NOT NULL
             AND kf.voided_at IS NULL AND kf.deleted_at IS NULL
             AND b.deleted_at IS NULL
-            AND kf.distributed_at >= ${startDate} AND kf.distributed_at <= ${endDate}
+            AND kf.distributed_at >= ${startDate} AND kf.distributed_at < ${endExclusive}
           GROUP BY kf.batch_id
         `);
 
@@ -2985,7 +2994,7 @@ export const ttbRouter = router({
           WHERE br.voided_at IS NULL
             AND b.deleted_at IS NULL
             AND br.status IN ('distributed', 'completed')
-            AND br.distributed_at >= ${startDate} AND br.distributed_at <= ${endDate}
+            AND br.distributed_at >= ${startDate} AND br.distributed_at < ${endExclusive}
           GROUP BY br.batch_id
         `);
 
@@ -3099,7 +3108,7 @@ export const ttbRouter = router({
                 sql`src.product_type = 'brandy'`,
                 sql`dest.product_type != 'brandy'`,
                 gte(batchTransfers.transferredAt, startDate),
-                lte(batchTransfers.transferredAt, endDate)
+                lt(batchTransfers.transferredAt, endExclusive)
               )
             );
 
@@ -3171,7 +3180,7 @@ export const ttbRouter = router({
           .where(
             and(
               gte(basefruitPurchases.purchaseDate, startDate),
-              lte(basefruitPurchases.purchaseDate, endDate)
+              lt(basefruitPurchases.purchaseDate, endExclusive)
             )
           )
           .groupBy(baseFruitVarieties.fruitType);
@@ -3230,7 +3239,7 @@ export const ttbRouter = router({
           .where(
             and(
               gte(additivePurchases.purchaseDate, startDate),
-              lte(additivePurchases.purchaseDate, endDate)
+              lt(additivePurchases.purchaseDate, endExclusive)
             )
           )
           .groupBy(additiveVarieties.name, additivePurchaseItems.unit);
@@ -3277,7 +3286,7 @@ export const ttbRouter = router({
               isNull(batches.deletedAt),
               sql`COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded')`,
               eq(batches.status, "fermentation"),
-              sql`${ttbMembershipTs} <= ${endDate}`
+              sql`${ttbMembershipTs} < ${endExclusive}`
             )
           );
 
@@ -3306,7 +3315,7 @@ export const ttbRouter = router({
               isNull(bottleRuns.voidedAt),
               isNull(batches.deletedAt),
               gte(bottleRuns.packagedAt, startDate),
-              lte(bottleRuns.packagedAt, endDate)
+              lt(bottleRuns.packagedAt, endExclusive)
             )
           )
           .groupBy(bottleRuns.batchId);
@@ -3342,7 +3351,7 @@ export const ttbRouter = router({
               isNull(kegFills.deletedAt),
               isNull(batches.deletedAt),
               gte(kegFills.filledAt, startDate),
-              lte(kegFills.filledAt, endDate)
+              lt(kegFills.filledAt, endExclusive)
             )
           )
           .groupBy(kegFills.batchId);
@@ -3381,7 +3390,7 @@ export const ttbRouter = router({
             and(
               isNull(batchTransfers.deletedAt),
               gte(batchTransfers.transferredAt, startDate),
-              lte(batchTransfers.transferredAt, endDate)
+              lt(batchTransfers.transferredAt, endExclusive)
             )
           )
           .groupBy(sql`source_batch.id`, sql`source_batch.product_type`, sql`dest_batch.id`, sql`dest_batch.product_type`);
@@ -5649,7 +5658,7 @@ export const ttbRouter = router({
           and(
             isNull(batches.deletedAt),
             eq(batches.reconciliationStatus, "verified"),
-            sql`${batches.startDate} <= ${reconciliationDate}::date`,
+            sql`${batches.startDate}::date <= ${reconciliationDate}::date`,
             sql`COALESCE(${batches.currentVolumeLiters}, 0) > 0` // Only count batches with remaining volume
           )
         )
@@ -5672,7 +5681,7 @@ export const ttbRouter = router({
           and(
             isNull(inventoryItems.deletedAt),
             sql`${inventoryItems.currentQuantity} > 0`,
-            sql`${batches.startDate} <= ${reconciliationDate}::date`
+            sql`${batches.startDate}::date <= ${reconciliationDate}::date`
           )
         )
         .groupBy(sql`EXTRACT(YEAR FROM ${batches.startDate})`)
@@ -5728,7 +5737,7 @@ export const ttbRouter = router({
           and(
             isNull(batches.deletedAt),
             sql`(COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded') OR ${batches.isRackingDerivative} IS TRUE OR ${batches.parentBatchId} IS NOT NULL)`,
-            sql`${batches.startDate} <= ${reconciliationDate}::date`,
+            sql`${batches.startDate}::date <= ${reconciliationDate}::date`,
           )
         );
       const sbdResult = await computeSystemCalculatedOnHand(
@@ -6354,7 +6363,7 @@ export const ttbRouter = router({
               and(
                 isNull(inventoryItems.deletedAt),
                 sql`${inventoryItems.currentQuantity} > 0`,
-                sql`${batches.startDate} <= ${reconciliationDate}::date`
+                sql`${batches.startDate}::date <= ${reconciliationDate}::date`
               )
             )
             .orderBy(sql`CAST(${inventoryItems.currentQuantity} AS DECIMAL) * CAST(${inventoryItems.packageSizeML} AS DECIMAL) DESC`);

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -302,7 +302,7 @@ interface SystemVolumeBreakdown {
 async function computeSystemCalculatedOnHand(
   verifiedBatchIds: string[],
   asOfDate: string,
-): Promise<{ total: number; breakdown: SystemVolumeBreakdown; perBatch: Map<string, number>; perBatchClampedLoss: Map<string, number> }> {
+): Promise<{ total: number; breakdown: SystemVolumeBreakdown; perBatch: Map<string, number> }> {
   const emptyBreakdown: SystemVolumeBreakdown = {
     totalLiters: 0, initialVolumeLiters: 0, mergesInLiters: 0, mergesOutLiters: 0,
     transfersInLiters: 0, transfersOutLiters: 0, transferLossLiters: 0,
@@ -310,7 +310,7 @@ async function computeSystemCalculatedOnHand(
     distillationLiters: 0, adjustmentsLiters: 0, positiveAdjLiters: 0, negativeAdjLiters: 0,
     rackingLossLiters: 0, filterLossLiters: 0, clampedLossLiters: 0, batchCount: 0,
   };
-  if (verifiedBatchIds.length === 0) return { total: 0, breakdown: emptyBreakdown, perBatch: new Map(), perBatchClampedLoss: new Map() };
+  if (verifiedBatchIds.length === 0) return { total: 0, breakdown: emptyBreakdown, perBatch: new Map() };
 
   // Phase 1: SBD reconstruction = THE shared reducer in as-of-date mode, fed
   // by the same fetcher as per-batch validation (reconciliation plan §3).
@@ -329,7 +329,6 @@ async function computeSystemCalculatedOnHand(
   let totalLiters = 0;
   const bd: SystemVolumeBreakdown = { ...emptyBreakdown, batchCount: verifiedBatchIds.length };
   const perBatch = new Map<string, number>();
-  const perBatchClampedLoss = new Map<string, number>();
 
   for (const batchId of verifiedBatchIds) {
     const inputs = volumeInputs.get(batchId);
@@ -360,15 +359,17 @@ async function computeSystemCalculatedOnHand(
     bd.negativeAdjLiters += Math.abs(breakdown.adjustmentsNegativeL);
     bd.rackingLossLiters += breakdown.rackingLossL;
     bd.filterLossLiters += breakdown.filterLossL;
+    // Diagnostic only: magnitude of batches that reconstruct below zero. The
+    // ending itself flows through unclamped (perBatch, above); this sum feeds the
+    // getReconciliationSummary data-quality readout, it is NOT a form plug.
     if (ending < 0) {
       bd.clampedLossLiters += Math.abs(ending);
-      perBatchClampedLoss.set(batchId, Math.abs(ending));
     }
   }
 
   bd.totalLiters = totalLiters;
 
-  return { total: litersToWineGallons(totalLiters), breakdown: bd, perBatch, perBatchClampedLoss };
+  return { total: litersToWineGallons(totalLiters), breakdown: bd, perBatch };
 }
 
 /**
@@ -1706,8 +1707,6 @@ export const ttbRouter = router({
         let beginningPommeauBulkLiters = 0;
         let beginningWineUnder16BulkLiters = 0;
         let beginningBrandyBulkLiters = 0;
-        let begClampedLossLiters = 0;
-        let begPerBatchClampedLoss = new Map<string, number>();
 
         if (previousSnapshot) {
           // Use previous snapshot's ending inventory (sum of all tax class columns)
@@ -1851,8 +1850,6 @@ export const ttbRouter = router({
               beginningPommeauBulkLiters = begByClass["wine16To21"] || 0;
               beginningWineUnder16BulkLiters = begByClass["wineUnder16"] || 0;
               beginningBrandyBulkLiters = begByClass["appleBrandy"] || 0;
-              begClampedLossLiters = begSbdResult.breakdown.clampedLossLiters;
-              begPerBatchClampedLoss = begSbdResult.perBatchClampedLoss;
             }
 
             beginningPommeauBulkGallons = roundGallons(
@@ -2577,10 +2574,11 @@ export const ttbRouter = router({
         let endingWineUnder16BulkLiters = 0;
         let endingBrandyBulkLiters = 0;
 
-        // SBD is always needed for clamped loss calculation (form balancing)
-        // and for past years it's also used for ending inventory
-        let endClampedLossLiters = 0;
-        const clampedByTaxClass: Record<string, number> = {};
+        // SBD is used for past-year ending inventory and to surface any batch that
+        // reconstructs to a negative period-end volume (a data-quality signal now
+        // itemized as a `negativeBatchEnding` variance component — Phase 3 C5
+        // deleted the clamped-loss plug that used to absorb it into losses).
+        const negativeEndingsByClass: Record<string, Array<{ batchId: string; amount: number }>> = {};
         if (endBatchIds.length > 0) {
           const endSbdResult = await computeSystemCalculatedOnHand(endBatchIds, endDateStr);
 
@@ -2606,31 +2604,17 @@ export const ttbRouter = router({
             endingWineUnder16BulkLiters = endingLiveByClass["wineUnder16"] || 0;
             endingBrandyBulkLiters = endingLiveByClass["appleBrandy"] || 0;
           }
-          endClampedLossLiters = endSbdResult.breakdown.clampedLossLiters;
-
-          // Compute per-tax-class clamped loss for per-column loss allocation
-          for (const [batchId, clampedLiters] of endSbdResult.perBatchClampedLoss) {
-            const taxClass = getTaxClassFromMap(batchTaxClassMap, batchId, null) || "hardCider";
-            clampedByTaxClass[taxClass] = (clampedByTaxClass[taxClass] || 0) + litersToWineGallons(clampedLiters);
+          // Per-batch negative period-end reconstructions, grouped by tax class.
+          // These are itemized (not absorbed) as negativeBatchEnding variance
+          // components below. Threshold -0.5 gal filters rounding noise; the amount
+          // is the signed (negative) ending in gallons.
+          for (const [batchId, endingLiters] of endSbdResult.perBatch) {
+            const endingGallons = roundGallons(litersToWineGallons(endingLiters));
+            if (endingGallons < -0.5) {
+              const taxClass = getTaxClassFromMap(batchTaxClassMap, batchId, null) || "hardCider";
+              (negativeEndingsByClass[taxClass] ??= []).push({ batchId, amount: endingGallons });
+            }
           }
-          for (const [batchId, clampedLiters] of begPerBatchClampedLoss) {
-            const taxClass = getTaxClassFromMap(batchTaxClassMap, batchId, null) || "hardCider";
-            clampedByTaxClass[taxClass] = (clampedByTaxClass[taxClass] || 0) - litersToWineGallons(clampedLiters);
-          }
-          for (const key of Object.keys(clampedByTaxClass)) {
-            clampedByTaxClass[key] = roundGallons(Math.max(0, clampedByTaxClass[key]));
-          }
-        }
-
-        // Period-specific clamped loss: adjust process losses so the form balances
-        // (line 12 = line 32). Clamped loss represents over-recorded losses on batches
-        // that reconstructed to negative volume. SBD clamps these to 0, so we subtract
-        // the excess from aggregate losses to maintain the accounting identity.
-        const periodClampedLossLiters = endClampedLossLiters - begClampedLossLiters;
-        if (periodClampedLossLiters > 0) {
-          const clampedGallons = roundGallons(litersToWineGallons(periodClampedLossLiters));
-          otherRemovals.processLosses = roundGallons(otherRemovals.processLosses - clampedGallons);
-          otherRemovals.total = roundGallons(otherRemovals.total - clampedGallons);
         }
 
         // Bottled inventory AS OF period end date
@@ -3480,10 +3464,10 @@ export const ttbRouter = router({
         const ciderLine12 = roundGallons(
           ciderBeginning + ciderProducedGallons + ciderChangeIn + ciderGains
         );
-        // Real recorded HC losses (same derivation the other classes already had)
-        const ciderRecordedLosses = roundGallons(
-          (lossesByTaxClass["hardCider"] || 0) - (clampedByTaxClass["hardCider"] || 0)
-        );
+        // Real recorded HC losses (same derivation the other classes already had).
+        // Phase 3 C5: no longer net out clamped negative-ending volume — that
+        // amount is itemized as a negativeBatchEnding variance component instead.
+        const ciderRecordedLosses = roundGallons(lossesByTaxClass["hardCider"] || 0);
         // Phase 3 C2: no plug/flip. Line 29 = the class's real recorded losses,
         // Line 9 = its real positive adjustments, Line 12 stays un-inflated, and
         // Line 32 is the true arithmetic sum of outflow lines + ending (allowed to
@@ -3536,7 +3520,7 @@ export const ttbRouter = router({
         const wineUnder16KegFilled = roundGallons(kegFilledByTaxClass["wineUnder16"] || 0);
         const wineUnder16BottlingLoss = roundGallons(bottlingLossByTaxClass["wineUnder16"] || 0);
         const wineUnder16Packed = roundGallons(wineUnder16Bottled + wineUnder16KegFilled - wineUnder16BottlingLoss);
-        const wineUnder16RecordedLosses = roundGallons((lossesByTaxClass["wineUnder16"] || 0) - (clampedByTaxClass["wineUnder16"] || 0));
+        const wineUnder16RecordedLosses = roundGallons(lossesByTaxClass["wineUnder16"] || 0);
         const wineUnder16Line12 = roundGallons(beginningWineUnder16BulkGallons + fruitWineProducedGallons + wineUnder16ChangeIn + wineUnder16Gains);
         // Phase 3 C2: no plug/flip — Line 29 = recorded losses, Line 32 = true sum.
         const wineUnder16LossesRaw = roundGallons(
@@ -3590,7 +3574,7 @@ export const ttbRouter = router({
         const pommeauBottlingLoss = roundGallons(bottlingLossByTaxClass["wine16To21"] || 0);
         const pommeauPacked = roundGallons(pommeauBottled + pommeauKegFilled - pommeauBottlingLoss);
         const pommeauDistillation = roundGallons(distillationByTaxClass["wine16To21"] || 0);
-        const pommeauRecordedLosses = roundGallons((lossesByTaxClass["wine16To21"] || 0) - (clampedByTaxClass["wine16To21"] || 0));
+        const pommeauRecordedLosses = roundGallons(lossesByTaxClass["wine16To21"] || 0);
         const pommeauLine12 = roundGallons(beginningPommeauBulkGallons + pommeauProducedGallons + pommeauChangeIn + pommeauGains);
         // Phase 3 C2: no plug/flip — Line 29 = recorded losses, Line 32 = true sum.
         const pommeauLossesRaw = roundGallons(
@@ -3767,12 +3751,15 @@ export const ttbRouter = router({
             manualAdjustments: 0, // applied server-side in C4
             components: [],
           };
-          const clamped = roundGallons(clampedByTaxClass[cls] || 0);
-          if (Math.abs(clamped) >= 0.1) {
+          // Phase 3 C5: itemize each batch that reconstructs to a negative
+          // period-end volume, sourced directly from the per-batch SBD endings
+          // (the clamped-loss plug is gone). amount is the signed negative ending.
+          for (const neg of negativeEndingsByClass[cls] ?? []) {
             varianceByClass[cls].components.push({
               kind: "negativeBatchEnding",
-              amount: clamped,
-              note: "Negative reconstructed batch endings clamped inside SBD (removed in C5)",
+              amount: neg.amount,
+              batchId: neg.batchId,
+              note: `Batch reconstructs to a negative period-end volume (${neg.amount} gal)`,
             });
           }
         }
@@ -3872,7 +3859,7 @@ export const ttbRouter = router({
           recordedLosses: {
             total: recordedLosses,
             byTaxClass: Object.fromEntries(
-              Object.entries(lossesByTaxClass).map(([k, v]) => [k, roundGallons(v - (clampedByTaxClass[k] || 0))])
+              Object.entries(lossesByTaxClass).map(([k, v]) => [k, roundGallons(v)])
             ),
           },
         };
@@ -5533,7 +5520,10 @@ export const ttbRouter = router({
       // Total inventory = production - removals
       const historicalInventoryGallons = totalProductionGallons - totalRemovalsGallons;
 
-      // Split into bulk and packaged:
+      // Split into bulk and packaged for DISPLAY only. Display-cosmetic clamps kept
+      // (Phase 3 C5): these two feed on-hand breakdown figures, not the variance
+      // identity — `historicalInventoryGallons` above stays signed and carries the
+      // real net signal. A negative displayed inventory split is not meaningful.
       // Packaged = volume packaged - distributions
       const historicalPackagedGallons = Math.max(0, packagedVolumeBeforeGallons - distributionsBeforeGallons);
 
@@ -6937,7 +6927,10 @@ export const ttbRouter = router({
         // Ending includes ALL on-premises inventory: bulk + packaged at period end.
         const sbdBulkEnding = sbdTc?.ending || 0;
         const endPkg = packagedByTaxClass[key] || 0;
-        const physical = sbdBulkEnding + Math.max(0, endPkg);
+        // Phase 3 C5: no clamp — a negative packaged ending (class distributes more
+        // than it packaged, a scope/data mismatch) must flow into unexplainedVariance
+        // below, not be floored to zero and hidden.
+        const physical = sbdBulkEnding + endPkg;
 
         // Formula: opening(total) + inflows - outflows = ending(total).
         // Phase 3 C3: no reconAdj plug. calculatedEnding is the PURE formula value
@@ -6960,7 +6953,10 @@ export const ttbRouter = router({
           // instead of waterfall-aggregated ending, which can diverge for zero-volume
           // intermediate batches that the waterfall computes as negative.
           const bulkEnding = bulkByTaxClass[key] || 0;
-          // Section B ending: all undistributed packaged inventory at period end
+          // Section B ending: all undistributed packaged inventory at period end.
+          // Display-cosmetic clamp kept: a negative packaged inventory count is not
+          // meaningful to show as an on-hand figure; the negative signal is already
+          // surfaced through `physical`/`unexplainedVariance` above (Phase 3 C5).
           const packagedEnding = Math.max(0, endPkg);
           waterfallData.push({
             taxClass: key,
@@ -7323,9 +7319,12 @@ export const ttbRouter = router({
       const packagedOnHandLiters = (sbd.bottlingLiters - sbd.bottlingLossLiters)
         + (sbd.keggingLiters - sbd.keggingLossLiters)
         - batchScopedDistributionsLiters;
-      // Exclude brandy from wine reconciliation total (Part I is wine-only)
+      // Exclude brandy from wine reconciliation total (Part I is wine-only).
+      // Phase 3 C5: no clamp — a negative packaged-on-hand (distributions exceed
+      // reconstructed packaging within batch scope) must reduce the reconstructed
+      // system total so the mismatch surfaces as variance, not be floored to zero.
       const systemTotalOnHand = wineOnlyReconstructedOnHand
-        + litersToWineGallons(Math.max(0, packagedOnHandLiters));
+        + litersToWineGallons(packagedOnHandLiters);
 
       // ============================================
       // AGGREGATE-BASED TTB WATERFALL
@@ -7495,7 +7494,9 @@ export const ttbRouter = router({
         // Additional breakdown for UI display
         breakdown: {
           bulkInventory: parseFloat(actualBulkGallons.toFixed(1)),
-          // SBD-based packaged inventory (date-bounded, batch-scoped) — replaces LIVE query
+          // SBD-based packaged inventory (date-bounded, batch-scoped) — replaces LIVE query.
+          // Display-cosmetic clamp kept (Phase 3 C5): a shown on-hand packaged figure is
+          // not meaningfully negative; the signal lives in systemTotalOnHand/variance.
           packagedInventory: parseFloat(litersToWineGallons(Math.max(0, packagedOnHandLiters)).toFixed(1)),
           // Keep LIVE value for reference/debugging
           livePackagedInventory: parseFloat(actualPackagedGallons.toFixed(1)),
@@ -7543,6 +7544,10 @@ export const ttbRouter = router({
               filter: parseFloat(filterLossesBeforeGallons.toFixed(2)),
               bottling: parseFloat(bottlingLossesBeforeGallons.toFixed(2)),
               transfer: parseFloat(transferLossesBeforeGallons.toFixed(2)),
+              // Signed (negative): source query filters adjustmentAmount < 0, and this
+              // term enters processLossesLiters as a negative, so displaying it signed
+              // makes the breakdown reconcile to `total`. Phase 3 C5 removed the
+              // conversion clamp that used to mask this to 0.00.
               volumeAdjustments: parseFloat(volumeAdjustmentsBeforeGallons.toFixed(2)),
               kegFills: parseFloat(kegFillLossesBeforeGallons.toFixed(2)),
               total: parseFloat(lossesGallons.toFixed(2)),

--- a/packages/db/migrations/0146_snapshot_variance_analysis.sql
+++ b/packages/db/migrations/0146_snapshot_variance_analysis.sql
@@ -1,0 +1,5 @@
+-- Phase 3 C7 (reconciliation-robustness-plan §3): a filed TTB period snapshot
+-- records the varianceAnalysis (per-class unexplained variance + components)
+-- at generation time, so the filing preserves what was unexplained when it
+-- was made (feeds the Phase 4 filed-vs-recompute drift comparison).
+ALTER TABLE ttb_reporting_periods ADD COLUMN variance_analysis jsonb;

--- a/packages/db/src/schema/ttb.ts
+++ b/packages/db/src/schema/ttb.ts
@@ -10,6 +10,7 @@
 
 import { relations } from "drizzle-orm";
 import {
+  jsonb,
   pgTable,
   uuid,
   text,
@@ -200,6 +201,9 @@ export const ttbReportingPeriods = pgTable(
     submittedAt: timestamp("submitted_at"),
     submittedBy: uuid("submitted_by").references(() => users.id),
     notes: text("notes"),
+    // Phase 3 C7: the varianceAnalysis at filing time — a filed period records
+    // what was unexplained when it was generated (feeds Phase 4 drift compare).
+    varianceAnalysis: jsonb("variance_analysis"),
 
     // Audit
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/packages/lib/src/__tests__/calc/ttb.test.ts
+++ b/packages/lib/src/__tests__/calc/ttb.test.ts
@@ -141,10 +141,12 @@ describe("Volume Conversions", () => {
       expect(litersToWineGallons(0)).toBe(0);
     });
 
-    it("should return 0 for negative inputs", () => {
-      expect(litersToWineGallons(-1)).toBe(0);
-      expect(litersToWineGallons(-100)).toBe(0);
-      expect(litersToWineGallons(-0.001)).toBe(0);
+    // Phase 3 C5: conversion is SIGNED — the old clamp-to-0 hid net-negative
+    // reconciliation/variance signal. Negatives now convert straight through.
+    it("should convert negative inputs to negative gallons (signed)", () => {
+      expect(litersToWineGallons(-1)).toBeCloseTo(-0.264172, 5);
+      expect(litersToWineGallons(-100)).toBeCloseTo(-26.4172, 3);
+      expect(litersToWineGallons(-0.001)).toBeCloseTo(-0.000264172, 8);
     });
 
     it("should handle very small volumes", () => {
@@ -174,9 +176,10 @@ describe("Volume Conversions", () => {
       expect(wineGallonsToLiters(0)).toBe(0);
     });
 
-    it("should return 0 for negative inputs", () => {
-      expect(wineGallonsToLiters(-1)).toBe(0);
-      expect(wineGallonsToLiters(-500)).toBe(0);
+    // Phase 3 C5: signed conversion (clamp-to-0 removed).
+    it("should convert negative inputs to negative liters (signed)", () => {
+      expect(wineGallonsToLiters(-1)).toBeCloseTo(-3.78541, 4);
+      expect(wineGallonsToLiters(-500)).toBeCloseTo(-1892.705, 2);
     });
 
     it("should handle 1 gallon", () => {
@@ -217,9 +220,9 @@ describe("Volume Conversions", () => {
       expect(mlToWineGallons(0)).toBe(0);
     });
 
-    it("should handle negative inputs (delegates to litersToWineGallons)", () => {
-      // -500ml => -0.5L => litersToWineGallons(-0.5) => 0
-      expect(mlToWineGallons(-500)).toBe(0);
+    it("should handle negative inputs (delegates to signed litersToWineGallons)", () => {
+      // Phase 3 C5: -500ml => -0.5L => litersToWineGallons(-0.5) => signed negative
+      expect(mlToWineGallons(-500)).toBeCloseTo(-0.132086, 5);
     });
 
     it("should handle a standard case of 473ml (US pint)", () => {

--- a/packages/lib/src/calculations/ttb.ts
+++ b/packages/lib/src/calculations/ttb.ts
@@ -755,6 +755,39 @@ export interface FermentersSection {
 }
 
 /**
+ * Phase 3: per-class variance itemization — every gallon a balancing
+ * mechanism would otherwise silently absorb, under an honest name.
+ * `unexplained` is SIGNED: positive = volume missing (would have been plugged
+ * into Line 29 losses), negative = surplus (would have been flipped into
+ * Line 9 gains).
+ */
+export interface TTBVarianceComponent {
+  kind: "outOfScopeInflow" | "negativeBatchEnding" | "roundingResidual" | "sectionBalancing" | "other";
+  /** Signed gallons. */
+  amount: number;
+  batchId?: string;
+  note: string;
+}
+
+export interface TTBVarianceClassAnalysis {
+  /** Signed unexplained gallons for this class. */
+  unexplained: number;
+  /** Real recorded operational losses (racking/filter/bottling/etc.). */
+  recordedLosses: number;
+  /** Manual ttb_waterfall_adjustments applied for this class (0 until applied server-side). */
+  manualAdjustments: number;
+  components: TTBVarianceComponent[];
+}
+
+export interface TTBVarianceAnalysis {
+  byTaxClass: Record<string, TTBVarianceClassAnalysis>;
+  /** Sum of |per-class unexplained| direction-preserving total (signed sum). */
+  totalUnexplained: number;
+  /** Headline data-quality metric: stored vs reconstructed drift, gallons. */
+  sbdDriftGal?: number;
+}
+
+/**
  * Complete TTB Form 5120.17 data structure
  */
 export interface TTBForm512017Data {
@@ -813,6 +846,14 @@ export interface TTBForm512017Data {
     /** Whether the books balance */
     balanced: boolean;
   };
+
+  /**
+   * Phase 3 variance itemization: what the form's balancing mechanisms
+   * absorb, per tax class, under honest names. While the plugs are still
+   * active (Phase 3 C1) this REPORTS what they absorb; after de-plug it IS
+   * the unexplained variance.
+   */
+  varianceAnalysis?: TTBVarianceAnalysis;
 
   /** Distillery operations (cider sent, brandy received) */
   distilleryOperations?: DistilleryOperations;

--- a/packages/lib/src/calculations/ttb.ts
+++ b/packages/lib/src/calculations/ttb.ts
@@ -302,28 +302,35 @@ export function classifyBatchTaxClass(
 /**
  * Convert liters to wine gallons.
  *
- * @param liters - Volume in liters
- * @returns Volume in wine gallons
+ * Signed: a negative liters value converts to a negative gallons value. Phase 3
+ * (C5) removed the clamp-to-zero that used to hide net-negative flows, so that a
+ * real negative signal (e.g. a reconstructed batch ending below zero) surfaces in
+ * reconciliation/variance instead of being silently absorbed. Display-only sites
+ * that need a floor of zero must apply their own `Math.max(0, ...)`.
+ *
+ * @param liters - Volume in liters (may be negative)
+ * @returns Volume in wine gallons (sign preserved)
  *
  * @example
  * litersToWineGallons(1000) // 264.17 wine gallons
  */
 export function litersToWineGallons(liters: number): number {
-  if (liters < 0) return 0;
   return liters * WINE_GALLONS_PER_LITER;
 }
 
 /**
  * Convert wine gallons to liters.
  *
- * @param gallons - Volume in wine gallons
- * @returns Volume in liters
+ * Signed: see `litersToWineGallons`. A negative gallons value converts to a
+ * negative liters value; the clamp-to-zero was removed in Phase 3 (C5).
+ *
+ * @param gallons - Volume in wine gallons (may be negative)
+ * @returns Volume in liters (sign preserved)
  *
  * @example
  * wineGallonsToLiters(264.17) // ~1000 liters
  */
 export function wineGallonsToLiters(gallons: number): number {
-  if (gallons < 0) return 0;
   return gallons * LITERS_PER_WINE_GALLON;
 }
 


### PR DESCRIPTION
## Summary

Every balancing plug in the TTB reporting engine is dead, replaced by honest derivations and a first-class **unexplained variance** concept — built on the Phase 1/2 unified engine (PR #118), with the itemize-before-remove discipline the reverted April attempt (51adc9b) lacked.

**The plugs, removed (C0–C6):**
- Line-29 loss plug → line 29 = recorded operational losses only; line 32 is the true sum, allowed to differ from line 12
- Per-class Line-9 gains flips → deleted (no more fabricated inventory gains)
- Section-balancing loops → deleted; per-class gaps measured as named variance components
- `reconAdj` (variance-zero-by-construction) → deleted; waterfall rows carry signed `unexplainedVariance`
- `ttbWaterfallAdjustments` → applied server-side (they now EXPLAIN variance; Phase 6's accept-flow writes through this)
- Negative-value clamps → signed conversions with full call-site audit; per-batch `negativeBatchEnding` components
- carbonatedWine/sparklingWine → real bulk columns (their losses were falling off the form)

**What the form honestly says now:** 2024 −576.7 gal · 2025 **1,136.3 gal** (the owner-accepted fall-2025 backlog, named in golden KNOWN_DELTAs) · 2026 **347.2 gal** (carbonation-reclassification gap, now visible). 3-state UI (green / amber with per-class itemization / red) across TTBFormPreview, BatchReconciliation, TTBReconciliationSummary. Filed snapshots persist their varianceAnalysis (migration 0146, applied).

**The sequencing thesis, verified (C8):** the day-boundary fix that produced a ±1,300-gal phantom swing pre-de-plug measures **−4.997 gal** post-de-plug — one real Dec-31 adjustment event, independently verified in the DB. 2025/2026 boundary windows proven empty.

**Refused on principle (C6):** out-of-scope-inflow attribution — investigation proved same-class boundary transfers cancel in the variance; emitting components would have fabricated a decomposition, i.e. rebuilt a plug.

**Gates on every commit:** phase0 diagnostic (per-batch 21/49/57, 0 fails, unchanged throughout), golden 73/73, parity 14/14, lib 769/769, typechecks clean. Migration 0146 applied to dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)