### PR TITLE
Recipe split-path sync, split-batch naming, and cellar UX fixes

### DIFF
--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -487,7 +487,8 @@ export default function ReportsPage() {
                     <SelectItem value="all">All Batches</SelectItem>
                     {batchList.map((batch) => (
                       <SelectItem key={batch.id} value={batch.id}>
-                        {batch.name}
+                        {batch.customName || batch.name}
+                        {batch.vesselName ? ` · ${batch.vesselName}` : ""}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/web/src/components/admin/BatchLifecycleAudit.tsx
+++ b/apps/web/src/components/admin/BatchLifecycleAudit.tsx
@@ -213,7 +213,8 @@ export function BatchLifecycleAudit({
                     {batchList?.batches && batchList.batches.length > 0 ? (
                       batchList.batches.map((batch) => (
                         <SelectItem key={batch.id} value={batch.id}>
-                          {batch.customName || batch.name} ({batch.productType})
+                          {batch.customName || batch.name}
+                          {batch.vesselName ? ` · ${batch.vesselName}` : ""} ({batch.productType})
                         </SelectItem>
                       ))
                     ) : (

--- a/apps/web/src/components/cellar/CreateFortifiedBlendDialog.tsx
+++ b/apps/web/src/components/cellar/CreateFortifiedBlendDialog.tsx
@@ -178,10 +178,11 @@ export function CreateFortifiedBlendDialog({
     }
   };
 
-  // Get batch display name
-  const getBatchDisplayName = (batch: { customName: string | null; name: string; currentVolume?: string | null }) => {
+  // Get batch display name - includes current vessel to disambiguate same-named batches
+  const getBatchDisplayName = (batch: { customName: string | null; name: string; currentVolume?: string | null; vesselName?: string | null }) => {
     const vol = parseFloat(batch.currentVolume || "0").toFixed(1);
-    return `${batch.customName || batch.name} (${vol}L)`;
+    const vessel = batch.vesselName ? ` · ${batch.vesselName}` : "";
+    return `${batch.customName || batch.name}${vessel} (${vol}L)`;
   };
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/apps/web/src/components/cellar/CreatePommeauBlendDialog.tsx
+++ b/apps/web/src/components/cellar/CreatePommeauBlendDialog.tsx
@@ -307,7 +307,8 @@ export function CreatePommeauBlendDialog({
                       const abvLabel = abv === 0 ? "Fresh juice" : `${abv.toFixed(1)}% ABV`;
                       return (
                         <SelectItem key={batch.id} value={batch.id}>
-                          {batch.name} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L, {abvLabel})
+                          {batch.customName || batch.name}
+                          {batch.vesselName ? ` · ${batch.vesselName}` : ""} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L, {abvLabel})
                         </SelectItem>
                       );
                     })
@@ -393,7 +394,8 @@ export function CreatePommeauBlendDialog({
                   ) : (
                     brandyBatches.map((batch) => (
                       <SelectItem key={batch.id} value={batch.id}>
-                        {batch.name} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L,{" "}
+                        {batch.customName || batch.name}
+                        {batch.vesselName ? ` · ${batch.vesselName}` : ""} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L,{" "}
                         {batch.actualAbv || "?"}% ABV)
                       </SelectItem>
                     ))

--- a/apps/web/src/components/cellar/RackingModal.tsx
+++ b/apps/web/src/components/cellar/RackingModal.tsx
@@ -358,7 +358,7 @@ export function RackingModal({
                             )}
                             {hasBatch && !isCurrentVessel && (
                               <Badge variant="secondary" className="text-xs">
-                                In Use
+                                {vessel.batchCustomName || vessel.batchNumber || "In Use"}
                               </Badge>
                             )}
                             {isEmpty && (

--- a/apps/web/src/components/cellar/SendToDistilleryDialog.tsx
+++ b/apps/web/src/components/cellar/SendToDistilleryDialog.tsx
@@ -175,12 +175,12 @@ export function SendToDistilleryDialog({
     });
   };
 
-  // Get batch display name - prefer customName, fall back to name
+  // Get batch display name - prefer customName, fall back to name; always show current vessel
   const getBatchDisplayName = (batchId: string) => {
     const batch = availableBatches.find(b => b.id === batchId);
     if (!batch) return "Loading...";
-    // Prefer customName if it exists, otherwise use name
-    return batch.customName || batch.name;
+    const base = batch.customName || batch.name;
+    return batch.vesselName ? `${base} · ${batch.vesselName}` : base;
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -292,7 +292,8 @@ export function SendToDistilleryDialog({
                           ) : (
                             availableOptions.map((batch) => (
                               <SelectItem key={batch.id} value={batch.id}>
-                                {batch.customName || batch.name} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L)
+                                {batch.customName || batch.name}
+                                {batch.vesselName ? ` · ${batch.vesselName}` : ""} ({parseFloat(batch.currentVolume || "0").toFixed(1)}L)
                               </SelectItem>
                             ))
                           )}

--- a/apps/web/src/components/cellar/TankTransferForm.tsx
+++ b/apps/web/src/components/cellar/TankTransferForm.tsx
@@ -430,6 +430,8 @@ export function TankTransferForm({
                         {hasLiquid && (
                           <span className="text-xs text-orange-600 font-medium">
                             • Contains {vesselCurrentVolume.toFixed(1)} {capacityUnit}
+                            {(vesselLiquidMap?.batchCustomName || vesselLiquidMap?.batchNumber) &&
+                              ` · ${vesselLiquidMap.batchCustomName || vesselLiquidMap.batchNumber}`}
                           </span>
                         )}
                       </span>

--- a/apps/web/src/components/dashboard/widgets/RecentActivityWidget.tsx
+++ b/apps/web/src/components/dashboard/widgets/RecentActivityWidget.tsx
@@ -98,7 +98,12 @@ export function RecentActivityWidget({ compact, onRefresh }: WidgetProps) {
           // Only link if the record still exists (not soft-deleted) and the
           // table has a sensible destination page.
           const href = item.linkable ? hrefFor(item.tableName, item.recordId) : null;
-          const when = formatDistanceToNow(new Date(item.changedAt), { addSuffix: true });
+          // Show when the event physically happened (occurredAt), not when it
+          // was entered — backdated entries would otherwise all read "today".
+          const when = formatDistanceToNow(
+            new Date(item.occurredAt ?? item.changedAt),
+            { addSuffix: true },
+          );
 
           const row = (
             <div

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -175,6 +175,15 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
 
   const { execution } = data;
   const tasks = data.tasks as Task[];
+  // Steps completed on a related batch (a transfer split clones the checklist
+  // onto the child). The server pairs this batch's open bottle/keg-path steps
+  // against family completions; these render as done instead of overdue.
+  const fulfilledBy = (data.fulfilledBy ?? {}) as Record<
+    string,
+    { batchId: string; batchLabel: string; completedAt: string | Date | null }
+  >;
+  const actuals = data.packagedActuals ?? { bottledL: 0, keggedL: 0 };
+  const fmtVol = (v: number) => (Math.round(v * 10) / 10).toString();
   // Keg-label details (shown on the "Label Kegs" step). Keg size comes from the
   // keg Package step's planned container size.
   const kegSizeML = tasks.find((t) => t.kind === "package" && t.packagingPath === "keg")
@@ -184,8 +193,10 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
     abv: (batchData?.actualAbv ?? batchData?.estimatedAbv) ?? null,
     kegSizeL: typeof kegSizeML === "number" ? kegSizeML / 1000 : null,
   };
-  const done = tasks.filter((t) => t.status === "done").length;
-  const openBySeq = tasks.filter((t) => t.status === "pending" || t.status === "in_progress");
+  const done = tasks.filter((t) => t.status === "done" || fulfilledBy[t.id]).length;
+  const openBySeq = tasks.filter(
+    (t) => (t.status === "pending" || t.status === "in_progress") && !fulfilledBy[t.id],
+  );
 
   // Sorted by recipe step order. The due-date column still shifts as steps are
   // completed (rescheduleWithActuals), but the rows stay in the recipe's logical
@@ -194,16 +205,18 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
 
   // The single "do this next" step: earliest non-terminal, non-blocked step.
   const nextReadyId = sorted.find(
-    (t) => t.status !== "done" && t.status !== "skipped" && !blockedReason(t),
+    (t) =>
+      t.status !== "done" && t.status !== "skipped" && !fulfilledBy[t.id] && !blockedReason(t),
   )?.id;
   const isOverdue = (t: Task) => {
     if (t.status === "done" || t.status === "skipped" || !t.scheduledDate) return false;
+    if (fulfilledBy[t.id]) return false;
     const end = new Date(t.scheduledDate);
     end.setHours(23, 59, 59, 999);
     return end.getTime() < Date.now();
   };
   const rowStatus = (t: Task): RowStatus => {
-    if (t.status === "done") return "done";
+    if (t.status === "done" || fulfilledBy[t.id]) return "done";
     if (t.status === "skipped") return "skipped";
     if (blockedReason(t)) return "blocked";
     if (isOverdue(t)) return "overdue";
@@ -255,7 +268,8 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
     const toReopen: Task[] = [];
     const wantSkipped = (steps: Task[]) =>
       steps.forEach((t) => {
-        if (t.status !== "skipped" && t.status !== "done") toSkip.push(t);
+        // A step fulfilled on a related batch reads as done — don't skip it.
+        if (t.status !== "skipped" && t.status !== "done" && !fulfilledBy[t.id]) toSkip.push(t);
       });
     const wantActive = (steps: Task[]) =>
       steps.forEach((t) => {
@@ -284,8 +298,9 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
       <CardHeader>
         <CardTitle className="text-base">Recipe checklist</CardTitle>
         <CardDescription>
-          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)} ·{" "}
-          {execution.bottleVolumeL ?? 0} L bottled / {execution.kegVolumeL ?? 0} L kegged ·{" "}
+          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)} · bottled{" "}
+          {fmtVol(actuals.bottledL)} of {Number(execution.bottleVolumeL ?? 0)} L · kegged{" "}
+          {fmtVol(actuals.keggedL)} of {Number(execution.kegVolumeL ?? 0)} L ·{" "}
           {done}/{tasks.length} done · in recipe order
         </CardDescription>
       </CardHeader>
@@ -343,18 +358,33 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           </TableHeader>
           <TableBody>
             {sorted.map((t) => {
+              const fulfilled = fulfilledBy[t.id];
               const terminal = t.status === "done" || t.status === "skipped";
               const rs = rowStatus(t);
               return (
                 <TableRow
                   key={t.id}
                   onClick={() => openStep(t)}
-                  className={`cursor-pointer hover:bg-gray-50 ${ROW_ACCENT[rs]} ${terminal ? "opacity-60" : ""}`}
+                  className={`cursor-pointer hover:bg-gray-50 ${ROW_ACCENT[rs]} ${terminal || fulfilled ? "opacity-60" : ""}`}
                 >
                   <TableCell className="text-muted-foreground">{t.sequence + 1}</TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className={t.status === "done" ? "line-through" : ""}>{t.label}</span>
+                      <span className={t.status === "done" || fulfilled ? "line-through" : ""}>
+                        {t.label}
+                      </span>
+                      {fulfilled && (
+                        <Link
+                          href={`/batch/${fulfilled.batchId}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-[11px] text-green-700 hover:underline"
+                          title={`This step was completed on ${fulfilled.batchLabel}${
+                            fulfilled.completedAt ? ` on ${fmtDate(fulfilled.completedAt)}` : ""
+                          }`}
+                        >
+                          via {fulfilled.batchLabel}
+                        </Link>
+                      )}
                       {blockedReason(t) && (
                         <span className="inline-flex items-center gap-1 text-[11px] text-amber-600" title={blockedReason(t)!}>
                           <Lock className="w-3 h-3" /> {blockedReason(t)}
@@ -386,7 +416,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                     </Badge>
                   </TableCell>
                   <TableCell className="text-right whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
-                    {terminal ? (
+                    {fulfilled && !terminal ? (
+                      // Fulfilled on a related batch — nothing to do here. The row
+                      // click still opens the real action modal if the operator
+                      // wants to package this batch's portion separately.
+                      <span className="text-[11px] text-muted-foreground">—</span>
+                    ) : terminal ? (
                       <Button
                         size="sm"
                         variant="ghost"

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -38,6 +38,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Check, SkipForward, RotateCcw, Lock } from "lucide-react";
+import { formatDateForInput } from "@/utils/date-format";
 
 // Display status (richer than the raw status) → left-border accent + badge.
 type RowStatus = "done" | "ready" | "overdue" | "blocked" | "skipped" | "pending";
@@ -185,13 +186,19 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
   const actuals = data.packagedActuals ?? { bottledL: 0, keggedL: 0 };
   const fmtVol = (v: number) => (Math.round(v * 10) / 10).toString();
   // Keg-label details (shown on the "Label Kegs" step). Keg size comes from the
-  // keg Package step's planned container size.
+  // keg Package step's planned container size; the label date defaults to the
+  // most recent keg fill so labeling after the fact still shows the fill date.
   const kegSizeML = tasks.find((t) => t.kind === "package" && t.packagingPath === "keg")
     ?.actionData?.sizeML;
+  const latestKegFillAt = ((runsData?.runs ?? []) as Array<Record<string, any>>)
+    .filter((r) => r.source === "keg_fill")
+    .map((r) => r.packagedAt ?? r.createdAt)
+    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
   const kegLabel = {
     batchName: batchData?.customName || batchData?.name || "",
     abv: (batchData?.actualAbv ?? batchData?.estimatedAbv) ?? null,
     kegSizeL: typeof kegSizeML === "number" ? kegSizeML / 1000 : null,
+    kegFillDate: latestKegFillAt ? formatDateForInput(latestKegFillAt) : null,
   };
   const done = tasks.filter((t) => t.status === "done" || fulfilledBy[t.id]).length;
   const openBySeq = tasks.filter(

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -27,6 +27,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Check } from "lucide-react";
+import { DateInput } from "@/components/ui/date-input";
+import { formatDateForInput, parseDateInput } from "@/utils/date-format";
 import { AddBatchMeasurementForm } from "@/components/cellar/AddBatchMeasurementForm";
 import { AddBatchAdditiveForm } from "@/components/cellar/AddBatchAdditiveForm";
 
@@ -77,7 +79,12 @@ export function StepDetailModal({
   sources: Source[];
   plannedVolumeL: number;
   ingredients: Ingredient[];
-  kegLabel?: { batchName: string; abv: string | null; kegSizeL: number | null } | null;
+  kegLabel?: {
+    batchName: string;
+    abv: string | null;
+    kegSizeL: number | null;
+    kegFillDate: string | null;
+  } | null;
 }) {
   const utils = trpc.useUtils();
   const ad = (task?.actualData ?? {}) as Record<string, unknown>;
@@ -86,6 +93,10 @@ export function StepDetailModal({
   );
   const [vesselSearch, setVesselSearch] = useState("");
   const [notes, setNotes] = useState(task?.notes ?? "");
+  // Keg-label date edit, keyed by task so switching steps doesn't leak the value.
+  const [labelDateEdit, setLabelDateEdit] = useState<{ taskId: string; value: string } | null>(
+    null,
+  );
 
   // Total to transfer = sum of each source cider's planned draw (set at
   // instantiation); falls back to the batch's planned volume.
@@ -125,9 +136,19 @@ export function StepDetailModal({
   const isDone = task.status === "done" || task.status === "skipped";
   const isKegLabel = task.packagingPath === "keg" && /label/i.test(task.label);
 
+  // Date written on the kegs: what was saved on completion, else the operator's
+  // edit, else the keg fill date, else today.
+  const labelDate =
+    labelDateEdit?.taskId === task.id
+      ? labelDateEdit.value
+      : ((ad.labelDate as string | undefined) ??
+        kegLabel?.kegFillDate ??
+        formatDateForInput(new Date()));
+
   const buildActualData = () => {
     const out: Record<string, unknown> = {};
     if (task.kind === "transfer" && destVesselId) out.destinationVesselId = destVesselId;
+    if (isKegLabel && labelDate) out.labelDate = labelDate;
     return Object.keys(out).length ? out : null;
   };
 
@@ -152,7 +173,7 @@ export function StepDetailModal({
         contentsL,
         spaceL,
         isEmpty: !v.currentBatch || contentsL < 0.1,
-        batchName: v.currentBatch?.name ?? null,
+        batchName: v.currentBatch?.customName || v.currentBatch?.name || null,
         fits: spaceL + 0.001 >= plannedTotalL,
       };
     })
@@ -322,8 +343,21 @@ export function StepDetailModal({
                 <dl className="grid grid-cols-[5rem_1fr] gap-x-2 gap-y-0.5">
                   <dt className="text-muted-foreground">Name</dt>
                   <dd className="font-medium">{kegLabel?.batchName ?? "—"}</dd>
-                  <dt className="text-muted-foreground">Date</dt>
-                  <dd>{new Date().toLocaleDateString()}</dd>
+                  <dt className="text-muted-foreground self-center">Date</dt>
+                  <dd>
+                    {isDone ? (
+                      (parseDateInput(labelDate)?.toLocaleDateString() ?? labelDate)
+                    ) : (
+                      <DateInput
+                        value={labelDate}
+                        onChange={(v) =>
+                          v && setLabelDateEdit({ taskId: task.id, value: v })
+                        }
+                        className="h-8 text-sm"
+                        showClearButton={false}
+                      />
+                    )}
+                  </dd>
                   <dt className="text-muted-foreground">ABV</dt>
                   <dd>{kegLabel?.abv != null ? `${Number(kegLabel.abv).toFixed(1)}%` : "—"}</dd>
                   <dt className="text-muted-foreground">Keg size</dt>

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -35,6 +35,7 @@ import { batchCarbonationOperations } from "db/src/schema/carbonation";
 import { eq, and, isNull, isNotNull, desc, asc, sql, or, like, ilike, inArray, aliasedTable, ne, gte, lte, gt } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { convertToLiters, additiveRateGramsPerL } from "lib/src/units/conversions";
+import { splitChildCustomName } from "lib";
 import { validateBatches, type BatchValidation } from "../validation/batch-validation";
 import { buildReconciliationBatchList } from "../services/reconciliation-batch-list";
 import {
@@ -5761,6 +5762,15 @@ export const batchRouter = router({
             const uniqueSuffix = Date.now().toString(36); // Base36 timestamp for compact unique ID
             const childBatchNumber = `${batch[0].batchNumber}-R${uniqueSuffix}`; // e.g., "25-Rm5abc123"
             const childBatchName = `Batch #${childBatchNumber}`; // e.g., "Batch #25-Rm5abc123"
+            const existingChildren = await tx
+              .select({ id: batches.id })
+              .from(batches)
+              .where(
+                and(
+                  eq(batches.parentBatchId, batch[0].id),
+                  isNull(batches.deletedAt),
+                ),
+              );
 
             // Create child batch in destination vessel with racked volume
             // Note: initialVolume is 0 because the volume comes from a transfer, not as initial production
@@ -5769,7 +5779,10 @@ export const batchRouter = router({
               .values({
                 vesselId: input.destinationVesselId,
                 name: childBatchName,
-                customName: batch[0].customName, // Inherit parent's custom name without suffix
+                customName: splitChildCustomName(
+                  batch[0].customName,
+                  existingChildren.length,
+                ),
                 batchNumber: childBatchNumber,
                 initialVolumeLiters: "0", // Volume comes from transfer, not initial production
                 currentVolume: volumeRackedL.toString(),

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -42,7 +42,7 @@ import { productionReportsRouter } from "./productionReports";
 import { recipesRouter } from "./recipes";
 import { recipeExecutionRouter } from "./recipeExecution";
 import { planningRouter } from "./planning";
-import { MIN_WORKING_VOLUME_L } from "lib";
+import { MIN_WORKING_VOLUME_L, splitChildCustomName } from "lib";
 import { writeLedgerEntry } from "../lib/volume-ledger";
 import { recomputeBatchVolume } from "../services/batch-volume-recompute";
 import {
@@ -2611,6 +2611,7 @@ export const appRouter = router({
             // Batch information (if exists)
             batchId: batches.id,
             batchName: batches.name,
+            batchCustomName: batches.customName,
             currentVolume: batches.currentVolume,
             currentVolumeUnit: batches.currentVolumeUnit,
             batchStatus: batches.status,
@@ -2647,6 +2648,7 @@ export const appRouter = router({
               ? {
                   id: vessel.batchId,
                   name: vessel.batchName,
+                  customName: vessel.batchCustomName,
                   currentVolume: vessel.currentVolume,
                   currentVolumeUnit: vessel.currentVolumeUnit,
                   status: vessel.batchStatus,
@@ -4024,6 +4026,15 @@ export const appRouter = router({
               const uniqueSuffix = Date.now().toString(36); // Base36 timestamp for compact unique ID
               const transferredBatchNumber = `${sourceBatch[0].batchNumber}-T${uniqueSuffix}`;
               const transferredBatchName = `Batch #${transferredBatchNumber}`;
+              const existingChildren = await tx
+                .select({ id: batches.id })
+                .from(batches)
+                .where(
+                  and(
+                    eq(batches.parentBatchId, sourceBatch[0].id),
+                    isNull(batches.deletedAt),
+                  ),
+                );
 
               const newTransferredBatch = await tx
                 .insert(batches)
@@ -4031,7 +4042,10 @@ export const appRouter = router({
                   vesselId: input.toVesselId,
                   name: transferredBatchName,
                   batchNumber: transferredBatchNumber,
-                  customName: sourceBatch[0].customName, // Inherit parent's custom name
+                  customName: splitChildCustomName(
+                    sourceBatch[0].customName,
+                    existingChildren.length,
+                  ),
                   initialVolumeLiters: input.volumeL.toString(),
                   currentVolume: input.volumeL.toString(),
                   currentVolumeUnit: "L",
@@ -5004,6 +5018,15 @@ export const appRouter = router({
                 const uniqueSuffix = Date.now().toString(36);
                 const transferredBatchNumber = `${sourceBatch[0].batchNumber}-T${uniqueSuffix}`;
                 const transferredBatchName = `Batch #${transferredBatchNumber}`;
+                const existingChildren = await tx
+                  .select({ id: batches.id })
+                  .from(batches)
+                  .where(
+                    and(
+                      eq(batches.parentBatchId, sourceBatch[0].id),
+                      isNull(batches.deletedAt),
+                    ),
+                  );
 
                 const newTransferredBatch = await tx
                   .insert(batches)
@@ -5011,7 +5034,10 @@ export const appRouter = router({
                     vesselId: input.toVesselId,
                     name: transferredBatchName,
                     batchNumber: transferredBatchNumber,
-                    customName: sourceBatch[0].customName,
+                    customName: splitChildCustomName(
+                      sourceBatch[0].customName,
+                      existingChildren.length,
+                    ),
                     initialVolumeLiters: "0",
                     currentVolume: input.volumeL.toString(),
                     currentVolumeUnit: "L",

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -18,7 +18,7 @@
 
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import {
   db,
   batches,
@@ -30,10 +30,13 @@ import {
   batchStepTasks,
   batchMergeHistory,
   batchTransfers,
+  bottleRuns,
+  kegFills,
 } from "db";
 import { buildStepSchedule, rescheduleWithActuals } from "lib";
 import { router, createRbacProcedure } from "../trpc";
 import { recomputeBatchVolume } from "../services/batch-volume-recompute";
+import { computeFamilyFulfillment } from "../services/recipe-family-fulfillment";
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -287,7 +290,15 @@ export const recipeExecutionRouter = router({
         .from(batchRecipeExecutions)
         .where(eq(batchRecipeExecutions.batchId, input.batchId))
         .limit(1);
-      if (!execution) return { execution: null, tasks: [] };
+      if (!execution)
+        return {
+          execution: null,
+          tasks: [],
+          sources: [],
+          ingredients: [],
+          fulfilledBy: {},
+          packagedActuals: null,
+        };
 
       const tasks = await db
         .select()
@@ -342,7 +353,101 @@ export const recipeExecutionRouter = router({
           ),
         );
 
-      return { execution, tasks, sources, ingredients };
+      // ---- Batch-family sync (split executions) -------------------------
+      // A vessel-transfer split clones this execution onto the child batch
+      // (vessel.transfer), so the bottle/keg paths exist on every family
+      // member. Pair this batch's open path steps against completions on the
+      // parent / children / siblings so "bottled on the child" doesn't show
+      // as overdue here, and report actual packaged liters across the family.
+      const [selfBatch] = await db
+        .select({ id: batches.id, parentBatchId: batches.parentBatchId })
+        .from(batches)
+        .where(eq(batches.id, input.batchId))
+        .limit(1);
+      const familyConditions = [eq(batches.parentBatchId, input.batchId)];
+      if (selfBatch?.parentBatchId) {
+        familyConditions.push(eq(batches.id, selfBatch.parentBatchId));
+        familyConditions.push(eq(batches.parentBatchId, selfBatch.parentBatchId));
+      }
+      const familyRows = await db
+        .select({
+          id: batches.id,
+          batchNumber: batches.batchNumber,
+          name: batches.name,
+          customName: batches.customName,
+        })
+        .from(batches)
+        .where(
+          and(
+            or(...familyConditions),
+            ne(batches.id, input.batchId),
+            isNull(batches.deletedAt),
+          ),
+        );
+      const familyIds = familyRows.map((b) => b.id);
+      const familyLabel = new Map(
+        familyRows.map((b) => [b.id, b.customName || b.name || b.batchNumber]),
+      );
+
+      let fulfilledBy: Record<
+        string,
+        { batchId: string; batchLabel: string; completedAt: Date | string | null }
+      > = {};
+      if (familyIds.length) {
+        const familyDone = await db
+          .select({
+            kind: batchStepTasks.kind,
+            label: batchStepTasks.label,
+            packagingPath: batchStepTasks.packagingPath,
+            batchId: batchStepTasks.batchId,
+            completedAt: batchStepTasks.completedAt,
+          })
+          .from(batchStepTasks)
+          .where(
+            and(
+              inArray(batchStepTasks.batchId, familyIds),
+              eq(batchStepTasks.status, "done"),
+              ne(batchStepTasks.packagingPath, "all"),
+            ),
+          );
+        fulfilledBy = Object.fromEntries(
+          Object.entries(computeFamilyFulfillment(tasks, familyDone)).map(
+            ([taskId, f]) => [
+              taskId,
+              { ...f, batchLabel: familyLabel.get(f.batchId) ?? "related batch" },
+            ],
+          ),
+        );
+      }
+
+      // Actual packaged volume across the whole family (self + relatives), so
+      // the header can show real bottled/kegged liters next to the plan.
+      const packagedIds = [input.batchId, ...familyIds];
+      const bottleRows = await db
+        .select({ liters: bottleRuns.volumeTakenLiters })
+        .from(bottleRuns)
+        .where(
+          and(inArray(bottleRuns.batchId, packagedIds), isNull(bottleRuns.voidedAt)),
+        );
+      const kegRows = await db
+        .select({ volume: kegFills.volumeTaken, unit: kegFills.volumeTakenUnit })
+        .from(kegFills)
+        .where(
+          and(
+            inArray(kegFills.batchId, packagedIds),
+            isNull(kegFills.voidedAt),
+            isNull(kegFills.deletedAt),
+          ),
+        );
+      const packagedActuals = {
+        bottledL: bottleRows.reduce((sum, r) => sum + (Number(r.liters) || 0), 0),
+        keggedL: kegRows.reduce((sum, r) => {
+          const v = Number(r.volume) || 0;
+          return sum + (r.unit === "gal" ? v * 3.78541 : v);
+        }, 0),
+      };
+
+      return { execution, tasks, sources, ingredients, fulfilledBy, packagedActuals };
     }),
 
   /** Cross-batch work queue: every open task across all active executions. */

--- a/packages/api/src/services/__tests__/recipe-family-fulfillment.test.ts
+++ b/packages/api/src/services/__tests__/recipe-family-fulfillment.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeFamilyFulfillment,
+  type FamilyDoneTaskLite,
+  type LocalTaskLite,
+} from "../recipe-family-fulfillment";
+
+const local = (over: Partial<LocalTaskLite> = {}): LocalTaskLite => ({
+  id: "local-1",
+  kind: "package",
+  label: "Package Cider in 750ml bottles",
+  packagingPath: "bottle",
+  status: "pending",
+  ...over,
+});
+
+const familyDone = (over: Partial<FamilyDoneTaskLite> = {}): FamilyDoneTaskLite => ({
+  kind: "package",
+  label: "Package Cider in 750ml bottles",
+  packagingPath: "bottle",
+  batchId: "child-batch",
+  completedAt: "2026-07-08T12:00:00Z",
+  ...over,
+});
+
+describe("computeFamilyFulfillment", () => {
+  it("pairs an open path task with a matching family completion (the Duskrun case)", () => {
+    const result = computeFamilyFulfillment([local()], [familyDone()]);
+    expect(result).toEqual({
+      "local-1": { batchId: "child-batch", completedAt: "2026-07-08T12:00:00Z" },
+    });
+  });
+
+  it("pairs on the exact (kind, path, label) triple — any mismatch means no pairing", () => {
+    expect(
+      computeFamilyFulfillment([local()], [familyDone({ label: "Package Cider in Kegs" })]),
+    ).toEqual({});
+    expect(
+      computeFamilyFulfillment([local()], [familyDone({ packagingPath: "keg" })]),
+    ).toEqual({});
+    expect(computeFamilyFulfillment([local()], [familyDone({ kind: "measure" })])).toEqual({});
+  });
+
+  it("never pairs shared-path steps — post-split they are per-vessel physical work", () => {
+    const filterLocal = local({ kind: "filter", label: "Fine Filter Cider", packagingPath: "all" });
+    const filterFamily = familyDone({
+      kind: "filter",
+      label: "Fine Filter Cider",
+      packagingPath: "all",
+    });
+    expect(computeFamilyFulfillment([filterLocal], [filterFamily])).toEqual({});
+  });
+
+  it("leaves locally-done and skipped tasks alone", () => {
+    expect(computeFamilyFulfillment([local({ status: "done" })], [familyDone()])).toEqual({});
+    expect(computeFamilyFulfillment([local({ status: "skipped" })], [familyDone()])).toEqual({});
+  });
+
+  it("also fulfills in_progress tasks", () => {
+    const result = computeFamilyFulfillment([local({ status: "in_progress" })], [familyDone()]);
+    expect(result["local-1"]?.batchId).toBe("child-batch");
+  });
+
+  it("picks the earliest family completion when several batches did the step", () => {
+    const result = computeFamilyFulfillment(
+      [local()],
+      [
+        familyDone({ batchId: "late-sibling", completedAt: "2026-07-10T00:00:00Z" }),
+        familyDone({ batchId: "first-child", completedAt: "2026-07-08T00:00:00Z" }),
+      ],
+    );
+    expect(result["local-1"]?.batchId).toBe("first-child");
+  });
+
+  it("treats a null completedAt as latest, so dated completions win the tie-break", () => {
+    const result = computeFamilyFulfillment(
+      [local()],
+      [
+        familyDone({ batchId: "undated", completedAt: null }),
+        familyDone({ batchId: "dated", completedAt: "2026-07-08T00:00:00Z" }),
+      ],
+    );
+    expect(result["local-1"]?.batchId).toBe("dated");
+  });
+
+  it("fulfills multiple distinct path steps independently", () => {
+    const tasks = [
+      local({ id: "carb", kind: "carbonate", label: "Carbonate Cider" }),
+      local({ id: "pkg" }),
+      local({ id: "keg-pkg", label: "Package Cider in Kegs", packagingPath: "keg" }),
+    ];
+    const family = [
+      familyDone({ kind: "carbonate", label: "Carbonate Cider" }),
+      familyDone(),
+    ];
+    const result = computeFamilyFulfillment(tasks, family);
+    expect(Object.keys(result).sort()).toEqual(["carb", "pkg"]);
+  });
+
+  it("returns empty for empty inputs", () => {
+    expect(computeFamilyFulfillment([], [familyDone()])).toEqual({});
+    expect(computeFamilyFulfillment([local()], [])).toEqual({});
+  });
+});

--- a/packages/api/src/services/recentActivityFormatter.ts
+++ b/packages/api/src/services/recentActivityFormatter.ts
@@ -26,6 +26,13 @@ export interface FormattedActivity {
   recordId: string;
   operation: string;
   changedAt: Date;
+  /**
+   * When the event physically happened (transfer date, cleaning date, fill
+   * date, …) as opposed to when it was entered. Falls back to changedAt when
+   * the record carries no domain date. The widget displays this; the feed
+   * stays ordered by changedAt so backdated entries still surface on top.
+   */
+  occurredAt: Date;
   userName: string;
   message: string;
   /**
@@ -49,6 +56,42 @@ function num(v: any): number | null {
   if (v === null || v === undefined || v === "") return null;
   const n = typeof v === "number" ? v : Number(v);
   return Number.isFinite(n) ? n : null;
+}
+
+// Domain-date fields, in priority order, that mark when an event physically
+// happened (vs. when it was entered). Both camelCase and snake_case are
+// checked because audit payloads carry either depending on the writer.
+const OCCURRENCE_DATE_KEYS = [
+  ["transferredAt", "transferred_at"],
+  ["cleanedAt", "cleaned_at"],
+  ["filledAt", "filled_at"],
+  ["packagedAt", "packaged_at"],
+  ["rackedAt", "racked_at"],
+  ["measuredAt", "measured_at", "measurementDate", "measurement_date"],
+  ["addedAt", "added_at"],
+  ["startedAt", "started_at"],
+  ["eventDate", "event_date"],
+  ["distributionDate", "distribution_date"],
+  ["sentAt", "sent_at"],
+  ["dateCompleted", "date_completed"],
+] as const;
+
+/**
+ * When the event physically occurred, per the record's own date fields;
+ * falls back to the audit entry time for records with no domain date
+ * (e.g. plain batch updates).
+ */
+function occurredAtFor(row: RawActivityRow): Date {
+  const newData = row.newData as Json;
+  const oldData = row.oldData as Json;
+  for (const keys of OCCURRENCE_DATE_KEYS) {
+    const raw = get(newData, ...keys) ?? get(oldData, ...keys);
+    if (raw) {
+      const d = new Date(raw);
+      if (!Number.isNaN(d.getTime())) return d;
+    }
+  }
+  return row.changedAt;
 }
 
 function fmtSG(v: any): string | null {
@@ -740,6 +783,7 @@ export async function formatRecentActivity(
     recordId: r.recordId,
     operation: r.operation,
     changedAt: r.changedAt,
+    occurredAt: occurredAtFor(r),
     userName: r.userName ?? r.changedByEmail ?? "System",
     message: formatRow(r, lookups),
     linkable: isLinkable(r, lookups),

--- a/packages/api/src/services/recipe-family-fulfillment.ts
+++ b/packages/api/src/services/recipe-family-fulfillment.ts
@@ -1,0 +1,77 @@
+/**
+ * Family fulfillment for split recipe executions.
+ *
+ * When a vessel transfer splits a recipe batch, the child batch gets its own
+ * cloned execution (vessel.transfer in routers/index.ts). The bottle/keg
+ * packaging paths belong to the batch FAMILY, not to one vessel: bottling the
+ * child's portion fulfills the bottle path for the parent too. This module
+ * pairs a batch's open path-specific tasks against `done` tasks on related
+ * executions (parent / children / siblings) so the checklist can show them as
+ * "done via <batch>" instead of overdue.
+ *
+ * Shared steps (packagingPath === "all") are deliberately NOT paired — after a
+ * split they are physical per-vessel work (filtering the parent tank does not
+ * filter the child tank).
+ *
+ * Pure function: the router loads the rows, this decides the pairing.
+ */
+
+export interface LocalTaskLite {
+  id: string;
+  kind: string;
+  label: string;
+  packagingPath: string;
+  status: string;
+}
+
+export interface FamilyDoneTaskLite {
+  kind: string;
+  label: string;
+  packagingPath: string;
+  batchId: string;
+  completedAt: Date | string | null;
+}
+
+export interface Fulfillment {
+  batchId: string;
+  completedAt: Date | string | null;
+}
+
+const pairKey = (t: { kind: string; packagingPath: string; label: string }) =>
+  `${t.kind}|${t.packagingPath}|${t.label}`;
+
+/**
+ * Map of local task id → the family completion that fulfills it.
+ *
+ * A local task is fulfillable only when it is path-specific (bottle/keg) and
+ * still open (pending/in_progress) — a task the operator already completed,
+ * skipped, or that belongs to the shared path is left alone. When several
+ * family batches completed the same step, the earliest completion wins.
+ */
+export function computeFamilyFulfillment(
+  localTasks: LocalTaskLite[],
+  familyDoneTasks: FamilyDoneTaskLite[],
+): Record<string, Fulfillment> {
+  if (localTasks.length === 0 || familyDoneTasks.length === 0) return {};
+
+  const doneByKey = new Map<string, FamilyDoneTaskLite>();
+  for (const ft of familyDoneTasks) {
+    if (ft.packagingPath === "all") continue;
+    const key = pairKey(ft);
+    const prev = doneByKey.get(key);
+    if (!prev || completedMs(ft) < completedMs(prev)) doneByKey.set(key, ft);
+  }
+  if (doneByKey.size === 0) return {};
+
+  const out: Record<string, Fulfillment> = {};
+  for (const t of localTasks) {
+    if (t.packagingPath === "all") continue;
+    if (t.status !== "pending" && t.status !== "in_progress") continue;
+    const match = doneByKey.get(pairKey(t));
+    if (match) out[t.id] = { batchId: match.batchId, completedAt: match.completedAt };
+  }
+  return out;
+}
+
+const completedMs = (t: FamilyDoneTaskLite) =>
+  t.completedAt ? new Date(t.completedAt).getTime() : Number.MAX_SAFE_INTEGER;

--- a/packages/lib/src/naming/batchName.spec.ts
+++ b/packages/lib/src/naming/batchName.spec.ts
@@ -4,6 +4,7 @@ import {
   generateVarietyCode,
   selectPrimaryVariety,
   generateBatchNameFromComposition,
+  splitChildCustomName,
   type BatchComposition,
   type GenerateBatchNameOptions,
   type BatchCompositionInput,
@@ -339,5 +340,39 @@ describe("batchName", () => {
       expect(uniqueResults.size).toBe(1);
       expect(results[0]).toBe("2025-09-19_TK03_GRAV_A");
     });
+  });
+});
+
+describe("splitChildCustomName", () => {
+  it("suffixes the first child with ' - A'", () => {
+    expect(splitChildCustomName("Winter Blend 2", 0)).toBe("Winter Blend 2 - A");
+  });
+
+  it("increments the letter per existing child", () => {
+    expect(splitChildCustomName("Winter Blend 2", 1)).toBe("Winter Blend 2 - B");
+    expect(splitChildCustomName("Summer Community Blend 4", 2)).toBe(
+      "Summer Community Blend 4 - C",
+    );
+    expect(splitChildCustomName("X", 25)).toBe("X - Z");
+  });
+
+  it("falls back to ordinal numbers past 26 children", () => {
+    expect(splitChildCustomName("X", 26)).toBe("X - 27");
+    expect(splitChildCustomName("X", 30)).toBe("X - 31");
+  });
+
+  it("returns null when the parent has no custom name", () => {
+    expect(splitChildCustomName(null, 0)).toBeNull();
+    expect(splitChildCustomName(undefined, 3)).toBeNull();
+    expect(splitChildCustomName("   ", 0)).toBeNull();
+  });
+
+  it("trims the parent name before suffixing", () => {
+    expect(splitChildCustomName("  Duskrun  ", 0)).toBe("Duskrun - A");
+  });
+
+  it("clamps negative/fractional counts to a valid letter", () => {
+    expect(splitChildCustomName("X", -1)).toBe("X - A");
+    expect(splitChildCustomName("X", 1.7)).toBe("X - B");
   });
 });

--- a/packages/lib/src/naming/batchName.ts
+++ b/packages/lib/src/naming/batchName.ts
@@ -159,3 +159,27 @@ export function generateBatchNameFromComposition(
     primaryVariety,
   });
 }
+
+/**
+ * Display name for a child batch created by splitting a parent
+ * (partial transfer or partial rack into an empty vessel).
+ *
+ * Children get a " - A", " - B", ... suffix so siblings that would otherwise
+ * share the parent's custom name stay distinguishable in batch pickers.
+ * After 26 children the suffix falls back to the child's ordinal number.
+ *
+ * @param parentCustomName - The parent batch's custom (display) name
+ * @param existingChildCount - How many children the parent already has (0 → "A")
+ * @returns Suffixed custom name, or null when the parent has no custom name
+ */
+export function splitChildCustomName(
+  parentCustomName: string | null | undefined,
+  existingChildCount: number,
+): string | null {
+  const base = parentCustomName?.trim();
+  if (!base) return null;
+
+  const n = Math.max(0, Math.floor(existingChildCount));
+  const suffix = n < 26 ? String.fromCharCode(65 + n) : String(n + 1);
+  return `${base} - ${suffix}`;
+}


### PR DESCRIPTION
## Summary

- **Recipe checklist reflects family completions after a transfer split** — steps completed by a split-off sibling batch (e.g. the bottling portion) display as fulfilled on the parent's checklist.
- **Keg-label step: editable label date** — the Label Kegs card has a date input persisted in `actualData.labelDate`, defaulting to the most recent keg fill date; read-only once done.
- **Split children get distinguishing name suffixes** — partial transfers and partial racks previously copied the parent's custom name verbatim, creating indistinguishable twin batches that caused misattributed draws (root cause of the TANK-1000/1100 reconciliation mess). Children now get " - A" / " - B" … via `splitChildCustomName()` in `lib/naming` (unit tested).
- **Batch pickers show the current vessel** — batch dropdowns (Send to Distillery, Fortified/Pommeau Blend, Batch Lifecycle Audit, reports filter) render `Name · VESSEL`; TankTransferForm / RackingModal show each destination vessel's occupying batch; `vessel.listWithBatches` returns `customName`.
- **Recent Activity shows occurrence dates** — feed rows display when the event physically happened (transfer/cleaning/fill/packaging date) instead of when it was entered; ordering unchanged.

## Testing

- `pnpm typecheck` clean across all packages
- New unit tests for `splitChildCustomName` (34 passing in `lib/naming`)
- Note: the failing CI checks are a pre-existing workflow issue ("Unable to locate executable file: pnpm" — setup ordering), failing on every PR since July; the Vercel build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)