### PR TITLE
Hotfix: /recipes Suspense boundary — restores production deploys

### DIFF
--- a/apps/web/src/app/recipes/page.tsx
+++ b/apps/web/src/app/recipes/page.tsx
@@ -11,7 +11,7 @@
  * the permission, but the server is the source of truth.
  */
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -89,6 +89,18 @@ function statusBadgeClass(status: string): string {
 }
 
 export default function RecipesPage() {
+  // useSearchParams (in the inner component) requires a Suspense boundary for
+  // static prerender — without it `next build` fails on this page and EVERY
+  // Vercel deploy dies (which silently pinned production to a stale build
+  // from 2026-07-20 until this fix).
+  return (
+    <Suspense fallback={null}>
+      <RecipesPageInner />
+    </Suspense>
+  );
+}
+
+function RecipesPageInner() {
   const { data: session } = useSession();
   const user = session?.user as
     | { role?: string; permissionOverrides?: Record<string, boolean> }


### PR DESCRIPTION
One-file fix: `useSearchParams` in /recipes without a Suspense boundary has failed `next build` — and therefore every Vercel deploy — since PR #117 merged on 2026-07-20. Production (ciderpilot.com) has been serving a stale build from before the rebrand and all reconciliation work; the client-side exception the owner hit on the admin page is old code.

After this merges and Vercel deploys: six days of merged work goes live at once (PRs #117–#122).

Build verified locally: ✓ 44/44 pages generate. (A non-fatal `location is not defined` SSR warning remains — tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)