### PR TITLE
Reconciliation Phase 4: filed-drift detection — the filed years are frozen

### DIFF
--- a/apps/web/src/app/reports/ttb/page.tsx
+++ b/apps/web/src/app/reports/ttb/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "lucide-react";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
-import { TTBFormPreview } from "@/components/reports/TTBFormPreview";
+import { TTBFormPreview, FiledComparisonBadge } from "@/components/reports/TTBFormPreview";
 import { TTBPeriodFinalization } from "@/components/reports/TTBPeriodFinalization";
 import { ReportExportDropdown } from "@/components/reports/ReportExportDropdown";
 import { downloadTTBFormPDF, type TTBFormPDFData } from "@/utils/pdf/ttbForm512017";
@@ -335,6 +335,14 @@ export default function TTBReportsPage() {
                 <Save className="w-4 h-4 mr-1" />
                 {saveSnapshotMutation.isPending ? "Saving..." : "Save Snapshot"}
               </Button>
+
+              {/* Compact filed-comparison badge for FILED annual periods
+                  (Phase 4 C6) — reuses the page-level form query, no recompute. */}
+              {formData?.formData?.filedDrift && (
+                <span className="ml-auto">
+                  <FiledComparisonBadge drift={formData.formData.filedDrift} />
+                </span>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/apps/web/src/components/reports/TTBFormPreview.tsx
+++ b/apps/web/src/components/reports/TTBFormPreview.tsx
@@ -144,6 +144,123 @@ function VarianceBreakdown({ analysis }: { analysis: TTBForm512017Data["variance
 }
 
 // ---------------------------------------------------------------------------
+// Filed comparison (Phase 4 C6 — filed years are frozen)
+// ---------------------------------------------------------------------------
+
+// Per-line table behind the amber/red filed-comparison badge: label, filed,
+// recomputed, expected delta, residual, status.
+function FiledDriftTable({
+  lines,
+  tone,
+}: {
+  lines: NonNullable<TTBForm512017Data["filedDrift"]>["lines"];
+  tone: "amber" | "red";
+}) {
+  if (lines.length === 0) return null;
+  const box =
+    tone === "red"
+      ? "border-red-300 bg-red-50 text-red-900"
+      : "border-amber-300 bg-amber-50 text-amber-900";
+  const head = tone === "red" ? "text-red-800" : "text-amber-800";
+  return (
+    <div className={`border ${box} rounded p-2 text-[10px] space-y-1`}>
+      <p className={`font-semibold uppercase ${head}`}>Filed vs recompute (wine gallons)</p>
+      <table className="w-full tabular-nums">
+        <thead>
+          <tr className="text-left">
+            <th className="pr-2 font-semibold">Line</th>
+            <th className="px-1 text-right font-semibold">Filed</th>
+            <th className="px-1 text-right font-semibold">Recomp</th>
+            <th className="px-1 text-right font-semibold">Exp Δ</th>
+            <th className="px-1 text-right font-semibold">Resid</th>
+            <th className="pl-1 font-semibold">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lines.map((l, i) => (
+            <tr key={i}>
+              <td className="pr-2">{l.label}</td>
+              <td className="px-1 text-right">{l.filedGal == null ? "—" : fmtAlways(l.filedGal)}</td>
+              <td className="px-1 text-right">{l.recomputedGal == null ? "—" : fmtAlways(l.recomputedGal)}</td>
+              <td className="px-1 text-right">{fmtAlways(l.expectedDeltaGal)}</td>
+              <td className="px-1 text-right">{l.residualGal == null ? "—" : fmtAlways(l.residualGal)}</td>
+              <td className="pl-1">{l.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Filed-vs-recompute badge (present only for FILED annual periods). Mirrors the
+// variance badge's 3-state + expandable pattern:
+//  clean         → green "Matches filing"
+//  expected_only → amber "Matches filing + documented deltas" (expandable)
+//  new_drift     → red   "Recompute has drifted…" (expandable, drifted lines)
+export function FiledComparisonBadge({ drift }: { drift: TTBForm512017Data["filedDrift"] }) {
+  if (!drift) return null;
+
+  if (drift.status === "clean") {
+    return (
+      <span className="ml-2">
+        <Badge variant="default" className="bg-green-600 text-[10px] py-0">
+          <CheckCircle className="w-3 h-3 mr-1" />Matches filing
+        </Badge>
+      </span>
+    );
+  }
+
+  if (drift.status === "new_drift") {
+    const driftedLines = drift.lines.filter((l) => l.status === "new_drift");
+    return (
+      <details className="ml-2 relative">
+        <summary className="list-none cursor-pointer">
+          <Badge variant="destructive" className="text-[10px] py-0">
+            <AlertTriangle className="w-3 h-3 mr-1" />
+            Recompute has drifted from the filed form — investigate
+          </Badge>
+        </summary>
+        <div className="absolute right-0 top-full z-10 mt-1 w-96">
+          <FiledDriftTable lines={driftedLines} tone="red" />
+        </div>
+      </details>
+    );
+  }
+
+  // expected_only — documented deltas hold; show the compared (non-skipped) lines.
+  const comparedLines = drift.lines.filter((l) => l.status !== "skipped");
+  return (
+    <details className="ml-2 relative">
+      <summary className="list-none cursor-pointer">
+        <Badge variant="outline" className="border-amber-500 bg-amber-50 text-amber-700 text-[10px] py-0">
+          <CheckCircle className="w-3 h-3 mr-1" />
+          Matches filing + documented deltas
+        </Badge>
+      </summary>
+      <div className="absolute right-0 top-full z-10 mt-1 w-96">
+        <FiledDriftTable lines={comparedLines} tone="amber" />
+      </div>
+    </details>
+  );
+}
+
+// Small amber note for opening-chain diagnostics (Phase 4 C5). Warn-only.
+function OpeningWarningsNote({ warnings }: { warnings: TTBForm512017Data["openingWarnings"] }) {
+  if (!warnings || warnings.length === 0) return null;
+  return (
+    <div className="border border-amber-300 bg-amber-50 rounded p-2 text-[10px] text-amber-900 space-y-0.5">
+      {warnings.map((w, i) => (
+        <div key={i} className="flex gap-1">
+          <AlertTriangle className="w-3 h-3 mt-px flex-shrink-0 text-amber-600" />
+          <span>{w.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -350,8 +467,16 @@ export function TTBFormPreview({ formData, periodLabel, orgInfo }: TTBFormPrevie
                 </details>
               );
             })()}
+            {/* Filed comparison — only for FILED annual periods (Phase 4 C6). */}
+            <FiledComparisonBadge drift={formData.filedDrift} />
           </div>
         </div>
+        {/* Opening-chain diagnostics (Phase 4 C5) — warn-only. */}
+        {formData.openingWarnings && formData.openingWarnings.length > 0 && (
+          <div className="mt-2">
+            <OpeningWarningsNote warnings={formData.openingWarnings} />
+          </div>
+        )}
       </div>
 
       {/* ============================================================ */}

--- a/docs/reconciliation-robustness-plan.md
+++ b/docs/reconciliation-robustness-plan.md
@@ -155,6 +155,22 @@ Not a problem (verified correct): juice is excluded until it becomes cider/pomme
 - **Fix the period day-boundary here (bug-hunt finding #1), NOT standalone.** `generateForm512017` compares timestamp columns with `lte(col, endDate)` where `endDate` = 00:00 of the last day, silently dropping the entire last calendar day (understates removals/production/ending). The surgical fix (a next-day-midnight `endExclusive` with `lt`/`>= endExclusive` on ~40 timestamp comparisons) is correct and preserves internal parity — BUT tested in isolation it produced a **+1285/−1319 gal Hard Cider swing that only ~19 gal of real Dec-31 activity explains**, because the form plugs-to-balance (Line 29) and amplifies small boundary changes. So the boundary fix must land *after* the plugs are replaced, when its effect is a real number instead of plug noise. The isolated patch is reproducible: add `const endExclusive = new Date(endDate); endExclusive.setDate(endExclusive.getDate()+1)` after the `getPeriodDateRange` destructure, then `lte(col,endDate)→lt(col,endExclusive)`, `<= ${endDate}→< ${endExclusive}`, `> ${endDate}→>= ${endExclusive}` on timestamp columns only (leave `endDate.toISOString()` date-strings, `batches.endDate` column checks, and the display field). Golden tests will need re-derivation once it lands.
 
 ### Phase 4 — Snapshot-vs-recompute drift detection
+> **STATUS: DONE 2026-07-24** (branch `recon/phase4-filed-drift`, commits C1–C8). The filed 2024/2025
+> numbers + their documented expected deltas live in ONE canonical source
+> (`packages/lib/src/calculations/ttb-filed.ts`) materialized onto the two finalized snapshots
+> (migration 0148: is_filed/filed_at/filed_form/expected_drift), with a golden describe block that
+> fails CI if DB and constants diverge. `computeFiledDrift` runs on every form generation for a filed
+> year: 2024 verifies "clean" (flow lines skipped per the freeze), 2025 "expected_only" (max residual
+> 0.05 gal); any NEW drift is a red alarm in CI and in the UI (3-state Filed-comparison badge on
+> TTBFormPreview + reports/ttb page). Opening-source resolution is shared and adjacency-checked with
+> warn-only openingGap/openingReconstructed warnings (2025/2026 open from adjacent snapshots).
+> Pommeau booking methodology v2 (2026+, prospective gate like ttb_origin_year): the filed
+> methodology's cider double-count (line 4 + line 10, baked into filed 2025 line 4 = 119, zero tax
+> impact) ends — cider books once as change-of-class, brandy on line 4; 2026 pommeau gap
+> +29.6 → +3.96, form variance 40.3 → **14.7 gal**; 2024/2025 byte-identical. Packaged ledger
+> unified into computeReconciliationFromBatches (one per-run basis, byte-identical outputs),
+> proving the hardCider −13.3 checkpoint residual is a packaging-loss BASIS difference
+> (bulk reducer gross vs ledger net) — the named follow-up. Golden 75/75 throughout.
 - Store filed 2024/2025 numbers in the DB (they currently live only in tests) and add a runtime path that compares a recomputed period against its filed `ttbPeriodSnapshot`, flagging drift.
 - Enforce opening-source consistency across period boundaries (§2.9).
 

--- a/packages/api/scripts/phase0-recon-diagnostic.ts
+++ b/packages/api/scripts/phase0-recon-diagnostic.ts
@@ -206,6 +206,34 @@ for (const year of YEARS) {
     plug.clampedVolume = null; // filled from recon summary below if exposed
     yearOut.plugInstrumentation = plug;
     console.log("plug instrumentation:", JSON.stringify(plug, null, 1));
+
+    // --- Phase 4 C4: filed-vs-recompute drift ---------------------------
+    // Attached by generateForm512017 when a FILED annual snapshot covers the
+    // period. Expected: 2025 "expected_only" (0 new_drift), 2024 "clean".
+    const fd = form.filedDrift;
+    if (fd) {
+      yearOut.filedDrift = {
+        status: fd.status,
+        newDriftCount: fd.newDriftCount,
+        maxResidualGal: fd.maxResidualGal,
+      };
+      const newDriftLines = (fd.lines ?? [])
+        .filter((l: any) => l.status === "new_drift")
+        .map((l: any) =>
+          `${l.label}: recomputed=${l.recomputedGal}, filed=${l.filedGal}, ` +
+          `delta=${l.deltaGal}, expected=${l.expectedDeltaGal}, residual=${l.residualGal}`,
+        );
+      console.log(
+        `filedDrift: status=${fd.status}, newDriftCount=${fd.newDriftCount}, ` +
+        `maxResidualGal=${fd.maxResidualGal}`,
+      );
+      if (newDriftLines.length > 0) {
+        console.log("  NEW DRIFT lines:");
+        for (const line of newDriftLines) console.log(`    ${line}`);
+      }
+    } else {
+      console.log("filedDrift: (none — no filed snapshot for this period)");
+    }
   } catch (e: any) {
     yearOut.formError = e.message;
     console.log(`generateForm512017 FAILED: ${e.message}`);

--- a/packages/api/scripts/phase0-recon-diagnostic.ts
+++ b/packages/api/scripts/phase0-recon-diagnostic.ts
@@ -234,6 +234,30 @@ for (const year of YEARS) {
     } else {
       console.log("filedDrift: (none — no filed snapshot for this period)");
     }
+
+    // --- Phase 4 C5: opening-source consistency -------------------------
+    // Attached by generateForm512017 for every period. Expected: 2025/2026
+    // adjacent-snapshot (clean, no warnings); 2024 is the first year (report
+    // what it shows).
+    const os = form.openingSource;
+    if (os) {
+      yearOut.openingSource = {
+        source: os.source,
+        adjacent: os.adjacent,
+        gapDays: os.gapDays,
+      };
+      yearOut.openingWarnings = form.openingWarnings ?? [];
+      console.log(
+        `openingSource: source=${os.source}, adjacent=${os.adjacent}, gapDays=${os.gapDays}`,
+      );
+      const warns = form.openingWarnings ?? [];
+      if (warns.length > 0) {
+        console.log("  opening warnings:");
+        for (const w of warns) console.log(`    [${w.category}] ${w.message}`);
+      }
+    } else {
+      console.log("openingSource: (none)");
+    }
   } catch (e: any) {
     yearOut.formError = e.message;
     console.log(`generateForm512017 FAILED: ${e.message}`);

--- a/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
+++ b/packages/api/src/routers/__tests__/ttb-golden-2025.test.ts
@@ -12,7 +12,15 @@
  * They will FAIL until the calculation fixes are applied.
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { db, ttbPeriodSnapshots } from "db";
 import { appRouter } from "..";
+import {
+  FILED_2024,
+  FILED_2025,
+  EXPECTED_DRIFT_2024,
+  EXPECTED_DRIFT_2025,
+} from "lib";
 
 // Admin context — same pattern as ttb-parity.test.ts
 const testContext = {
@@ -53,121 +61,26 @@ function expectClose(actual: number, expected: number, label: string, tol = TOLE
 }
 
 // ============================================
-// KNOWN-CORRECT 2025 PDF VALUES
-// From verified TTB Form 5120.17 filing
+// KNOWN-CORRECT 2025 PDF VALUES + PERMANENT DELTAS
 // ============================================
+// Both the filed numbers (FILED_2025) and the documented recompute-vs-filed
+// deltas (EXPECTED_DRIFT_2025) now live in packages/lib/src/calculations/
+// ttb-filed.ts (Phase 4 C1). This test consumes them so there is exactly one
+// source of truth, shared with the DB seed and the runtime comparator.
+//
+// FILED_2025 is the verified 2025 Form 5120.17; the deltas exist because the
+// fall-2025 production backlog was data-entered in 2026 with 2026-dated events,
+// so filed reflects physical reality while the recompute reflects events exactly
+// as entered (owner decision 2026-07-20: no re-dating, no amended filing).
+// If one of these drifts, the ENGINE changed (investigate) — the data
+// explanation did not.
+const PDF = FILED_2025;
 
-const PDF = {
-  sectionA: {
-    hardCider: {
-      line1_opening: 1061.0,
-      line2_produced: 4807.7,
-      line10_changeOfClassIn: 5.0,
-      line12_totalIn: 5873.7,
-      line13_packaged: 148.9,
-      line16_distillation: 753.2,
-      line24_changeOfClassOut: 641.4, // perry no longer cross-class (cider→perry are both hardCider)
-      line29_losses: 238.2,       // all losses: bulk + bottling. Line 30 reserved for physical inventory shortages only. +5 gal from distillery adj.
-      line31_ending: 4092.3,      // LIVE currentVolumeLiters — after data fixes
-      line32_totalOut: 5873.7,
-    },
-    wineUnder16: {
-      line1_opening: 0.0,
-      line2_produced: 56.2,
-      line10_changeOfClassIn: 641.4, // perry no longer cross-class (cider→perry are both hardCider)
-      line12_totalIn: 697.6,      // adjusted for perry classification
-      line13_packaged: 628.2,
-      line24_changeOfClassOut: 5.0,
-      line29_losses: 46.6,        // all losses: bulk + bottling. Line 30 reserved for physical inventory shortages only.
-      line31_ending: 17.9,
-      line32_totalOut: 697.6,     // adjusted for perry classification
-    },
-    wine16To21: {
-      line1_opening: 60.0,
-      line4_wineSpirits: 119.0,
-      line12_totalIn: 179.0,
-      line13_packaged: 55.2,
-      line29_losses: 1.5,         // all losses: bulk (1.3) + bottling (0.2). Line 30 reserved for physical inventory shortages only.
-      line31_ending: 122.3,
-      line32_totalOut: 179.0,
-    },
-  },
-  sectionB: {
-    hardCider: {
-      line2_bottledFromBulk: 148.9,
-      line8_removedTaxPaid: 148.9,
-      line20_endingBottled: 0.0,
-    },
-    wineUnder16: {
-      line2_bottledFromBulk: 628.2,
-      line8_removedTaxPaid: 566.3,
-      line20_endingBottled: 61.9,
-    },
-    wine16To21: {
-      line2_bottledFromBulk: 55.2,
-      line8_removedTaxPaid: 55.2,
-      line20_endingBottled: 0.0,
-    },
-  },
-  materials: {
-    applesLbs: 63299,
-    juiceGal: 3872,
-    otherFruitLbs: 786,
-    sugarLbs: 40,
-  },
-  brandy: {
-    receivedGal: 55.0,
-    receivedProofGal: 77.0,
-    usedGal: 29.9,
-    usedProofGal: 41.9,
-    remainingGal: 25.1,
-    remainingProofGal: 35.1,
-  },
-};
-
-// ============================================
-// PERMANENT RECOMPUTE-vs-FILED DELTAS
-// ============================================
-// The PDF constants above are the FILED 2025 numbers and remain the documented
-// source of truth. Some recomputed lines permanently differ from what was
-// filed. Cause: the fall-2025 production backlog was data-entered in 2026 with
-// 2026-dated events, so the filed numbers reflect physical reality while the
-// recompute reflects events exactly as entered. Owner decision (2026-07-20):
-// no event re-dating, no amended filing — so these deltas are documented here,
-// not hidden. Each entry is `delta = recomputed_actual - filed_expected`
-// (rounded to 0.1 gal) keyed by the exact assertion label. If one of these
-// drifts, the ENGINE changed (investigate) — the data explanation did not.
-const KNOWN_DELTA: Record<string, number> = {
-  // Hard Cider — the backlog lands here. Recompute counts fall-2025 volume as
-  // still-on-hand (booked 2026) rather than lost/ended in 2025, deflating Line
-  // 31 ending by ~1.15k gal.
-  // Phase 3 C2 (de-plug): Line 29 is now the REAL recorded operational losses,
-  // no longer the balance-forcing plug. The old +1111.6 delta was the plugged
-  // backlog it absorbed; that discrepancy is now surfaced as the honest
-  // unexplained variance (~1096 gal, see the "gap vs unexplained" balance test),
-  // NOT hidden in losses. Delta is now just the small recorded-loss difference.
-  "HC Line 29 Losses": 15.4, // actual 253.6 (recorded losses) vs filed 238.2
-  "HC Line 31 Ending": -1156.1, // actual 2936.2 vs filed 4092.3
-  "HC Line 12 Total In": 1.6, // actual 5875.3 vs filed 5873.7 (rounding of backlog inflows)
-  // Wine <16% — plum/quince packaging booked 2026, so less packaged/ending in 2025.
-  "W<16 Line 13 Packaged": -35.5, // actual 592.7 vs filed 628.2
-  // Phase 3 C2 (de-plug): Line 29 = real recorded losses (37.1), not the plug.
-  // The former +18.0 plugged amount is now honest unexplained variance (~27.5).
-  "W<16 Line 29 Losses": -9.5, // actual 37.1 (recorded losses) vs filed 46.6
-  "W<16 Line 31 Ending": -5.0, // actual 12.9 vs filed 17.9
-  "W<16 Line 12 Total In": -22.4, // actual 675.2 vs filed 697.6
-  "W<16-B Line 2 Bottled": -35.5, // actual 592.7 vs filed 628.2 (same event as Line 13)
-  "W<16-B Line 20 Ending": -35.5, // actual 26.4 vs filed 61.9
-  // Wine 16-21% (Pommeau) — extra 2025 blend inflow present in recompute.
-  "W16-21 Line 12 Total In": 45.7, // actual 224.7 vs filed 179.0
-  // Materials — apple weight off by one small backlog receipt (tol 100).
-  "Materials Apples (lbs)": -357.0, // actual 62942 vs filed 63299
-  // Opening balances: SBD reconstruction of the Dec-31-2024 carried-forward
-  // batches runs ~10 gal below the filed opening. This is reconstruction drift
-  // on opening (not the backlog), permanent given no re-dating of history.
-  "Waterfall total opening": -9.8, // actual 1111.3 vs filed 1121.0 (tol 5)
-  "HC waterfall opening": -10.2, // actual 1051.8 vs filed 1062.0 (tol 5)
-};
+// KNOWN_DELTA keyed by the exact assertion label, derived from the shared
+// entries (delta = recomputed_actual − filed_expected, rounded to 0.1 gal).
+const KNOWN_DELTA: Record<string, number> = Object.fromEntries(
+  EXPECTED_DRIFT_2025.map((e) => [e.label, e.deltaGal]),
+);
 
 // This suite asserts the recompute equals the FILED numbers plus the documented
 // permanent deltas above (KNOWN_DELTA). It runs unconditionally.
@@ -1147,4 +1060,49 @@ describe("TTB Golden 2025 — Reconciliation Summary", () => {
       expect(pct, `${pct.toFixed(0)}% batches exceed vessel capacity`).toBeLessThan(20);
     });
   });
+});
+
+// ============================================
+// FILED-SNAPSHOT SOURCE PARITY (Phase 4 C2)
+// ============================================
+// The seeded filed_form / expected_drift jsonb on the 2024 & 2025 period
+// snapshots MUST stay byte-for-byte equal to the lib constants they were seeded
+// from. This guard fails if the DB rows drift from packages/lib (e.g. someone
+// re-seeds from a stale copy, or edits the constants without re-running
+// seed-filed-snapshots.ts). It keeps the runtime comparator (C4) honest.
+describe("TTB Filed-Snapshot Source Parity", () => {
+  const SNAPSHOTS = [
+    {
+      year: 2024,
+      id: "fb3964e1-3560-43a1-9ec6-377e9cc1778a",
+      filedForm: FILED_2024,
+      expectedDrift: EXPECTED_DRIFT_2024,
+    },
+    {
+      year: 2025,
+      id: "f968b31f-7ee7-43bc-9e06-510cfd3920c0",
+      filedForm: FILED_2025,
+      expectedDrift: EXPECTED_DRIFT_2025,
+    },
+  ] as const;
+
+  for (const snap of SNAPSHOTS) {
+    it(`${snap.year} snapshot filed_form/expected_drift equals lib constants`, async () => {
+      const [row] = await db
+        .select({
+          isFiled: ttbPeriodSnapshots.isFiled,
+          filedForm: ttbPeriodSnapshots.filedForm,
+          expectedDrift: ttbPeriodSnapshots.expectedDrift,
+        })
+        .from(ttbPeriodSnapshots)
+        .where(eq(ttbPeriodSnapshots.id, snap.id));
+
+      expect(row, `${snap.year} filed snapshot ${snap.id} must exist`).toBeDefined();
+      expect(row.isFiled, `${snap.year} snapshot must be flagged is_filed`).toBe(true);
+      // jsonb round-trips as plain JSON — compare against the JSON projection of
+      // the lib constants so readonly/`as const` typing doesn't affect equality.
+      expect(row.filedForm).toEqual(JSON.parse(JSON.stringify(snap.filedForm)));
+      expect(row.expectedDrift).toEqual(JSON.parse(JSON.stringify(snap.expectedDrift)));
+    });
+  }
 });

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -441,6 +441,10 @@ interface BatchTTBContribution {
   sales: number;
   distillation: number;
   ending: number;
+  // C8 packaged-ledger (wine gallons, per-run basis shared with bulk):
+  openingPackaged: number;          // packaged on-hand at period start
+  packagedEnding: number;           // packaged on-hand at period end
+  unrecordedDistribution: number;   // ledger removals over the window not backed by recorded sales
   identityCheck: number;
   lossBreakdown: {
     racking: number;
@@ -499,6 +503,12 @@ interface BatchReconciliationResult {
     adjustments: number;
   };
   crossClassByTaxClass: Record<string, { in: number; out: number }>;
+  // C8: packaged-goods ledger per tax class (wine gallons), computed ONCE here so
+  // bulk (byTaxClass.ending) and packaged share one per-run basis. Consumed by the
+  // getReconciliationSummary waterfall instead of a second ledger pass. removedWindow
+  // = ledger removals over [start,end]; the waterfall nets recorded sales off it to
+  // derive unrecordedDistribution (keeping the sales basis it already used).
+  packagedByTaxClass: Record<string, { openingPackaged: number; packagedEnding: number; removedWindow: number }>;
   byTaxClass: Record<string, {
     opening: number;
     production: number;
@@ -536,6 +546,91 @@ interface BatchReconciliationResult {
   vesselCapacityWarnings: number;
 }
 
+/** One packaged-run row's on-hand + removed volume (wine gallons), as-of a date. */
+export interface PackagedLedgerEntry {
+  onHand: number;
+  removed: number;
+}
+
+/**
+ * Packaged-goods ledger (C8): per bottle-run / keg-fill, as-of a date, on ONE
+ * consistent basis so packaged on-hand and packaged removals never diverge.
+ *
+ * Per run, as-of `asOf`:
+ *   removed = distributed_at flag set ? full net volume
+ *                                     : recorded inventory_distributions (capped at net)
+ *   onHand  = net packaged − removed
+ * Kegs distribute all-or-nothing via distributed_at (no partial
+ * inventory_distributions), so removed = net when flagged else 0.
+ * onHand + removed = net packaged for every run.
+ *
+ * Hoisted from a getReconciliationSummary closure so computeReconciliationFromBatches
+ * consumes the SAME ledger per batch — bulk and packaged share one per-run basis.
+ * Returns both a per-tax-class and a per-batch view (identical totals).
+ */
+async function computePackagedLedger(
+  asOf: string,
+  batchTaxClassMap: Map<string, TTBTaxClass | null>,
+): Promise<{
+  byTaxClass: Record<string, PackagedLedgerEntry>;
+  byBatch: Record<string, PackagedLedgerEntry>;
+}> {
+  const byTaxClass: Record<string, PackagedLedgerEntry> = {};
+  const byBatch: Record<string, PackagedLedgerEntry> = {};
+  const add = (tc: string, batchId: string, onHand: number, removed: number) => {
+    if (!byTaxClass[tc]) byTaxClass[tc] = { onHand: 0, removed: 0 };
+    byTaxClass[tc].onHand += onHand;
+    byTaxClass[tc].removed += removed;
+    if (!byBatch[batchId]) byBatch[batchId] = { onHand: 0, removed: 0 };
+    byBatch[batchId].onHand += onHand;
+    byBatch[batchId].removed += removed;
+  };
+  const bottleLedger = await db.execute(sql`
+    SELECT br.batch_id AS "batchId", b.product_type AS "productType",
+      (br.volume_taken_liters::numeric - (CASE WHEN br.loss_unit = 'gal'
+         THEN COALESCE(br.loss::numeric, 0) * 3.78541 ELSE COALESCE(br.loss::numeric, 0) END)) AS net_l,
+      (br.distributed_at IS NOT NULL AND br.distributed_at::date <= ${asOf}::date) AS flagged,
+      COALESCE((
+        SELECT SUM((idr.quantity_distributed::numeric * ii.package_size_ml::numeric) / 1000.0)
+        FROM inventory_distributions idr
+        JOIN inventory_items ii ON idr.inventory_item_id = ii.id
+        WHERE ii.bottle_run_id = br.id AND idr.distribution_date::date <= ${asOf}::date
+      ), 0) AS inv_l
+    FROM bottle_runs br
+    JOIN batches b ON br.batch_id = b.id
+    WHERE br.voided_at IS NULL AND b.deleted_at IS NULL
+      AND COALESCE(b.reconciliation_status, 'pending') NOT IN ('duplicate', 'excluded')
+      AND br.packaged_at::date <= ${asOf}::date
+  `);
+  for (const row of bottleLedger.rows as any[]) {
+    const tc = getTaxClassFromMap(batchTaxClassMap, row.batchId, row.productType);
+    if (!tc) continue;
+    const net = litersToWineGallons(Number(row.net_l || 0));
+    const inv = litersToWineGallons(Number(row.inv_l || 0));
+    const removed = row.flagged ? net : Math.min(net, inv);
+    add(tc, row.batchId, net - removed, removed);
+  }
+  const kegLedger = await db.execute(sql`
+    SELECT kf.batch_id AS "batchId", b.product_type AS "productType",
+      ((CASE WHEN kf.volume_taken_unit = 'gal' THEN COALESCE(kf.volume_taken::numeric, 0) * 3.78541 ELSE COALESCE(kf.volume_taken::numeric, 0) END)
+       - (CASE WHEN kf.loss_unit = 'gal' THEN COALESCE(kf.loss::numeric, 0) * 3.78541 ELSE COALESCE(kf.loss::numeric, 0) END)) AS net_l,
+      (kf.distributed_at IS NOT NULL AND kf.distributed_at::date <= ${asOf}::date) AS flagged
+    FROM keg_fills kf
+    JOIN batches b ON kf.batch_id = b.id
+    WHERE kf.voided_at IS NULL AND kf.deleted_at IS NULL AND b.deleted_at IS NULL
+      AND COALESCE(b.reconciliation_status, 'pending') NOT IN ('duplicate', 'excluded')
+      AND kf.filled_at::date <= ${asOf}::date
+  `);
+  for (const row of kegLedger.rows as any[]) {
+    const tc = getTaxClassFromMap(batchTaxClassMap, row.batchId, row.productType);
+    if (!tc) continue;
+    const net = litersToWineGallons(Number(row.net_l || 0));
+    const removed = row.flagged ? net : 0;
+    add(tc, row.batchId, net - removed, removed);
+  }
+  return { byTaxClass, byBatch };
+}
+
 /**
  * Compute TTB reconciliation from batch operations.
  * Reconstructs all volumes purely from operations — never uses currentVolumeLiters.
@@ -555,6 +650,7 @@ async function computeReconciliationFromBatches(
     identityCheck: 0,
     lossBreakdown: { racking: 0, filter: 0, bottling: 0, kegging: 0, transfer: 0, pressTransfer: 0, adjustments: 0 },
     crossClassByTaxClass: {},
+    packagedByTaxClass: {},
     byTaxClass: {},
     batchesWithIdentityIssues: 0,
     batchesWithDrift: 0,
@@ -661,6 +757,15 @@ async function computeReconciliationFromBatches(
 
   // Resolve tax class map: use provided map or build one
   const taxClassMap = batchTaxClassMapInput ?? (await buildBatchTaxClassMap()).map;
+
+  // C8: packaged-goods ledger, as-of period start + end, on the SAME per-run basis
+  // used for bulk. Consumed per batch below (packaged ending, unrecorded removals)
+  // and returned per tax class so the getReconciliationSummary waterfall reuses this
+  // one ledger instead of a second independent pass.
+  const [pkgLedgerStart, pkgLedgerEnd] = await Promise.all([
+    computePackagedLedger(startDate, taxClassMap),
+    computePackagedLedger(endDate, taxClassMap),
+  ]);
 
   const idList = sql.join(batchIds.map((id) => sql`${id}`), sql`, `);
 
@@ -1269,6 +1374,14 @@ async function computeReconciliationFromBatches(
     const packagingGal = litersToWineGallons(periodBottlingTakenL + periodKeggingTakenL - periodBottlingLossL - periodKeggingLossL);
     const salesGal = litersToWineGallons(periodSalesL);
     const distillationGal = litersToWineGallons(periodDistillationL);
+    // C8: packaged on-hand (start/end) and window removals for THIS batch, from the
+    // shared per-run ledger (already in wine gallons). unrecordedDistribution = ledger
+    // removals over the window not backed by recorded sales (salesGal, inventory_distributions).
+    const openingPackagedGal = pkgLedgerStart.byBatch[batchId]?.onHand || 0;
+    const packagedEndingGal = pkgLedgerEnd.byBatch[batchId]?.onHand || 0;
+    const ledgerRemovedWindowGal = (pkgLedgerEnd.byBatch[batchId]?.removed || 0)
+      - (pkgLedgerStart.byBatch[batchId]?.removed || 0);
+    const unrecordedDistributionGal = ledgerRemovedWindowGal - salesGal;
     // Use raw conversion to preserve negative endings (batches over-packaged/transferred);
     // litersToWineGallons clamps negatives to 0 which inflates the waterfall total.
     const endingGal = endingL * WINE_GALLONS_PER_LITER;
@@ -1341,6 +1454,9 @@ async function computeReconciliationFromBatches(
       sales: parseFloat(salesGal.toFixed(3)),
       distillation: parseFloat(distillationGal.toFixed(3)),
       ending: parseFloat(endingGal.toFixed(3)),
+      openingPackaged: parseFloat(openingPackagedGal.toFixed(3)),
+      packagedEnding: parseFloat(packagedEndingGal.toFixed(3)),
+      unrecordedDistribution: parseFloat(unrecordedDistributionGal.toFixed(3)),
       identityCheck: parseFloat(identityGal.toFixed(3)),
       lossBreakdown: {
         racking: parseFloat(lossBreakdown.racking.toFixed(3)),
@@ -1520,6 +1636,25 @@ async function computeReconciliationFromBatches(
     crossClassByTaxClass[tc].out = parseFloat(crossClassByTaxClass[tc].out.toFixed(1));
   }
 
+  // C8: packaged ledger per tax class (from the ONE shared ledger, over ALL its
+  // rows — same basis the waterfall used from its old closure). removedWindow is
+  // raw (not rounded) so the waterfall's `unrec = removedWindow − actualSales`
+  // stays numerically identical to the pre-hoist computation.
+  const packagedByTaxClass: BatchReconciliationResult["packagedByTaxClass"] = {};
+  const pkgClasses = new Set<string>([
+    ...Object.keys(pkgLedgerStart.byTaxClass),
+    ...Object.keys(pkgLedgerEnd.byTaxClass),
+  ]);
+  for (const tc of pkgClasses) {
+    const s = pkgLedgerStart.byTaxClass[tc] || { onHand: 0, removed: 0 };
+    const e = pkgLedgerEnd.byTaxClass[tc] || { onHand: 0, removed: 0 };
+    packagedByTaxClass[tc] = {
+      openingPackaged: s.onHand,
+      packagedEnding: e.onHand,
+      removedWindow: e.removed - s.removed,
+    };
+  }
+
   return {
     batches: contributions,
     totals: roundedTotals,
@@ -1534,6 +1669,7 @@ async function computeReconciliationFromBatches(
       adjustments: parseFloat(aggLoss.adjustments.toFixed(1)),
     },
     crossClassByTaxClass,
+    packagedByTaxClass,
     byTaxClass,
     batchesWithIdentityIssues,
     batchesWithDrift,
@@ -3885,9 +4021,16 @@ export const ttbRouter = router({
         };
 
         // Wine 16-21% column (pommeau): produced by wine spirits (Line 4)
-        // Pommeau = juice fortified with apple brandy. The full pommeau volume goes on
-        // Line 4 ("Produced by addition of wine spirits") in the per-class column.
-        // The total column Line 4 shows only the brandy portion (spirits entering wine system).
+        // Pommeau = juice fortified with apple brandy.
+        //
+        // Pommeau booking methodology v2 (2026+): cider entering pommeau is a
+        // change-of-class booked ONCE (Line 10); brandy (the wine spirits) is
+        // Line 4. Years <= 2025 keep the FILED methodology (the full pommeau
+        // volume — cider + brandy — on Line 4 via pommeauProducedGallons), which
+        // double-books transfer-built cider (also on Line 10 via its cross-class
+        // transfer) and inflates Line 12. Filed years stay frozen so recomputes
+        // match the filing — the resulting 2025 +45.07 wine16To21 delta is
+        // documented in EXPECTED_DRIFT_2025 (zero tax impact). See pommeauLine4Gallons below.
         const pommeauChangeIn = roundGallons(changeOfClassIn["wine16To21"] || 0);
         const pommeauChangeOut = roundGallons(changeOfClassOut["wine16To21"] || 0);
         const pommeauGains = roundGallons(gainsByTaxClass["wine16To21"] || 0);
@@ -3897,7 +4040,58 @@ export const ttbRouter = router({
         const pommeauPacked = roundGallons(pommeauBottled + pommeauKegFilled - pommeauBottlingLoss);
         const pommeauDistillation = roundGallons(distillationByTaxClass["wine16To21"] || 0);
         const pommeauRecordedLosses = roundGallons(lossesByTaxClass["wine16To21"] || 0);
-        const pommeauLine12 = roundGallons(beginningPommeauBulkGallons + pommeauProducedGallons + pommeauChangeIn + pommeauGains);
+
+        // Line 4 (wine spirits) for the pommeau column. Filed years keep
+        // pommeauProducedGallons (full pommeau volume, cider double-booked with
+        // Line 10 — frozen, see comment above). For 2026+ book by construction type
+        // so nothing is double- or zero-counted:
+        //   - transfer-built pommeau (cider arrived via a live cross-class transfer):
+        //       Line 4 = only the brandy that fortified it; the cider is Line 10.
+        //   - composed pommeau (blended at creation, no live cider transfer):
+        //       full initial (juice + brandy) stays on Line 4 as the filed methodology
+        //       (its juice never was a separate change-of-class, so it is not on Line 10).
+        let pommeauLine4Gallons = pommeauProducedGallons;
+        if (year >= 2026) {
+          // Brandy (wine spirits) transferred into ANY pommeau batch this period.
+          const brandyIntoPommeauRows = await db
+            .select({ liters: sql<number>`COALESCE(SUM(CAST(${batchTransfers.volumeTransferred} AS DECIMAL)), 0)` })
+            .from(batchTransfers)
+            .innerJoin(sql`batches src`, sql`src.id = ${batchTransfers.sourceBatchId}`)
+            .innerJoin(sql`batches dst`, sql`dst.id = ${batchTransfers.destinationBatchId}`)
+            .where(
+              and(
+                isNull(batchTransfers.deletedAt),
+                sql`src.product_type = 'brandy'`,
+                sql`dst.product_type = 'pommeau'`,
+                sql`dst.deleted_at IS NULL`,
+                sql`COALESCE(dst.reconciliation_status, 'pending') NOT IN ('duplicate', 'excluded')`,
+                gte(batchTransfers.transferredAt, startDate),
+                lt(batchTransfers.transferredAt, endExclusive),
+              ),
+            );
+          // Composed pommeau (initial>0, new in period, NO live cross-class cider
+          // transfer feeding it) keeps its full initial — same batches as
+          // pommeauWithInitialSum minus the transfer-built ones (whose cider is Line 10).
+          const composedPommeauRows = await db
+            .select({ liters: sql<number>`COALESCE(SUM(CAST(${batches.initialVolumeLiters} AS DECIMAL)), 0)` })
+            .from(batches)
+            .where(
+              and(
+                isNull(batches.deletedAt),
+                sql`COALESCE(${batches.reconciliationStatus}, 'pending') NOT IN ('duplicate', 'excluded')`,
+                eq(batches.productType, "pommeau"),
+                or(isNull(batches.parentBatchId), eq(batches.isRackingDerivative, false)),
+                sql`CAST(${batches.initialVolumeLiters} AS DECIMAL) > 0`,
+                gte(batches.startDate, startDate),
+                sql`${ttbMembershipTs} < ${endExclusive}`,
+                sql`NOT EXISTS (SELECT 1 FROM batch_transfers bt2 JOIN batches s2 ON bt2.source_batch_id = s2.id WHERE bt2.destination_batch_id = ${batches.id} AND bt2.deleted_at IS NULL AND s2.product_type NOT IN ('brandy', 'pommeau'))`,
+              ),
+            );
+          const brandyIntoPommeauLiters = Number(brandyIntoPommeauRows[0]?.liters || 0);
+          const composedPommeauLiters = Number(composedPommeauRows[0]?.liters || 0);
+          pommeauLine4Gallons = roundGallons(litersToWineGallons(brandyIntoPommeauLiters + composedPommeauLiters));
+        }
+        const pommeauLine12 = roundGallons(beginningPommeauBulkGallons + pommeauLine4Gallons + pommeauChangeIn + pommeauGains);
         // Phase 3 C2: no plug/flip — Line 29 = recorded losses, Line 32 = true sum.
         const pommeauLossesRaw = roundGallons(
           pommeauLine12 - pommeauPacked - pommeauDistillation - pommeauChangeOut - endingPommeauBulkGallons
@@ -3909,7 +4103,7 @@ export const ttbRouter = router({
           line1_onHandBeginning: beginningPommeauBulkGallons,
           line2_produced: 0,
           line3_sweetening: 0,
-          line4_wineSpirits: pommeauProducedGallons,
+          line4_wineSpirits: pommeauLine4Gallons,
           line5_blending: 0,
           line6_amelioration: 0,
           line7_receivedInBond: 0,
@@ -7370,80 +7564,16 @@ export const ttbRouter = router({
       const batchReconByTaxClass = batchRecon.byTaxClass;
 
       // ============================================
-      // PACKAGED-GOODS LEDGER (packaged-flow scope fix)
-      // Packaged on-hand and packaged removals MUST share one per-run ledger.
-      // The pre-fix asymmetry: on-hand was decided by the binary
-      // `bottle_runs`/`keg_fills` `distributed_at` flag (full run volume),
-      // while removals (`sales`) came from a DIFFERENT source
-      // (`inventory_distributions`). A run flagged distributed with missing or
-      // partial distribution records was dropped from on-hand WITHOUT a matching
-      // removal, so the packaged product vanished into unexplainedVariance.
-      //
-      // Per bottle run, as-of a date:
-      //   removed = distributed_at flag set  ? full net volume
-      //                                       : recorded inventory_distributions (capped at net)
-      //   onHand  = net packaged − removed
-      // Kegs distribute all-or-nothing via the distributed_at flag (they have no
-      // partial inventory_distributions rows), so removed = net when flagged else 0.
-      // onHand + removed = net packaged for every run, so the packaged ledger is
-      // internally consistent by construction: physical (endPkg) and the removal
-      // subtracted from calculatedEnding are on ONE basis and ONE window.
-      const computePackagedLedger = async (
-        asOf: string,
-      ): Promise<Record<string, { onHand: number; removed: number }>> => {
-        const acc: Record<string, { onHand: number; removed: number }> = {};
-        const add = (tc: string, onHand: number, removed: number) => {
-          if (!acc[tc]) acc[tc] = { onHand: 0, removed: 0 };
-          acc[tc].onHand += onHand;
-          acc[tc].removed += removed;
-        };
-        const bottleLedger = await db.execute(sql`
-          SELECT br.batch_id AS "batchId", b.product_type AS "productType",
-            (br.volume_taken_liters::numeric - (CASE WHEN br.loss_unit = 'gal'
-               THEN COALESCE(br.loss::numeric, 0) * 3.78541 ELSE COALESCE(br.loss::numeric, 0) END)) AS net_l,
-            (br.distributed_at IS NOT NULL AND br.distributed_at::date <= ${asOf}::date) AS flagged,
-            COALESCE((
-              SELECT SUM((idr.quantity_distributed::numeric * ii.package_size_ml::numeric) / 1000.0)
-              FROM inventory_distributions idr
-              JOIN inventory_items ii ON idr.inventory_item_id = ii.id
-              WHERE ii.bottle_run_id = br.id AND idr.distribution_date::date <= ${asOf}::date
-            ), 0) AS inv_l
-          FROM bottle_runs br
-          JOIN batches b ON br.batch_id = b.id
-          WHERE br.voided_at IS NULL AND b.deleted_at IS NULL
-            AND COALESCE(b.reconciliation_status, 'pending') NOT IN ('duplicate', 'excluded')
-            AND br.packaged_at::date <= ${asOf}::date
-        `);
-        for (const row of bottleLedger.rows as any[]) {
-          const tc = getTaxClassFromMap(batchTaxClassMap, row.batchId, row.productType);
-          if (!tc) continue;
-          const net = litersToWineGallons(Number(row.net_l || 0));
-          const inv = litersToWineGallons(Number(row.inv_l || 0));
-          const removed = row.flagged ? net : Math.min(net, inv);
-          add(tc, net - removed, removed);
-        }
-        const kegLedger = await db.execute(sql`
-          SELECT kf.batch_id AS "batchId", b.product_type AS "productType",
-            ((CASE WHEN kf.volume_taken_unit = 'gal' THEN COALESCE(kf.volume_taken::numeric, 0) * 3.78541 ELSE COALESCE(kf.volume_taken::numeric, 0) END)
-             - (CASE WHEN kf.loss_unit = 'gal' THEN COALESCE(kf.loss::numeric, 0) * 3.78541 ELSE COALESCE(kf.loss::numeric, 0) END)) AS net_l,
-            (kf.distributed_at IS NOT NULL AND kf.distributed_at::date <= ${asOf}::date) AS flagged
-          FROM keg_fills kf
-          JOIN batches b ON kf.batch_id = b.id
-          WHERE kf.voided_at IS NULL AND kf.deleted_at IS NULL AND b.deleted_at IS NULL
-            AND COALESCE(b.reconciliation_status, 'pending') NOT IN ('duplicate', 'excluded')
-            AND kf.filled_at::date <= ${asOf}::date
-        `);
-        for (const row of kegLedger.rows as any[]) {
-          const tc = getTaxClassFromMap(batchTaxClassMap, row.batchId, row.productType);
-          if (!tc) continue;
-          const net = litersToWineGallons(Number(row.net_l || 0));
-          const removed = row.flagged ? net : 0;
-          add(tc, net - removed, removed);
-        }
-        return acc;
-      };
-      const packagedLedgerEnd = await computePackagedLedger(reconciliationDate);
-      const packagedLedgerStart = await computePackagedLedger(batchReconStartDate);
+      // PACKAGED-GOODS LEDGER (C8: unified into computeReconciliationFromBatches)
+      // Packaged on-hand and packaged removals share ONE per-run ledger with the
+      // bulk reconstruction — computeReconciliationFromBatches now computes it (via
+      // the hoisted computePackagedLedger) over the SAME period and returns it as
+      // packagedByTaxClass. The waterfall consumes that here instead of a second
+      // independent ledger pass, so bulk and packaged can never drift on basis.
+      // openingPackaged/packagedEnding = ledger on-hand at period start/end;
+      // removedWindow = ledger removals over [start,end]. unrecordedDistribution is
+      // derived below by netting recorded sales off removedWindow (unchanged basis).
+      const packagedLedger = batchRecon.packagedByTaxClass;
 
       for (const key of waterfallTaxClasses) {
         const sbdTc = sbdWaterfallByTaxClass[key];
@@ -7468,19 +7598,18 @@ export const ttbRouter = router({
         // SBD-derived packaging (net product volume transferred from bulk to packaged)
         const sbdPackaging = reconTc?.packaging || 0;
 
-        // Packaged-goods ledger (per-run on-hand + removal, one consistent basis).
-        const ledgerEnd = packagedLedgerEnd[key] || { onHand: 0, removed: 0 };
-        const ledgerStart = packagedLedgerStart[key] || { onHand: 0, removed: 0 };
+        // Packaged-goods ledger (C8: the ONE ledger from computeReconciliationFromBatches).
+        const ledger = packagedLedger[key] || { openingPackaged: 0, packagedEnding: 0, removedWindow: 0 };
 
         // Opening includes ALL on-premises inventory: bulk + packaged at period start.
         // This ensures the TTB "On Premises" line reflects everything physically in bond.
         const openBulk = sbdTc?.opening || 0;
-        const openPkg = ledgerStart.onHand;
+        const openPkg = ledger.openingPackaged;
         const openingTotal = openBulk + openPkg;
 
         // Ending includes ALL on-premises inventory: bulk + packaged at period end.
         const sbdBulkEnding = sbdTc?.ending || 0;
-        const endPkg = ledgerEnd.onHand;
+        const endPkg = ledger.packagedEnding;
         // Phase 3 C5: no clamp — a negative packaged ending (class distributes more
         // than it packaged, a scope/data mismatch) must flow into unexplainedVariance
         // below, not be floored to zero and hidden.
@@ -7491,7 +7620,7 @@ export const ttbRouter = router({
         // by recorded distributions (runs flagged distributed with missing/partial
         // inventory_distributions). It is a named removal component — the packaged
         // product left on-hand and must be subtracted just like `sales`, not hidden.
-        const packagedRemovalWindow = ledgerEnd.removed - ledgerStart.removed;
+        const packagedRemovalWindow = ledger.removedWindow;
         const unrecordedDistribution = packagedRemovalWindow - actualSales;
 
         // Formula: opening(total) + inflows - outflows = ending(total).

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -91,6 +91,9 @@ import {
   type BrandyTransfer,
   type CiderBrandyInventory,
   type CiderBrandyReconciliation,
+  computeFiledDrift,
+  type FiledDriftResult,
+  type ExpectedDriftEntry,
 } from "lib";
 import { fetchBatchVolumeEvents } from "../services/batch-volume-events";
 import { recomputeBatchVolume } from "../services/batch-volume-recompute";
@@ -4275,6 +4278,45 @@ export const ttbRouter = router({
         // and line32_total during initial construction above — no post-hoc update needed.
 
         // ============================================
+        // Phase 4: filed-vs-recompute drift
+        // ============================================
+        // If a FILED annual snapshot covers this period, compare the recompute
+        // to the filed numbers, tolerating the documented permanent deltas
+        // (surface==="form" only — checkpoint-surface deltas belong to the
+        // reconciliation waterfall, not the form). Surfaces NEW drift beside
+        // varianceAnalysis without changing any line value.
+        let filedDrift: FiledDriftResult | undefined;
+        if (periodType === "annual") {
+          const [filedSnap] = await db
+            .select({
+              filedForm: ttbPeriodSnapshots.filedForm,
+              expectedDrift: ttbPeriodSnapshots.expectedDrift,
+            })
+            .from(ttbPeriodSnapshots)
+            .where(
+              and(
+                eq(ttbPeriodSnapshots.periodType, "annual"),
+                eq(ttbPeriodSnapshots.year, year),
+                eq(ttbPeriodSnapshots.isFiled, true),
+              ),
+            )
+            .limit(1);
+
+          if (filedSnap?.filedForm && Array.isArray(filedSnap.expectedDrift)) {
+            const formEntries = (filedSnap.expectedDrift as ExpectedDriftEntry[]).filter(
+              (e) => e.surface === "form",
+            );
+            // Only the recomputed columns/materials are needed to resolve the
+            // form-surface field paths.
+            filedDrift = computeFiledDrift(
+              { bulkWinesByTaxClass, bottledWinesByTaxClass, materials },
+              filedSnap.filedForm,
+              formEntries,
+            );
+          }
+        }
+
+        // ============================================
         // Build Response
         // ============================================
 
@@ -4292,6 +4334,7 @@ export const ttbRouter = router({
           materials,
           fermenters,
           varianceAnalysis,
+          filedDrift,
           beginningInventory,
           wineProduced: {
             total: wineProducedGallons, // Press runs + juice purchases (pommeau juice already included)

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -94,6 +94,8 @@ import {
   computeFiledDrift,
   type FiledDriftResult,
   type ExpectedDriftEntry,
+  type TTBOpeningSourceInfo,
+  type TTBOpeningWarning,
 } from "lib";
 import { fetchBatchVolumeEvents } from "../services/batch-volume-events";
 import { recomputeBatchVolume } from "../services/batch-volume-recompute";
@@ -1540,6 +1542,124 @@ async function computeReconciliationFromBatches(
   };
 }
 
+/** Whole days between two "YYYY-MM-DD" date strings (later − earlier). */
+function daysBetweenDateStrings(earlier: string, later: string): number {
+  const a = Date.parse(`${earlier}T00:00:00Z`);
+  const b = Date.parse(`${later}T00:00:00Z`);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return 0;
+  return Math.round((b - a) / 86_400_000);
+}
+
+/**
+ * Resolve which prior-period source seeds a TTB period's opening inventory, and
+ * whether that source chains cleanly to the period start.
+ *
+ * Shared by generateForm512017 and getBeginningInventory so both agree on the
+ * finalized-snapshot lookup (previously duplicated with NO adjacency check: a
+ * period whose immediately-prior snapshot was missing silently opened from an
+ * OLDER snapshot, dropping the uncovered gap).
+ *
+ * Warn-only: a non-adjacent snapshot is still returned and used — the gap is
+ * only reported. Never blocks form generation.
+ *
+ * `adjacent` ⇔ the finalized snapshot's periodEnd is exactly the day before
+ * `startDate` (date-string arithmetic, day granularity).
+ */
+async function resolveOpeningSource(startDate: Date): Promise<{
+  source: TTBOpeningSourceInfo["source"];
+  snapshot?: typeof ttbPeriodSnapshots.$inferSelect;
+  adjacent: boolean;
+  gapDays: number;
+  warnings: TTBOpeningWarning[];
+}> {
+  const startDateStr = startDate.toISOString().split("T")[0];
+  const dayBefore = new Date(startDate);
+  dayBefore.setDate(dayBefore.getDate() - 1);
+  const dayBeforeStr = dayBefore.toISOString().split("T")[0];
+
+  const warnings: TTBOpeningWarning[] = [];
+
+  // Tier 1: most recent FINALIZED snapshot ending before the period start.
+  const [snapshot] = await db
+    .select()
+    .from(ttbPeriodSnapshots)
+    .where(
+      and(
+        sql`${ttbPeriodSnapshots.periodEnd} < ${startDateStr}::date`,
+        eq(ttbPeriodSnapshots.status, "finalized"),
+      ),
+    )
+    .orderBy(desc(ttbPeriodSnapshots.periodEnd))
+    .limit(1);
+
+  if (snapshot) {
+    const adjacent = snapshot.periodEnd === dayBeforeStr;
+    const gapDays = adjacent
+      ? 0
+      : daysBetweenDateStrings(snapshot.periodEnd, dayBeforeStr);
+    if (!adjacent) {
+      warnings.push({
+        level: "warning",
+        category: "openingGap",
+        message: `Opening from snapshot ended ${snapshot.periodEnd}; ${gapDays} days uncovered before period start`,
+      });
+    }
+    return { source: "snapshot", snapshot, adjacent, gapDays, warnings };
+  }
+
+  // No finalized snapshot before this period — classify the fallback source,
+  // mirroring generateForm512017's manual-seed (opening balance, first period
+  // only) vs reconstructed decision.
+  const [settings] = await db
+    .select({
+      ttbOpeningBalanceDate: organizationSettings.ttbOpeningBalanceDate,
+      ttbOpeningBalances: organizationSettings.ttbOpeningBalances,
+    })
+    .from(organizationSettings)
+    .limit(1);
+
+  const openingBalanceDate = settings?.ttbOpeningBalanceDate
+    ? new Date(settings.ttbOpeningBalanceDate)
+    : null;
+  const dayAfterOpening = openingBalanceDate ? new Date(openingBalanceDate) : null;
+  if (dayAfterOpening) dayAfterOpening.setDate(dayAfterOpening.getDate() + 2);
+  const isFirstPeriod = !!(
+    openingBalanceDate &&
+    dayAfterOpening &&
+    startDate >= openingBalanceDate &&
+    startDate <= dayAfterOpening
+  );
+  const source: TTBOpeningSourceInfo["source"] =
+    settings?.ttbOpeningBalances && isFirstPeriod
+      ? "ttb_opening_balance"
+      : "calculated";
+
+  // A draft (un-finalized) prior-period snapshot means the chain is breakable:
+  // finalizing it would let this period open from it instead of reconstructing.
+  const [priorDraft] = await db
+    .select({ periodEnd: ttbPeriodSnapshots.periodEnd })
+    .from(ttbPeriodSnapshots)
+    .where(
+      and(
+        sql`${ttbPeriodSnapshots.periodEnd} < ${startDateStr}::date`,
+        sql`${ttbPeriodSnapshots.status} <> 'finalized'`,
+      ),
+    )
+    .orderBy(desc(ttbPeriodSnapshots.periodEnd))
+    .limit(1);
+
+  if (priorDraft) {
+    warnings.push({
+      level: "warning",
+      category: "openingReconstructed",
+      message:
+        "opening reconstructed from events; finalize the prior period's snapshot to chain openings",
+    });
+  }
+
+  return { source, adjacent: false, gapDays: 0, warnings };
+}
+
 export const ttbRouter = router({
   /**
    * READ-ONLY reconciliation diagnostic: reconstruct EVERY batch's on-hand
@@ -1717,20 +1837,12 @@ export const ttbRouter = router({
         const beginningBottledByClass: Record<string, number> = {};
 
         // 1. Check for previous period snapshot
-        // Format startDate as string for comparison
-        const startDateStr = startDate.toISOString().split("T")[0];
-
-        const [previousSnapshot] = await db
-          .select()
-          .from(ttbPeriodSnapshots)
-          .where(
-            and(
-              sql`${ttbPeriodSnapshots.periodEnd} < ${startDateStr}::date`,
-              eq(ttbPeriodSnapshots.status, "finalized")
-            )
-          )
-          .orderBy(desc(ttbPeriodSnapshots.periodEnd))
-          .limit(1);
+        // Phase 4 C5: shared opening-source resolution with adjacency check.
+        // `previousSnapshot` (below) drives the opening VALUES exactly as before;
+        // `openingResolution` additionally surfaces whether that snapshot chains
+        // cleanly to the period start (warn-only — values are unchanged).
+        const openingResolution = await resolveOpeningSource(startDate);
+        const previousSnapshot = openingResolution.snapshot;
 
         // Hoisted beginning bulk variables for calculated path
         let beginningBulkLiters = 0;
@@ -4336,6 +4448,12 @@ export const ttbRouter = router({
           varianceAnalysis,
           filedDrift,
           beginningInventory,
+          openingSource: {
+            source: openingResolution.source,
+            adjacent: openingResolution.adjacent,
+            gapDays: openingResolution.gapDays,
+          },
+          openingWarnings: openingResolution.warnings,
           wineProduced: {
             total: wineProducedGallons, // Press runs + juice purchases (pommeau juice already included)
           },
@@ -5155,22 +5273,24 @@ export const ttbRouter = router({
     .query(async ({ input }) => {
       try {
         // 1. Check for previous finalized snapshot
-        const [previousSnapshot] = await db
-          .select()
-          .from(ttbPeriodSnapshots)
-          .where(
-            and(
-              eq(ttbPeriodSnapshots.status, "finalized"),
-              lt(ttbPeriodSnapshots.periodEnd, input.periodStart.toISOString().split("T")[0])
-            )
-          )
-          .orderBy(desc(ttbPeriodSnapshots.periodEnd))
-          .limit(1);
+        // Phase 4 C5: shared opening-source resolution with adjacency check.
+        // `openingSource`/`openingWarnings` surface whether the snapshot chains
+        // cleanly to the period start; the returned VALUES are unchanged.
+        const openingResolution = await resolveOpeningSource(input.periodStart);
+        const previousSnapshot = openingResolution.snapshot;
+        const openingSource = {
+          source: openingResolution.source,
+          adjacent: openingResolution.adjacent,
+          gapDays: openingResolution.gapDays,
+        };
+        const openingWarnings = openingResolution.warnings;
 
         if (previousSnapshot) {
           // Use ending inventory from previous finalized snapshot
           return {
             source: "snapshot" as const,
+            openingSource,
+            openingWarnings,
             snapshotId: previousSnapshot.id,
             snapshotPeriodEnd: previousSnapshot.periodEnd,
             bulk: {
@@ -5212,6 +5332,8 @@ export const ttbRouter = router({
             const balances = settings.ttbOpeningBalances;
             return {
               source: "opening_balances" as const,
+              openingSource,
+              openingWarnings,
               openingBalanceDate: settings.ttbOpeningBalanceDate,
               bulk: balances.bulk,
               bottled: balances.bottled,
@@ -5223,6 +5345,8 @@ export const ttbRouter = router({
         // 3. Return zeros if no prior data
         return {
           source: "none" as const,
+          openingSource,
+          openingWarnings,
           bulk: {
             hardCider: 0,
             wineUnder16: 0,

--- a/packages/db/migrations/0148_filed_snapshot_columns.sql
+++ b/packages/db/migrations/0148_filed_snapshot_columns.sql
@@ -1,0 +1,13 @@
+-- Phase 4 C2 (reconciliation-robustness-plan §3): persist the FILED TTB numbers
+-- on their period snapshot so a recomputed period can be compared to what was
+-- actually submitted, flagging NEW drift while tolerating the documented
+-- permanent deltas. `filed_form` = the filed Form 5120.17 values; `expected_drift`
+-- = the owner-accepted recompute-vs-filed deltas. Both sourced from
+-- packages/lib/src/calculations/ttb-filed.ts (seed-filed-snapshots.ts).
+ALTER TABLE ttb_period_snapshots ADD COLUMN is_filed boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE ttb_period_snapshots ADD COLUMN filed_at date;
+--> statement-breakpoint
+ALTER TABLE ttb_period_snapshots ADD COLUMN filed_form jsonb;
+--> statement-breakpoint
+ALTER TABLE ttb_period_snapshots ADD COLUMN expected_drift jsonb;

--- a/packages/db/scripts/seed-filed-snapshots.ts
+++ b/packages/db/scripts/seed-filed-snapshots.ts
@@ -1,0 +1,73 @@
+/**
+ * Seed the FILED TTB numbers onto their period snapshots (Phase 4 C2).
+ *
+ * Sets is_filed / filed_at / filed_form / expected_drift on the already-finalized
+ * 2024 and 2025 annual snapshots. The jsonb payloads come DIRECTLY from the lib
+ * constants (single source of truth — the golden suite's parity guard deep-equals
+ * these rows against the same constants). This script makes NO changes to any
+ * numeric inventory column; it only populates the four columns added by
+ * migration 0148.
+ *
+ * Run from repo root:
+ *   pnpm --filter db exec tsx scripts/seed-filed-snapshots.ts
+ */
+import { eq } from "drizzle-orm";
+import { db, ttbPeriodSnapshots } from "../src/index";
+// Pure constants module (no runtime deps) — imported by source path since the db
+// package does not declare a workspace dependency on lib.
+import {
+  FILED_2024,
+  FILED_2025,
+  EXPECTED_DRIFT_2024,
+  EXPECTED_DRIFT_2025,
+} from "../../lib/src/calculations/ttb-filed";
+
+// The finalized annual snapshot rows to stamp as filed.
+const ROWS = [
+  {
+    id: "fb3964e1-3560-43a1-9ec6-377e9cc1778a",
+    year: 2024,
+    filedAt: "2025-01-13",
+    filedForm: FILED_2024,
+    expectedDrift: EXPECTED_DRIFT_2024,
+  },
+  {
+    id: "f968b31f-7ee7-43bc-9e06-510cfd3920c0",
+    year: 2025,
+    filedAt: "2026-02-27",
+    filedForm: FILED_2025,
+    expectedDrift: EXPECTED_DRIFT_2025,
+  },
+];
+
+async function main() {
+  for (const row of ROWS) {
+    const result = await db
+      .update(ttbPeriodSnapshots)
+      .set({
+        isFiled: true,
+        filedAt: row.filedAt,
+        filedForm: row.filedForm,
+        expectedDrift: row.expectedDrift,
+      })
+      .where(eq(ttbPeriodSnapshots.id, row.id))
+      .returning({ id: ttbPeriodSnapshots.id, year: ttbPeriodSnapshots.year });
+
+    if (result.length === 0) {
+      throw new Error(
+        `Snapshot ${row.id} (year ${row.year}) not found — cannot seed filed data.`,
+      );
+    }
+    console.log(
+      `✅ Stamped filed data on ${row.year} snapshot ${row.id} ` +
+        `(filed_at=${row.filedAt}, expectedDrift entries=${row.expectedDrift.length})`,
+    );
+  }
+  console.log("Done.");
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/db/src/schema/ttb.ts
+++ b/packages/db/src/schema/ttb.ts
@@ -344,6 +344,16 @@ export const ttbPeriodSnapshots = pgTable(
     notes: text("notes"),
     adjustments: text("adjustments"), // JSON string for manual adjustments
 
+    // Filed-snapshot drift detection (migration 0148, Phase 4)
+    // When is_filed, this snapshot records the numbers as SUBMITTED to TTB:
+    // `filedForm` = the filed Form 5120.17 values, `expectedDrift` = the
+    // owner-accepted recompute-vs-filed deltas. A runtime recompute of the
+    // period is compared to these to surface NEW drift only.
+    isFiled: boolean("is_filed").notNull().default(false),
+    filedAt: date("filed_at"),
+    filedForm: jsonb("filed_form"),
+    expectedDrift: jsonb("expected_drift"),
+
     // Audit
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/lib/src/calculations/__tests__/filed-drift.test.ts
+++ b/packages/lib/src/calculations/__tests__/filed-drift.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for the filed-vs-recompute drift comparator (Phase 4 C3).
+ *
+ * Verbose by design: each case states the scenario it exercises so a failure
+ * points straight at the classification rule that broke.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeFiledDrift,
+  DEFAULT_FILED_DRIFT_TOLERANCE,
+} from "../filed-drift";
+import {
+  FILED_2025,
+  EXPECTED_DRIFT_2025,
+  EXPECTED_DRIFT_2024,
+  type ExpectedDriftEntry,
+} from "../ttb-filed";
+
+// --- helpers ---------------------------------------------------------------
+
+/** Set a dot-path on a plain object, creating intermediate objects. */
+function setPath(root: any, path: string, value: number): void {
+  const keys = path.split(".");
+  let cur = root;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const k = keys[i];
+    if (cur[k] == null || typeof cur[k] !== "object") cur[k] = {};
+    cur = cur[k];
+  }
+  cur[keys[keys.length - 1]] = value;
+}
+
+/** Read a dot-path number from a plain object (test-side mirror). */
+function getPath(root: any, path: string): number {
+  let cur = root;
+  for (const k of path.split(".")) cur = cur?.[k];
+  return cur as number;
+}
+
+/**
+ * Build a synthetic recomputed form from a filed form + entries so that each
+ * comparable entry reads exactly `filed + deltaGal` (i.e. the recompute matches
+ * every documented delta perfectly → expected/clean, no new drift).
+ */
+function buildMatchingForm(
+  filed: any,
+  entries: ExpectedDriftEntry[],
+): Record<string, unknown> {
+  const form: Record<string, unknown> = {};
+  for (const e of entries) {
+    if (e.mode === "skip") continue;
+    const filedVal = getPath(filed, e.filedField);
+    if (typeof filedVal !== "number") continue;
+    setPath(form, e.field, filedVal + e.deltaGal);
+  }
+  return form;
+}
+
+// A tiny hand-built entry set for precise unit control.
+const filed = {
+  sectionA: { hardCider: { line29_losses: 100, line31_ending: 200 } },
+  materials: { applesLbs: 60000 },
+};
+const zeroDriftEntry: ExpectedDriftEntry = {
+  label: "Z",
+  field: "a.b",
+  filedField: "sectionA.hardCider.line29_losses",
+  taxClass: "hardCider",
+  section: "A",
+  surface: "form",
+  deltaGal: 0,
+  reason: "test",
+};
+const documentedDriftEntry: ExpectedDriftEntry = {
+  label: "D",
+  field: "a.c",
+  filedField: "sectionA.hardCider.line31_ending",
+  taxClass: "hardCider",
+  section: "A",
+  surface: "form",
+  deltaGal: -50,
+  reason: "test",
+};
+
+// ---------------------------------------------------------------------------
+
+describe("computeFiledDrift — line classification", () => {
+  it('marks a zero-expected line that matches filed as "match" → year "clean"', () => {
+    const form = { a: { b: 100 } }; // equals filed 100, delta 0
+    const res = computeFiledDrift(form, filed, [zeroDriftEntry]);
+    expect(res.lines).toHaveLength(1);
+    expect(res.lines[0].status).toBe("match");
+    expect(res.lines[0].deltaGal).toBe(0);
+    expect(res.lines[0].residualGal).toBe(0);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("clean");
+  });
+
+  it('marks a documented nonzero delta present as expected → "expected" → "expected_only"', () => {
+    const form = { a: { c: 150 } }; // filed 200 + delta -50 = 150
+    const res = computeFiledDrift(form, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("expected");
+    expect(res.lines[0].deltaGal).toBe(-50);
+    expect(res.lines[0].residualGal).toBe(0);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("expected_only");
+  });
+
+  it('flags residual beyond tolerance as "new_drift" → year "new_drift"', () => {
+    const form = { a: { c: 160 } }; // filed 200 + observed delta -40; expected -50 → residual +10
+    const res = computeFiledDrift(form, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("new_drift");
+    expect(res.lines[0].residualGal).toBe(10);
+    expect(res.newDriftCount).toBe(1);
+    expect(res.maxResidualGal).toBe(10);
+    expect(res.status).toBe("new_drift");
+  });
+
+  it("treats residual exactly at tolerance as NOT new drift (boundary, ≤)", () => {
+    const form = { a: { c: 151 } }; // delta -49 vs expected -50 → residual +1 == default tol
+    const res = computeFiledDrift(form, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("expected");
+    expect(res.newDriftCount).toBe(0);
+  });
+
+  it("treats residual just above tolerance as new drift", () => {
+    const form = { a: { c: 151.01 } }; // residual +1.01 > default tol 1.0
+    const res = computeFiledDrift(form, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("new_drift");
+    expect(res.newDriftCount).toBe(1);
+  });
+
+  it("treats a documented delta that vanished (recompute now matches filed) as new drift", () => {
+    // Engine 'fixed' a documented -50 delta: recompute == filed → observed delta 0,
+    // residual = 0 - (-50) = 50 > tol. The documented explanation no longer holds.
+    const form = { a: { c: 200 } };
+    const res = computeFiledDrift(form, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("new_drift");
+    expect(res.lines[0].residualGal).toBe(50);
+  });
+
+  it("honors a per-entry tolerance override (materials, tol 100)", () => {
+    const entry: ExpectedDriftEntry = {
+      label: "M",
+      field: "materials.applesReceivedLbs",
+      filedField: "materials.applesLbs",
+      taxClass: null,
+      section: "materials",
+      surface: "form",
+      deltaGal: -357,
+      tolerance: 100,
+      reason: "test",
+    };
+    // filed 60000 + expected -357 = 59643; recompute 59700 → residual +57 (< 100)
+    const res = computeFiledDrift({ materials: { applesReceivedLbs: 59700 } }, filed, [entry]);
+    expect(res.lines[0].status).toBe("expected");
+    // Same line but residual 150 > 100 → new drift
+    const res2 = computeFiledDrift({ materials: { applesReceivedLbs: 59493 } }, filed, [entry]);
+    expect(res2.lines[0].status).toBe("new_drift");
+  });
+
+  it("uses the default tolerance constant when none is given", () => {
+    expect(DEFAULT_FILED_DRIFT_TOLERANCE).toBe(1.0);
+  });
+});
+
+describe("computeFiledDrift — skip / defensive resolution", () => {
+  it('mode:"skip" entries are always "skipped" and never counted as drift', () => {
+    const skipEntry: ExpectedDriftEntry = { ...documentedDriftEntry, mode: "skip" };
+    // Even with a wildly-off recompute, a skip entry contributes nothing.
+    const res = computeFiledDrift({ a: { c: 9999 } }, filed, [skipEntry]);
+    expect(res.lines[0].status).toBe("skipped");
+    expect(res.lines[0].deltaGal).toBeNull();
+    expect(res.lines[0].residualGal).toBeNull();
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("clean");
+  });
+
+  it('unresolvable recompute path → "skipped" (recomputedGal null)', () => {
+    const res = computeFiledDrift({}, filed, [documentedDriftEntry]);
+    expect(res.lines[0].status).toBe("skipped");
+    expect(res.lines[0].recomputedGal).toBeNull();
+    expect(res.lines[0].filedGal).toBe(200); // filed still resolved
+  });
+
+  it('unresolvable filed path → "skipped" (filedGal null)', () => {
+    const entry: ExpectedDriftEntry = { ...documentedDriftEntry, filedField: "nope.missing" };
+    const res = computeFiledDrift({ a: { c: 150 } }, filed, [entry]);
+    expect(res.lines[0].status).toBe("skipped");
+    expect(res.lines[0].filedGal).toBeNull();
+    expect(res.lines[0].recomputedGal).toBe(150);
+  });
+
+  it("never throws on null / non-object / array-in-path / non-numeric leaves", () => {
+    const weird: ExpectedDriftEntry = {
+      ...zeroDriftEntry,
+      field: "list.0.value", // array indexed by string key → null
+    };
+    expect(() => computeFiledDrift(null, filed, [zeroDriftEntry])).not.toThrow();
+    expect(() => computeFiledDrift(undefined, filed, [zeroDriftEntry])).not.toThrow();
+    expect(() => computeFiledDrift(42, filed, [zeroDriftEntry])).not.toThrow();
+    expect(() => computeFiledDrift("str", filed, [zeroDriftEntry])).not.toThrow();
+    expect(
+      computeFiledDrift({ list: [{ value: 5 }] }, filed, [weird]).lines[0].status,
+    ).toBe("skipped");
+    // non-numeric leaf resolves to null → skipped
+    expect(
+      computeFiledDrift({ a: { b: "100" } }, filed, [zeroDriftEntry]).lines[0].status,
+    ).toBe("skipped");
+    // NaN / Infinity leaves are not finite → skipped
+    expect(
+      computeFiledDrift({ a: { b: NaN } }, filed, [zeroDriftEntry]).lines[0].status,
+    ).toBe("skipped");
+  });
+
+  it("handles an empty expectedDrift array as clean with no lines", () => {
+    const res = computeFiledDrift({}, filed, []);
+    expect(res.lines).toHaveLength(0);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.maxResidualGal).toBe(0);
+    expect(res.status).toBe("clean");
+  });
+});
+
+describe("computeFiledDrift — roll-up status precedence", () => {
+  it("new_drift dominates expected when both present", () => {
+    const form = { a: { b: 100, c: 999 } }; // b matches (match), c is new drift
+    const res = computeFiledDrift(form, filed, [zeroDriftEntry, documentedDriftEntry]);
+    const statuses = res.lines.map((l) => l.status).sort();
+    expect(statuses).toContain("new_drift");
+    expect(res.status).toBe("new_drift");
+  });
+
+  it("maxResidualGal is the largest absolute residual across compared lines", () => {
+    const form = { a: { b: 103, c: 148 } }; // b residual +3, c residual -2
+    const res = computeFiledDrift(form, filed, [zeroDriftEntry, documentedDriftEntry]);
+    expect(res.maxResidualGal).toBe(3);
+  });
+});
+
+describe("computeFiledDrift — against real 2025 constants", () => {
+  const formEntries = EXPECTED_DRIFT_2025.filter((e) => e.surface === "form");
+
+  it("a faithful recompute of every documented delta yields expected_only, 0 new drift", () => {
+    const form = buildMatchingForm(FILED_2025, formEntries);
+    const res = computeFiledDrift(form, FILED_2025, formEntries);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("expected_only");
+    // Every form entry has a nonzero documented delta → all "expected".
+    expect(res.lines.every((l) => l.status === "expected")).toBe(true);
+    expect(res.maxResidualGal).toBeLessThanOrEqual(0.001);
+  });
+
+  it("a single engine change beyond tolerance surfaces exactly one new_drift line", () => {
+    const form = buildMatchingForm(FILED_2025, formEntries);
+    // Perturb HC Line 31 ending by +5 gal (beyond its default 1.0 tolerance).
+    setPath(
+      form,
+      "bulkWinesByTaxClass.hardCider.line31_onHandEnd",
+      getPath(form, "bulkWinesByTaxClass.hardCider.line31_onHandEnd") + 5,
+    );
+    const res = computeFiledDrift(form, FILED_2025, formEntries);
+    expect(res.newDriftCount).toBe(1);
+    expect(res.status).toBe("new_drift");
+    const drifted = res.lines.find((l) => l.status === "new_drift");
+    expect(drifted?.label).toBe("HC Line 31 Ending");
+    expect(drifted?.residualGal).toBeCloseTo(5, 5);
+  });
+
+  it("unresolved form fields (partial form) degrade to skipped, not new drift", () => {
+    // Empty form → nothing resolves → all skipped → clean (no false positives).
+    const res = computeFiledDrift({}, FILED_2025, formEntries);
+    expect(res.lines.every((l) => l.status === "skipped")).toBe(true);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("clean");
+  });
+});
+
+describe("computeFiledDrift — against real 2024 constants", () => {
+  const formEntries = EXPECTED_DRIFT_2024.filter((e) => e.surface === "form");
+
+  it("2024 form entries are all mode:skip → skipped regardless of recompute → clean", () => {
+    // 2024 is not event-sourced; feed a nonsense form and confirm no drift fires.
+    const junkForm = {
+      bulkWinesByTaxClass: {
+        hardCider: { line2_produced: 0, line13_bottled: 0, line16_distillingMaterial: 0, line29_losses: 0 },
+        wineUnder16: { line13_bottled: 0 },
+        wine16To21: { line4_wineSpirits: 0 },
+      },
+    };
+    const res = computeFiledDrift(junkForm, {}, formEntries);
+    expect(res.lines.every((l) => l.status === "skipped")).toBe(true);
+    expect(res.newDriftCount).toBe(0);
+    expect(res.status).toBe("clean");
+  });
+});

--- a/packages/lib/src/calculations/filed-drift.ts
+++ b/packages/lib/src/calculations/filed-drift.ts
@@ -1,0 +1,139 @@
+/**
+ * Filed-vs-recompute drift comparator (Phase 4 C3).
+ *
+ * Compares a recomputed TTB form against the FILED numbers for the same period,
+ * tolerating the documented owner-accepted permanent deltas (EXPECTED_DRIFT_*)
+ * and flagging anything else as NEW drift. This is the runtime realization of
+ * the golden test's static assertion: instead of "recompute == filed + known
+ * delta" checked in CI, it runs at form-generation time so an engine change that
+ * moves a filed line is surfaced to the owner immediately.
+ *
+ * Pure and defensive: unresolvable field paths become "skipped" lines; the
+ * function never throws on shape mismatch.
+ */
+import type { ExpectedDriftEntry } from "./ttb-filed";
+
+/** Per-line comparison outcome. */
+export type FiledDriftLineStatus =
+  | "match" // recompute matches filed (no meaningful drift expected or observed)
+  | "expected" // drift present and matches the documented expected delta
+  | "new_drift" // drift present that the documented delta does NOT explain
+  | "skipped"; // not comparable (mode:"skip" or a value could not be resolved)
+
+/** Roll-up status for the whole period. */
+export type FiledDriftStatus = "clean" | "expected_only" | "new_drift";
+
+export interface FiledDriftLine {
+  label: string;
+  field: string;
+  taxClass: ExpectedDriftEntry["taxClass"];
+  /** Filed value (null when unresolved). */
+  filedGal: number | null;
+  /** Recomputed value (null when unresolved). */
+  recomputedGal: number | null;
+  /** recomputed − filed (null when either side unresolved / skipped). */
+  deltaGal: number | null;
+  /** The documented expected delta for this line. */
+  expectedDeltaGal: number;
+  /** deltaGal − expectedDeltaGal (null when not compared). */
+  residualGal: number | null;
+  status: FiledDriftLineStatus;
+}
+
+export interface FiledDriftResult {
+  lines: FiledDriftLine[];
+  /** Count of lines whose status is "new_drift". */
+  newDriftCount: number;
+  /** Largest absolute residual across compared lines (0 when none compared). */
+  maxResidualGal: number;
+  status: FiledDriftStatus;
+}
+
+/** Default per-line tolerance (gal) when an entry does not specify one. */
+export const DEFAULT_FILED_DRIFT_TOLERANCE = 1.0;
+
+/**
+ * Resolve a dot-path (e.g. "bulkWinesByTaxClass.hardCider.line29_losses")
+ * against a plain object, returning a finite number or null. Never throws —
+ * missing keys, non-objects, arrays-indexed-by-string, and non-numeric leaves
+ * all resolve to null.
+ */
+function resolveNumber(root: unknown, path: string): number | null {
+  if (root == null || typeof root !== "object") return null;
+  let cur: any = root;
+  for (const key of path.split(".")) {
+    if (cur == null || typeof cur !== "object" || Array.isArray(cur)) return null;
+    cur = cur[key];
+  }
+  return typeof cur === "number" && Number.isFinite(cur) ? cur : null;
+}
+
+/**
+ * Compare a recomputed form against its filed form.
+ *
+ * @param formData    the recomputed form/recon object (source of `entry.field`)
+ * @param filedForm   the FILED_* constant for this period (source of `entry.filedField`)
+ * @param expectedDrift the documented EXPECTED_DRIFT_* entries to evaluate
+ */
+export function computeFiledDrift(
+  formData: unknown,
+  filedForm: unknown,
+  expectedDrift: ExpectedDriftEntry[],
+): FiledDriftResult {
+  const lines: FiledDriftLine[] = [];
+  let newDriftCount = 0;
+  let maxResidualGal = 0;
+  let hasExpected = false;
+
+  for (const entry of expectedDrift) {
+    const tolerance = entry.tolerance ?? DEFAULT_FILED_DRIFT_TOLERANCE;
+    const recomputedGal = resolveNumber(formData, entry.field);
+    const filedGal = resolveNumber(filedForm, entry.filedField);
+
+    const base: Omit<FiledDriftLine, "status" | "deltaGal" | "residualGal"> = {
+      label: entry.label,
+      field: entry.field,
+      taxClass: entry.taxClass,
+      filedGal,
+      recomputedGal,
+      expectedDeltaGal: entry.deltaGal,
+    };
+
+    // Not comparable: explicitly skipped, or a value could not be resolved.
+    if (entry.mode === "skip" || recomputedGal === null || filedGal === null) {
+      lines.push({ ...base, deltaGal: null, residualGal: null, status: "skipped" });
+      continue;
+    }
+
+    const deltaGal = recomputedGal - filedGal;
+    const residualGal = deltaGal - entry.deltaGal;
+    const absResidual = Math.abs(residualGal);
+    if (absResidual > maxResidualGal) maxResidualGal = absResidual;
+
+    let status: FiledDriftLineStatus;
+    if (absResidual > tolerance) {
+      // The documented delta does not explain the observed difference.
+      status = "new_drift";
+      newDriftCount++;
+    } else if (Math.abs(entry.deltaGal) <= tolerance) {
+      // Expected ~zero drift, and the recompute indeed matches filed.
+      status = "match";
+    } else {
+      // Documented nonzero drift, present as expected.
+      status = "expected";
+      hasExpected = true;
+    }
+
+    lines.push({ ...base, deltaGal, residualGal, status });
+  }
+
+  const status: FiledDriftStatus =
+    newDriftCount > 0 ? "new_drift" : hasExpected ? "expected_only" : "clean";
+
+  return {
+    lines,
+    newDriftCount,
+    maxResidualGal: Math.round(maxResidualGal * 100) / 100,
+    status,
+  };
+}

--- a/packages/lib/src/calculations/ttb-filed.ts
+++ b/packages/lib/src/calculations/ttb-filed.ts
@@ -1,0 +1,454 @@
+/**
+ * TTB Filed Numbers — source of truth for the already-submitted annual filings.
+ *
+ * Phase 4 (docs/reconciliation-robustness-plan.md §3) moves the filed 2024/2025
+ * Form 5120.17 numbers out of the golden test (where they lived as hardcoded
+ * expectations) and into a single shared module. They are then:
+ *   - imported by the golden test (which derives its KNOWN_DELTA map from the
+ *     EXPECTED_DRIFT entries — zero behavioral change),
+ *   - seeded into `ttb_period_snapshots` (migration 0148 columns) so a
+ *     recomputed period can be compared to what was filed at runtime,
+ *   - consumed by `computeFiledDrift` (filed-drift.ts) to flag NEW drift while
+ *     tolerating the documented, owner-accepted permanent deltas below.
+ *
+ * ANCHOR (plan §0): the filed 2024 & 2025 reports are the source of truth. We
+ * recompute honestly and *compare* — we never overwrite the filed numbers. When
+ * a recompute diverges from filed for a documented reason (the fall-2025 backlog
+ * booked with 2026 event dates; 2024 predating full event capture), that
+ * divergence is an EXPECTED_DRIFT entry, not a new problem. If a delta appears
+ * that is NOT in these arrays, the engine changed and must be investigated.
+ *
+ * FILED_* values are copied verbatim from the verified filings:
+ *   2024 filed 2025-01-13; 2025 filed 2026-02-27.
+ */
+
+// ---------------------------------------------------------------------------
+// Filed form shapes (values only — the numbers as submitted to TTB)
+// ---------------------------------------------------------------------------
+
+/**
+ * FILED_2025 mirrors the verified 2025 Form 5120.17 PDF, structured exactly as
+ * the golden test's former local `PDF` constant so the golden test can consume
+ * it directly (`const PDF = FILED_2025`).
+ */
+export const FILED_2025 = {
+  sectionA: {
+    hardCider: {
+      line1_opening: 1061.0,
+      line2_produced: 4807.7,
+      line10_changeOfClassIn: 5.0,
+      line12_totalIn: 5873.7,
+      line13_packaged: 148.9,
+      line16_distillation: 753.2,
+      line24_changeOfClassOut: 641.4, // perry no longer cross-class (cider→perry are both hardCider)
+      line29_losses: 238.2, // all losses: bulk + bottling. Line 30 reserved for physical inventory shortages only. +5 gal from distillery adj.
+      line31_ending: 4092.3, // LIVE currentVolumeLiters — after data fixes
+      line32_totalOut: 5873.7,
+    },
+    wineUnder16: {
+      line1_opening: 0.0,
+      line2_produced: 56.2,
+      line10_changeOfClassIn: 641.4, // perry no longer cross-class (cider→perry are both hardCider)
+      line12_totalIn: 697.6, // adjusted for perry classification
+      line13_packaged: 628.2,
+      line24_changeOfClassOut: 5.0,
+      line29_losses: 46.6, // all losses: bulk + bottling. Line 30 reserved for physical inventory shortages only.
+      line31_ending: 17.9,
+      line32_totalOut: 697.6, // adjusted for perry classification
+    },
+    wine16To21: {
+      line1_opening: 60.0,
+      line4_wineSpirits: 119.0,
+      line12_totalIn: 179.0,
+      line13_packaged: 55.2,
+      line29_losses: 1.5, // all losses: bulk (1.3) + bottling (0.2). Line 30 reserved for physical inventory shortages only.
+      line31_ending: 122.3,
+      line32_totalOut: 179.0,
+    },
+  },
+  sectionB: {
+    hardCider: {
+      line2_bottledFromBulk: 148.9,
+      line8_removedTaxPaid: 148.9,
+      line20_endingBottled: 0.0,
+    },
+    wineUnder16: {
+      line2_bottledFromBulk: 628.2,
+      line8_removedTaxPaid: 566.3,
+      line20_endingBottled: 61.9,
+    },
+    wine16To21: {
+      line2_bottledFromBulk: 55.2,
+      line8_removedTaxPaid: 55.2,
+      line20_endingBottled: 0.0,
+    },
+  },
+  materials: {
+    applesLbs: 63299,
+    juiceGal: 3872,
+    otherFruitLbs: 786,
+    sugarLbs: 40,
+  },
+  brandy: {
+    receivedGal: 55.0,
+    receivedProofGal: 77.0,
+    usedGal: 29.9,
+    usedProofGal: 41.9,
+    remainingGal: 25.1,
+    remainingProofGal: 35.1,
+  },
+} as const;
+
+/**
+ * FILED_2024 mirrors the verified 2024 Form 5120.17 (filed 2025-01-13).
+ * Source: the FILED table in docs/reconciliation-phase0-report.md §C and the
+ * FILED constant in packages/api/scripts/phase0-recon-diagnostic.ts.
+ *
+ * 2024 predates full event capture, so the flow lines are NOT reproducible from
+ * events (see EXPECTED_DRIFT_2024 — every flow line is mode:"skip"). Only the
+ * endings are meaningful, and even those carry documented reconstruction drift.
+ */
+export const FILED_2024 = {
+  sectionA: {
+    hardCider: {
+      line1_opening: 0,
+      line2_produced: 1496,
+      line13_bottled: 90,
+      line16_distilling: 264,
+      line20_blending: 42,
+      line29_losses: 39,
+      line31_ending: 1061,
+      line32_total: 1496,
+    },
+    wineUnder16: {
+      line1_opening: 0,
+      line5_blending: 127,
+      line13_bottled: 127,
+      line29_losses: 0,
+      line31_ending: 0,
+      line32_total: 127,
+    },
+    wine16To21: {
+      line1_opening: 0,
+      line4_spirits: 60,
+      line29_losses: 0,
+      line31_ending: 60,
+      line32_total: 60,
+    },
+  },
+  totals: { bulkEnding: 1121, packagedEnding: 0, onPremisesEnding: 1121 },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Expected-drift entries (recompute-vs-filed permanent deltas)
+// ---------------------------------------------------------------------------
+
+/** Which surface the drift is observed on. */
+export type FiledDriftSurface = "form" | "checkpoint";
+
+/**
+ * How the comparator treats the entry:
+ * - "compare" (default): recompute is expected to differ from filed by
+ *   ~`deltaGal`; residual = (recompute − filed) − deltaGal must stay within
+ *   tolerance or it becomes NEW drift.
+ * - "skip": the line is not reproducible from events (e.g. a pre-event-capture
+ *   year); do not compare it at all.
+ */
+export type FiledDriftMode = "compare" | "skip";
+
+/**
+ * One documented, owner-accepted difference between the recomputed form and the
+ * filed number. `deltaGal = recomputed − filed` (rounded to 0.1 gal).
+ */
+export interface ExpectedDriftEntry {
+  /** Human label — matches the golden test assertion label exactly. */
+  label: string;
+  /** Dot-path into the recomputed form/recon result for this value. */
+  field: string;
+  /** Dot-path into the FILED_* constant for the corresponding filed value. */
+  filedField: string;
+  /** Tax class this line belongs to (null for cross-class totals/materials). */
+  taxClass:
+    | "hardCider"
+    | "wineUnder16"
+    | "wine16To21"
+    | "carbonatedWine"
+    | "sparklingWine"
+    | null;
+  /** Form section the line lives on: "A" bulk, "B" bottled, or a memo group. */
+  section: "A" | "B" | "materials" | "waterfall";
+  surface: FiledDriftSurface;
+  /** recomputed − filed (gal). Ignored when mode === "skip". */
+  deltaGal: number;
+  /** Comparison tolerance in gal (defaults to 1.0 in the comparator). */
+  tolerance?: number;
+  mode?: FiledDriftMode;
+  /** Why this delta exists — the audit trail for the owner decision. */
+  reason: string;
+}
+
+/**
+ * 2025 permanent deltas — the golden test's former KNOWN_DELTA map, verbatim
+ * values, now with `field`/`filedField` paths + reasons. Cause (owner decision
+ * 2026-07-20, no re-dating / no amended filing): the fall-2025 production backlog
+ * was data-entered in 2026 with 2026-dated events, so filed numbers reflect
+ * physical reality while the recompute reflects events exactly as entered.
+ *
+ * The two waterfall-opening entries are surface:"checkpoint" (they come from the
+ * reconciliation waterfall, not the form).
+ */
+export const EXPECTED_DRIFT_2025: ExpectedDriftEntry[] = [
+  {
+    label: "HC Line 29 Losses",
+    field: "bulkWinesByTaxClass.hardCider.line29_losses",
+    filedField: "sectionA.hardCider.line29_losses",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 15.4, // actual 253.6 (recorded losses) vs filed 238.2
+    reason:
+      "Line 29 is now the REAL recorded operational losses (de-plugged, Phase 3 C2), not a balance-forcing plug. Small recorded-loss difference vs filed.",
+  },
+  {
+    label: "HC Line 31 Ending",
+    field: "bulkWinesByTaxClass.hardCider.line31_onHandEnd",
+    filedField: "sectionA.hardCider.line31_ending",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: -1156.1, // actual 2936.2 vs filed 4092.3
+    reason:
+      "Recompute counts fall-2025 volume as still-on-hand (booked 2026) rather than lost/ended in 2025, deflating Line 31 ending by ~1.15k gal.",
+  },
+  {
+    label: "HC Line 12 Total In",
+    field: "bulkWinesByTaxClass.hardCider.line12_total",
+    filedField: "sectionA.hardCider.line12_totalIn",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 1.6, // actual 5875.3 vs filed 5873.7
+    reason: "Rounding of backlog inflows.",
+  },
+  {
+    label: "W<16 Line 13 Packaged",
+    field: "bulkWinesByTaxClass.wineUnder16.line13_bottled",
+    filedField: "sectionA.wineUnder16.line13_packaged",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "form",
+    deltaGal: -35.5, // actual 592.7 vs filed 628.2
+    reason: "Plum/quince packaging booked 2026, so less packaged in 2025.",
+  },
+  {
+    label: "W<16 Line 29 Losses",
+    field: "bulkWinesByTaxClass.wineUnder16.line29_losses",
+    filedField: "sectionA.wineUnder16.line29_losses",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "form",
+    deltaGal: -9.5, // actual 37.1 (recorded losses) vs filed 46.6
+    reason:
+      "Line 29 = real recorded losses (37.1), not the former plug; difference now honest unexplained variance elsewhere.",
+  },
+  {
+    label: "W<16 Line 31 Ending",
+    field: "bulkWinesByTaxClass.wineUnder16.line31_onHandEnd",
+    filedField: "sectionA.wineUnder16.line31_ending",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "form",
+    deltaGal: -5.0, // actual 12.9 vs filed 17.9
+    reason: "Mirror of the plum/quince packaging booked in 2026.",
+  },
+  {
+    label: "W<16 Line 12 Total In",
+    field: "bulkWinesByTaxClass.wineUnder16.line12_total",
+    filedField: "sectionA.wineUnder16.line12_totalIn",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "form",
+    deltaGal: -22.4, // actual 675.2 vs filed 697.6
+    reason: "Fruited-cider inflow booked 2026.",
+  },
+  {
+    label: "W<16-B Line 2 Bottled",
+    field: "bottledWinesByTaxClass.wineUnder16.line2_bottled",
+    filedField: "sectionB.wineUnder16.line2_bottledFromBulk",
+    taxClass: "wineUnder16",
+    section: "B",
+    surface: "form",
+    deltaGal: -35.5, // actual 592.7 vs filed 628.2 (same event as Line 13)
+    reason: "Same plum/quince packaging event as Section A Line 13.",
+  },
+  {
+    label: "W<16-B Line 20 Ending",
+    field: "bottledWinesByTaxClass.wineUnder16.line20_onHandEnd",
+    filedField: "sectionB.wineUnder16.line20_endingBottled",
+    taxClass: "wineUnder16",
+    section: "B",
+    surface: "form",
+    deltaGal: -35.5, // actual 26.4 vs filed 61.9
+    reason: "Mirror of the plum/quince packaging booked 2026.",
+  },
+  {
+    label: "W16-21 Line 12 Total In",
+    field: "bulkWinesByTaxClass.wine16To21.line12_total",
+    filedField: "sectionA.wine16To21.line12_totalIn",
+    taxClass: "wine16To21",
+    section: "A",
+    surface: "form",
+    deltaGal: 45.7, // actual 224.7 vs filed 179.0
+    reason: "Extra 2025 blend inflow present in recompute (pommeau scope).",
+  },
+  {
+    label: "Materials Apples (lbs)",
+    field: "materials.applesReceivedLbs",
+    filedField: "materials.applesLbs",
+    taxClass: null,
+    section: "materials",
+    surface: "form",
+    deltaGal: -357.0, // actual 62942 vs filed 63299 (lbs, not gal)
+    tolerance: 100,
+    reason:
+      "Apple weight off by one small backlog receipt (value is lbs, wide tolerance).",
+  },
+  {
+    label: "Waterfall total opening",
+    field: "waterfall.totals.opening",
+    filedField: "totals.onPremisesEnding",
+    taxClass: null,
+    section: "waterfall",
+    surface: "checkpoint",
+    deltaGal: -9.8, // actual 1111.3 vs filed 1121.0
+    tolerance: 5,
+    reason:
+      "SBD reconstruction of Dec-31-2024 carried-forward batches runs ~10 gal below filed opening (reconstruction drift, permanent without re-dating history).",
+  },
+  {
+    label: "HC waterfall opening",
+    field: "waterfall.byTaxClass.hardCider.opening",
+    filedField: "sectionA.hardCider.line1_opening",
+    taxClass: "hardCider",
+    section: "waterfall",
+    surface: "checkpoint",
+    deltaGal: -10.2, // actual 1051.8 vs filed 1062.0
+    tolerance: 5,
+    reason: "Same opening reconstruction drift, hard-cider slice.",
+  },
+];
+
+/**
+ * 2024 permanent deltas. 2024 predates full event capture, so every flow line is
+ * mode:"skip" (not reproducible from events — the recompute produces near-zero
+ * flows against filed hundreds/thousands). Only the endings are compared, and
+ * they carry documented reconstruction drift. Endings are surface:"checkpoint"
+ * (internal reconstruction signal) — the 2024 form itself is frozen via its
+ * filed snapshot, never recomputed for filing (plan Phase 4 "freeze, not
+ * backfill").
+ */
+export const EXPECTED_DRIFT_2024: ExpectedDriftEntry[] = [
+  // --- Flow lines: not event-sourced, skip entirely ---
+  {
+    label: "HC Line 2 Produced",
+    field: "bulkWinesByTaxClass.hardCider.line2_produced",
+    filedField: "sectionA.hardCider.line2_produced",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 predates full event capture (recompute ~508 vs filed 1496).",
+  },
+  {
+    label: "HC Line 13 Bottled",
+    field: "bulkWinesByTaxClass.hardCider.line13_bottled",
+    filedField: "sectionA.hardCider.line13_bottled",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 not event-sourced (recompute 0 vs filed 90).",
+  },
+  {
+    label: "HC Line 16 Distilling",
+    field: "bulkWinesByTaxClass.hardCider.line16_distillingMaterial",
+    filedField: "sectionA.hardCider.line16_distilling",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 not event-sourced (recompute 0 vs filed 264).",
+  },
+  {
+    label: "HC Line 29 Losses (2024)",
+    field: "bulkWinesByTaxClass.hardCider.line29_losses",
+    filedField: "sectionA.hardCider.line29_losses",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 not event-sourced (filed 39).",
+  },
+  {
+    label: "W<16 Line 13 Bottled (2024)",
+    field: "bulkWinesByTaxClass.wineUnder16.line13_bottled",
+    filedField: "sectionA.wineUnder16.line13_bottled",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 not event-sourced (filed 127).",
+  },
+  {
+    label: "W16-21 Line 4 Spirits (2024)",
+    field: "bulkWinesByTaxClass.wine16To21.line4_wineSpirits",
+    filedField: "sectionA.wine16To21.line4_spirits",
+    taxClass: "wine16To21",
+    section: "A",
+    surface: "form",
+    deltaGal: 0,
+    mode: "skip",
+    reason: "2024 not event-sourced (filed 60).",
+  },
+  // --- Endings: documented reconstruction drift on the frozen year ---
+  {
+    label: "HC Line 31 Ending (2024)",
+    field: "bulkWinesByTaxClass.hardCider.line31_onHandEnd",
+    filedField: "sectionA.hardCider.line31_ending",
+    taxClass: "hardCider",
+    section: "A",
+    surface: "checkpoint",
+    deltaGal: -9.2, // recompute 1051.8 vs filed 1061
+    tolerance: 5,
+    reason:
+      "SBD reconstruction of carried-forward batches runs ~9 gal below filed HC ending.",
+  },
+  {
+    label: "W<16 Line 31 Ending (2024)",
+    field: "bulkWinesByTaxClass.wineUnder16.line31_onHandEnd",
+    filedField: "sectionA.wineUnder16.line31_ending",
+    taxClass: "wineUnder16",
+    section: "A",
+    surface: "checkpoint",
+    deltaGal: 197.9, // recompute 197.9 vs filed 0
+    tolerance: 5,
+    reason:
+      "Classification difference (not volume creation): perry/fruited volume the filing carried elsewhere lands in wineUnder16 on recompute.",
+  },
+  {
+    label: "W16-21 Line 31 Ending (2024)",
+    field: "bulkWinesByTaxClass.wine16To21.line31_onHandEnd",
+    filedField: "sectionA.wine16To21.line31_ending",
+    taxClass: "wine16To21",
+    section: "A",
+    surface: "checkpoint",
+    deltaGal: -0.6, // recompute 59.4 vs filed 60
+    tolerance: 5,
+    reason: "Minor reconstruction drift on wine16To21 ending.",
+  },
+];

--- a/packages/lib/src/calculations/ttb.ts
+++ b/packages/lib/src/calculations/ttb.ts
@@ -801,6 +801,34 @@ export interface TTBVarianceAnalysis {
 /**
  * Complete TTB Form 5120.17 data structure
  */
+/** Which prior-period source seeds a period's opening inventory. */
+export type TTBOpeningSourceType = "snapshot" | "ttb_opening_balance" | "calculated";
+
+/**
+ * Warn-only diagnostic about how a period's opening inventory was seeded.
+ * Never blocks form generation — surfaces facts the reviewer should see.
+ */
+export interface TTBOpeningWarning {
+  level: "warning";
+  /**
+   * `openingGap` — opening came from a snapshot that does NOT end the day
+   * before the period start, so the uncovered span is silently dropped.
+   * `openingReconstructed` — opening was reconstructed/manually seeded while a
+   * draft (un-finalized) prior-period snapshot exists that should be finalized.
+   */
+  category: "openingGap" | "openingReconstructed";
+  message: string;
+}
+
+/** How a period's opening inventory was resolved (surfaced, not enforced). */
+export interface TTBOpeningSourceInfo {
+  source: TTBOpeningSourceType;
+  /** True iff the snapshot's periodEnd is exactly the day before period start. */
+  adjacent: boolean;
+  /** Days between the snapshot's periodEnd and the day before period start. */
+  gapDays: number;
+}
+
 export interface TTBForm512017Data {
   /** Reporting period information */
   reportingPeriod: TTBReportingPeriod;
@@ -873,6 +901,19 @@ export interface TTBForm512017Data {
    * drift (status "new_drift" with newDriftCount > 0).
    */
   filedDrift?: FiledDriftResult;
+
+  /**
+   * Phase 4 C5: how this period's opening inventory was resolved (snapshot /
+   * manual seed / reconstructed) and whether the snapshot chains cleanly to the
+   * period start. Informational — the opening VALUES are unchanged by this.
+   */
+  openingSource?: TTBOpeningSourceInfo;
+
+  /**
+   * Phase 4 C5: warn-only diagnostics about the opening chain (e.g. a
+   * non-adjacent snapshot leaving an uncovered gap). Empty/absent when clean.
+   */
+  openingWarnings?: TTBOpeningWarning[];
 
   /** Distillery operations (cider sent, brandy received) */
   distilleryOperations?: DistilleryOperations;

--- a/packages/lib/src/calculations/ttb.ts
+++ b/packages/lib/src/calculations/ttb.ts
@@ -7,6 +7,8 @@
  * @see https://www.ttb.gov/forms/f512017.pdf
  */
 
+import type { FiledDriftResult } from "./filed-drift";
+
 // ============================================
 // Constants
 // ============================================
@@ -863,6 +865,14 @@ export interface TTBForm512017Data {
    * the unexplained variance.
    */
   varianceAnalysis?: TTBVarianceAnalysis;
+
+  /**
+   * Phase 4: filed-vs-recompute drift. Present only when an is_filed snapshot
+   * covers the requested annual period. Compares the recomputed form to the
+   * FILED numbers, tolerating the documented permanent deltas and flagging NEW
+   * drift (status "new_drift" with newDriftCount > 0).
+   */
+  filedDrift?: FiledDriftResult;
 
   /** Distillery operations (cider sent, brandy received) */
   distilleryOperations?: DistilleryOperations;

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -19,6 +19,8 @@ export * from "./calculations/batch-volume";
 export * from "./calculations/sugar";
 export * from "./calculations/pasteurization";
 export * from "./calculations/ttb";
+export * from "./calculations/ttb-filed";
+export * from "./calculations/filed-drift";
 export * from "./calculations/so2";
 
 // Re-export recipe domain logic (client-safe)


### PR DESCRIPTION
## Summary

Your officially filed 2024/2025 TTB numbers are now durable, guarded data — and any NEW divergence from them is an alarm, in CI and on screen.

**Filed numbers as data (C1–C2):** one canonical source (`packages/lib/src/calculations/ttb-filed.ts`: filed line values + every documented expected delta with its reason) materialized onto the two finalized snapshots (migration 0148: `is_filed`/`filed_at`/`filed_form`/`expected_drift`). A golden describe block deep-equals DB against constants — divergence fails CI. Golden suite now 75/75.

**Runtime drift alarms (C3–C4):** `computeFiledDrift` (19 unit tests) runs on every form generation for a filed year, classifying each line match / expected / new-drift / skipped. Verified live: 2024 = clean (flow lines skipped per the freeze decision), 2025 = expected_only with 0.05 gal max residual. New drift on a filed year renders a red 'recompute has drifted from the filed form' state.

**Opening-source consistency (C5–C6):** one shared `resolveOpeningSource` with adjacency checking and warn-only gap warnings; 3-state Filed-comparison badge + per-line table in TTBFormPreview and the reports page.

**Pommeau methodology v2, 2026+ (C7):** the filed methodology double-counted transfer-built pommeau cider (line 4 + line 10 — baked into filed 2025 line 4 = 119, zero tax impact). Fixed prospectively (period-gated like the origin-year guard): cider books once as change-of-class, brandy on line 4. 2026 pommeau gap +29.6 → +3.96; **2026 form variance 40.3 → 14.7 gal**; 2024/2025 byte-identical.

**Packaged-ledger unification (C8):** one per-run packaged basis shared by bulk + checkpoint (outputs byte-identical) — which proves the remaining hardCider −13.3 checkpoint residual is a packaging-loss basis difference (bulk gross vs ledger net), now a precisely-named follow-up.

**Gates on every commit:** diagnostic 21/49/57 (0 fails), golden 75/75, parity 14/14, typechecks clean. Migration 0148 applied + seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)