### PR TITLE
Filter action: optional destination tank

### DIFF
--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -104,7 +104,9 @@ interface CarbonateModalProps {
     isPressureVessel: "yes" | "no";
     maxPressure: number;
   } | null;
-  onSuccess?: () => void;
+  /** Receives the operation's start date so recipe callers can anchor the
+   *  remaining schedule to the actual date. */
+  onSuccess?: (startedAt?: Date) => void;
   /** Recipe-planned values to prefill (method uses recipe terms forced|natural). */
   prefillTargetCo2Volumes?: number;
   prefillMethod?: "forced" | "natural";
@@ -376,7 +378,13 @@ export function CarbonateModal({
       utils.batch.get.invalidate({ batchId: batch.id });
       utils.vessel.liquidMap.invalidate();
       utils.carbonation.listActive.invalidate();
-      onSuccess?.();
+      onSuccess?.(
+        startedAt instanceof Date
+          ? startedAt
+          : startedAt
+            ? parseDateTimeFromInput(startedAt)
+            : undefined,
+      );
       onOpenChange(false);
     },
     onError: (error) => {
@@ -396,7 +404,13 @@ export function CarbonateModal({
       utils.batch.get.invalidate({ batchId: batch.id });
       utils.vessel.liquidMap.invalidate();
       utils.carbonation.list.invalidate();
-      onSuccess?.();
+      onSuccess?.(
+        startedAt instanceof Date
+          ? startedAt
+          : startedAt
+            ? parseDateTimeFromInput(startedAt)
+            : undefined,
+      );
       onOpenChange(false);
     },
     onError: (error) => {

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -45,11 +45,16 @@ import { cn } from "@/lib/utils";
 
 interface AddBatchAdditiveFormProps {
   batchId: string;
-  onSuccess: () => void;
+  /** Receives the recorded addedAt so recipe callers can anchor the schedule
+   *  to the actual date (completeTask → recomputeSchedule). */
+  onSuccess: (addedAt?: Date) => void;
   onCancel: () => void;
   /** Recipe-planned values to prefill (e.g. Cascade Hops @ 1.5 g/L = 180 g). */
   prefillAdditiveType?: string | null;
   prefillVarietyName?: string | null;
+  /** Inventory variety the recipe ingredient is linked to — preselects the
+   *  first available lot of that variety so the user only verifies. */
+  prefillAdditiveVarietyId?: string | null;
   prefillDosageRate?: number | null;
   prefillDosageRateUnit?: string | null;
   prefillAmount?: number | null;
@@ -57,6 +62,8 @@ interface AddBatchAdditiveFormProps {
   /** Planned batch volume (L) for the g/L translation when the batch has no
    *  measurement yet (e.g. a freshly instantiated recipe batch). */
   prefillBatchVolumeL?: number | null;
+  /** Default the date field to the step's scheduled date instead of now. */
+  prefillAddedAt?: string | Date | null;
 }
 
 // Grouped so absolute amounts and concentrations can be visually separated
@@ -169,6 +176,8 @@ export function AddBatchAdditiveForm({
   onCancel,
   prefillAdditiveType,
   prefillVarietyName,
+  prefillAdditiveVarietyId,
+  prefillAddedAt,
   prefillDosageRate,
   prefillDosageRateUnit,
   prefillAmount,
@@ -186,7 +195,10 @@ export function AddBatchAdditiveForm({
   const [searchQuery, setSearchQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [addedDate, setAddedDate] = useState(() => {
-    return formatDateTimeForInput(new Date());
+    // Default to the recipe step's scheduled date when provided; the operator
+    // adjusts it if the work happened on a different day.
+    const seed = prefillAddedAt ? new Date(prefillAddedAt) : new Date();
+    return formatDateTimeForInput(Number.isNaN(seed.getTime()) ? new Date() : seed);
   });
   const [dateWarning, setDateWarning] = useState<string | null>(null);
   const [dosageRate, setDosageRate] = useState(prefillDosageRate != null ? String(prefillDosageRate) : "");
@@ -263,16 +275,28 @@ export function AddBatchAdditiveForm({
       },
     );
 
-  // Once the type's inventory loads, auto-select the lot matching the recipe
-  // variety — only when there's exactly one, to avoid guessing.
+  // Once the type's inventory loads, auto-select the lot for the recipe
+  // ingredient. The linked variety id is authoritative (first available lot
+  // of that variety); the name match is the fallback for unlinked
+  // ingredients — only when there's exactly one, to avoid guessing.
   React.useEffect(() => {
-    if (!prefillVarietyName || selectedInventoryItem) return;
+    if ((!prefillAdditiveVarietyId && !prefillVarietyName) || selectedInventoryItem) return;
     const items = inventoryData?.items ?? [];
+    if (prefillAdditiveVarietyId) {
+      const byId = items.filter(
+        (i: any) => i.additiveVarietyId === prefillAdditiveVarietyId,
+      );
+      if (byId.length > 0) {
+        setSelectedInventoryItem(byId[0]);
+        return;
+      }
+    }
+    if (!prefillVarietyName) return;
     const matches = items.filter(
       (i: any) => (i.varietyName || i.productName) === prefillVarietyName,
     );
     if (matches.length === 1) setSelectedInventoryItem(matches[0]);
-  }, [inventoryData, prefillVarietyName, selectedInventoryItem]);
+  }, [inventoryData, prefillAdditiveVarietyId, prefillVarietyName, selectedInventoryItem]);
 
   // Detect if the selected inventory item is a sulfite product (KMS)
   const isSulfiteProduct = useMemo(() => {
@@ -431,7 +455,7 @@ export function AddBatchAdditiveForm({
       if (data.reclassifiedAsWine) {
         utils.batch.invalidate();
       }
-      onSuccess();
+      onSuccess(parseDateTimeFromInput(addedDate));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -27,7 +27,8 @@ import { useDateFormat } from "@/hooks/useDateFormat";
 
 interface AddBatchMeasurementFormProps {
   batchId: string;
-  onSuccess: () => void;
+  /** Receives the measurement date for schedule anchoring. */
+  onSuccess: (measuredAt?: Date) => void;
   onCancel: () => void;
 }
 
@@ -181,7 +182,7 @@ export function AddBatchMeasurementForm({
         title: "Success",
         description: "Measurement added successfully",
       });
-      onSuccess();
+      onSuccess(parseDateTimeFromInput(measurementDateTime));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -77,6 +77,19 @@ export function FilterModal({
   const [lossPercentage, setLossPercentage] = useState(0);
   const [dateWarning, setDateWarning] = useState<string | null>(null);
   const [laborAssignments, setLaborAssignments] = useState<WorkerAssignment[]>([]);
+  // "same" = cider stays in the current tank; otherwise the id of the empty
+  // vessel the cider is filtered into.
+  const [destinationVesselId, setDestinationVesselId] = useState<string>("same");
+
+  // Empty, available vessels the batch can be filtered into.
+  const { data: vesselList } = trpc.vessel.listWithBatches.useQuery(undefined, {
+    enabled: open,
+  });
+  const destinationOptions = (
+    (Array.isArray(vesselList) ? [] : vesselList?.vessels) ?? []
+  ).filter(
+    (v) => v.id !== vesselId && !v.currentBatch && v.status === "available",
+  );
 
   // Date validation
   const { validateDate } = useBatchDateValidation(batchId);
@@ -146,6 +159,7 @@ export function FilterModal({
         notes: "",
       });
       setLaborAssignments([]);
+      setDestinationVesselId("same");
     }
   }, [open, currentVolumeL, reset, prefillFilterType]);
 
@@ -157,6 +171,7 @@ export function FilterModal({
       });
       utils.vessel.list.invalidate();
       utils.vessel.liquidMap.invalidate();
+      utils.vessel.listWithBatches.invalidate();
       utils.batch.getActivityHistory.invalidate();
       utils.batch.list.invalidate();
       onClose();
@@ -186,6 +201,8 @@ export function FilterModal({
     filterMutation.mutate({
       batchId,
       vesselId,
+      destinationVesselId:
+        destinationVesselId !== "same" ? destinationVesselId : undefined,
       filterType: data.filterType,
       volumeBefore: data.volumeBefore,
       volumeBeforeUnit: data.volumeBeforeUnit,
@@ -269,6 +286,29 @@ export function FilterModal({
             )}
             <p className="text-xs text-gray-500 mt-1">
               Coarse: Removes large particles | Fine: Removes small particles | Sterile: Final filtering
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="destinationVessel">Filter Into</Label>
+            <Select
+              value={destinationVesselId}
+              onValueChange={setDestinationVesselId}
+            >
+              <SelectTrigger className="mt-1">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="same">Keep in {vesselName}</SelectItem>
+                {destinationOptions.map((v: any) => (
+                  <SelectItem key={v.id} value={v.id}>
+                    {v.name} ({parseFloat(v.capacity || "0").toFixed(0)} {v.capacityUnit || "L"})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-gray-500 mt-1">
+              Filtering into another tank moves the batch there as part of this operation
             </p>
           </div>
 

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -54,8 +54,10 @@ interface FilterModalProps {
   vesselName: string;
   batchId: string;
   currentVolumeL: number;
-  /** Called after a filter operation succeeds (e.g. to complete a recipe task). */
-  onSuccess?: () => void;
+  /** Called after a filter operation succeeds (e.g. to complete a recipe
+   *  task). Receives the operation's filteredAt so recipe callers can anchor
+   *  the remaining schedule to the actual date. */
+  onSuccess?: (filteredAt?: Date) => void;
   /** Recipe-planned filter type to prefill. */
   prefillFilterType?: "coarse" | "fine" | "sterile";
 }
@@ -176,7 +178,7 @@ export function FilterModal({
       utils.batch.list.invalidate();
       onClose();
       reset();
-      onSuccess?.();
+      onSuccess?.(filteredAt);
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -57,7 +57,8 @@ interface LabelModalProps {
   bottleRunName: string;
   unitsProduced: number;
   unitsLabeled?: number; // Current number of labeled units (for partial labeling)
-  onSuccess: () => void;
+  /** Receives labeledAt for schedule anchoring. */
+  onSuccess: (labeledAt?: Date) => void;
 }
 
 export function LabelModal({
@@ -227,7 +228,7 @@ export function LabelModal({
       utils.packaging.list.invalidate();
       utils.packaging.get.invalidate(bottleRunId);
       refetchPackagingItems();
-      onSuccess();
+      onSuccess(labeledAt);
 
       // Close modal after successful labeling
       onClose();

--- a/apps/web/src/components/packaging/PasteurizeModal.tsx
+++ b/apps/web/src/components/packaging/PasteurizeModal.tsx
@@ -79,7 +79,8 @@ interface PasteurizeModalProps {
   bottleRunName: string;
   batchId: string;
   unitsProduced: number;
-  onSuccess: () => void;
+  /** Receives pasteurizedAt for schedule anchoring. */
+  onSuccess: (pasteurizedAt?: Date) => void;
 }
 
 export function PasteurizeModal({
@@ -355,7 +356,7 @@ export function PasteurizeModal({
         description: `Successfully recorded pasteurization for ${bottleRunName} with ${totalPU.toFixed(1)} PU`,
       });
       utils.packaging.list.invalidate();
-      onSuccess();
+      onSuccess(pasteurizedAt ? parseDateTimeFromInput(pasteurizedAt) : undefined);
       onClose();
     },
     onError: (error) => {

--- a/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
+++ b/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
@@ -20,7 +20,8 @@ interface UnifiedPackagingModalProps {
   currentVolumeL: number;
   initialType?: PackagingType;
   preBottling?: PreBottlingData;
-  onSuccess?: () => void;
+  /** Receives the packaging date (packagedAt / filledAt) from the inner modal. */
+  onSuccess?: (packagedAt?: Date) => void;
 }
 
 /**

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -72,7 +72,8 @@ interface BottleModalProps {
   showTypeSelector?: boolean; // Show package type selector (bottles vs kegs)
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
-  onSuccess?: () => void; // Called after a packaging run is created
+  /** Called after a packaging run is created; receives packagedAt for schedule anchoring. */
+  onSuccess?: (packagedAt?: Date) => void;
 }
 
 type InputMode = "volume" | "units";
@@ -127,6 +128,7 @@ export function BottleModal({
     formState: { errors },
     setValue,
     watch,
+    getValues,
     reset,
   } = useForm<BottleFormData>({
     resolver: zodResolver(bottleFormSchema),
@@ -424,7 +426,7 @@ export function BottleModal({
 
       console.log("Packaging run created:", result);
       onClose();
-      onSuccess?.();
+      onSuccess?.(parseDateTimeFromInput(getValues("packagedAt")));
     } catch (error) {
       console.error("Failed to create packaging run:", error);
 

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -52,7 +52,8 @@ interface FillKegModalProps {
   showTypeSelector?: boolean; // Show package type selector (bottles vs kegs)
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
-  onSuccess?: () => void; // Called after kegs are filled
+  /** Called after kegs are filled; receives filledAt for schedule anchoring. */
+  onSuccess?: (filledAt?: Date) => void;
 }
 
 // Memoized keg item component to prevent re-renders
@@ -125,6 +126,7 @@ export function FillKegModal({
     formState: { errors },
     setValue,
     watch,
+    getValues,
     reset,
   } = useForm<FillKegsForm>({
     resolver: zodResolver(fillKegsSchema),
@@ -165,7 +167,7 @@ export function FillKegModal({
       setSelectedKegIds([]);
       setKegVolumes({});
       onClose();
-      onSuccess?.();
+      onSuccess?.(parseDateTimeFromInput(getValues("filledAt")));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -507,7 +507,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 ? "sterile"
                 : "fine"
           }
-          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+          onSuccess={(actualAt?: Date) =>
+            actionTask &&
+            complete.mutate({
+              taskId: actionTask.id,
+              ...(actualAt ? { completedAt: actualAt } : {}),
+            })
+          }
         />
         <CarbonateModal
           open={actionTask?.kind === "carbonate"}
@@ -538,7 +544,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 ? "forced"
                 : undefined
           }
-          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+          onSuccess={(actualAt?: Date) =>
+            actionTask &&
+            complete.mutate({
+              taskId: actionTask.id,
+              ...(actualAt ? { completedAt: actualAt } : {}),
+            })
+          }
         />
         <UnifiedPackagingModal
           open={actionTask?.kind === "package"}
@@ -548,7 +560,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           batchId={batchId}
           currentVolumeL={currentVolumeL}
           initialType={actionTask?.packagingPath === "keg" ? "kegs" : "bottles"}
-          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+          onSuccess={(actualAt?: Date) =>
+            actionTask &&
+            complete.mutate({
+              taskId: actionTask.id,
+              ...(actualAt ? { completedAt: actualAt } : {}),
+            })
+          }
         />
       </>
     )}
@@ -563,7 +581,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
           batchId={batchId}
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
-          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+          onSuccess={(actualAt?: Date) =>
+            actionTask &&
+            complete.mutate({
+              taskId: actionTask.id,
+              ...(actualAt ? { completedAt: actualAt } : {}),
+            })
+          }
         />
         <LabelModal
           open={actionTask?.kind === "label"}
@@ -572,7 +596,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
           unitsLabeled={Number(latestRun.unitsLabeled ?? 0)}
-          onSuccess={() => actionTask && complete.mutate({ taskId: actionTask.id })}
+          onSuccess={(actualAt?: Date) =>
+            actionTask &&
+            complete.mutate({
+              taskId: actionTask.id,
+              ...(actualAt ? { completedAt: actualAt } : {}),
+            })
+          }
         />
       </>
     )}

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -305,10 +305,20 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
       <CardHeader>
         <CardTitle className="text-base">Recipe checklist</CardTitle>
         <CardDescription>
-          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)} · bottled{" "}
-          {fmtVol(actuals.bottledL)} of {Number(execution.bottleVolumeL ?? 0)} L · kegged{" "}
-          {fmtVol(actuals.keggedL)} of {Number(execution.kegVolumeL ?? 0)} L ·{" "}
-          {done}/{tasks.length} done · in recipe order
+          {/* Packaging progress is shown per planned path only — a path with
+              no plan (0 L) is omitted rather than rendering "kegged X of 0 L". */}
+          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)}
+          {Number(execution.bottleVolumeL ?? 0) > 0 && (
+            <>
+              {" "}· bottled {fmtVol(actuals.bottledL)} of {Number(execution.bottleVolumeL)} L
+            </>
+          )}
+          {Number(execution.kegVolumeL ?? 0) > 0 && (
+            <>
+              {" "}· kegged {fmtVol(actuals.keggedL)} of {Number(execution.kegVolumeL)} L
+            </>
+          )}
+          {" "}· {done}/{tasks.length} done · in recipe order
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -41,6 +41,7 @@ interface Task {
   isOptional: boolean;
   status: string;
   notes: string | null;
+  scheduledDate?: string | Date | null;
   actionData: Record<string, unknown> | null;
   actualData: Record<string, unknown> | null;
 }
@@ -186,7 +187,14 @@ export function StepDetailModal({
   const useRealForm =
     !isDone &&
     (task.kind === "measurement" || task.kind === "add_additive" || task.kind === "pitch_yeast");
-  const onRealSuccess = () => complete.mutate({ taskId: task.id });
+  // The real forms report the operation's actual date; passing it as
+  // completedAt lets recomputeSchedule re-anchor the remaining steps to when
+  // the work really happened.
+  const onRealSuccess = (actualAt?: Date) =>
+    complete.mutate({
+      taskId: task.id,
+      ...(actualAt ? { completedAt: actualAt } : {}),
+    });
 
   // Prefill the add-additive form from the recipe ingredient this step references.
   const additivePrefill = (() => {
@@ -207,6 +215,7 @@ export function StepDetailModal({
     return {
       additiveType: ing.additiveType ?? undefined,
       varietyName: ing.additiveName ?? ing.label,
+      additiveVarietyId: ing.additiveVarietyId ?? undefined,
       dosageRate: rate,
       dosageRateUnit: rateUnit,
       amount,
@@ -240,11 +249,13 @@ export function StepDetailModal({
               onCancel={onClose}
               prefillAdditiveType={additivePrefill?.additiveType}
               prefillVarietyName={additivePrefill?.varietyName}
+              prefillAdditiveVarietyId={additivePrefill?.additiveVarietyId}
               prefillDosageRate={additivePrefill?.dosageRate}
               prefillDosageRateUnit={additivePrefill?.dosageRateUnit}
               prefillAmount={additivePrefill?.amount}
               prefillUnit={additivePrefill?.unit}
               prefillBatchVolumeL={plannedTotalL > 0 ? plannedTotalL : null}
+              prefillAddedAt={task.scheduledDate ?? null}
             />
           )
         ) : (

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -530,6 +530,9 @@ const updateMergeSchema = z.object({
 const filterBatchSchema = z.object({
   batchId: z.string().uuid("Invalid batch ID"),
   vesselId: z.string().uuid("Invalid vessel ID"),
+  // When filtering into a different tank (filter inline between vessels),
+  // the batch moves there as part of the operation. Must be an empty vessel.
+  destinationVesselId: z.string().uuid("Invalid destination vessel ID").optional(),
   filterType: z.enum(["coarse", "fine", "sterile"]),
   volumeBefore: z.number().positive("Volume before must be positive"),
   volumeBeforeUnit: z.enum(['L', 'gal']).default('L'),
@@ -5430,16 +5433,87 @@ export const batchRouter = router({
           }
         }
 
-        // Update batch current volume
+        // Filtering into another tank: validate the destination and move the
+        // batch there as part of the operation.
+        const movesVessel =
+          !!input.destinationVesselId &&
+          input.destinationVesselId !== input.vesselId;
+        let destinationVesselName: string | null = null;
+
+        if (movesVessel) {
+          const destVessel = await db
+            .select({ id: vessels.id, name: vessels.name, status: vessels.status })
+            .from(vessels)
+            .where(
+              and(
+                eq(vessels.id, input.destinationVesselId!),
+                isNull(vessels.deletedAt),
+              ),
+            )
+            .limit(1);
+
+          if (!destVessel.length) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Destination vessel not found",
+            });
+          }
+
+          const occupant = await db
+            .select({ id: batches.id })
+            .from(batches)
+            .where(
+              and(
+                eq(batches.vesselId, input.destinationVesselId!),
+                inArray(batches.status, ["fermentation", "aging", "conditioning"]),
+                isNull(batches.deletedAt),
+              ),
+            )
+            .limit(1);
+
+          if (occupant.length) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Destination vessel ${destVessel[0].name} already holds a batch — filtering can only move into an empty vessel`,
+            });
+          }
+
+          destinationVesselName = destVessel[0].name;
+        }
+
+        // Update batch current volume (and vessel, when filtering into another tank)
         await db
           .update(batches)
           .set({
             currentVolume: volumeRackedL.toFixed(3),
             currentVolumeLiters: volumeRackedL.toFixed(3),
             currentVolumeUnit: 'L',
+            ...(movesVessel ? { vesselId: input.destinationVesselId! } : {}),
             updatedAt: new Date(),
           })
           .where(eq(batches.id, input.batchId));
+
+        // Record the vessel move as a full transfer so lineage and vessel
+        // history stay traceable.
+        if (movesVessel) {
+          await db.insert(batchTransfers).values({
+            sourceBatchId: input.batchId,
+            sourceVesselId: input.vesselId,
+            destinationBatchId: input.batchId,
+            destinationVesselId: input.destinationVesselId!,
+            volumeTransferred: volumeRackedL.toFixed(3),
+            volumeTransferredUnit: "L",
+            loss: volumeLossL.toFixed(3),
+            lossUnit: "L",
+            totalVolumeProcessed: volumeBeforeL.toFixed(3),
+            totalVolumeProcessedUnit: "L",
+            notes: `Filtered (${input.filterType}) into ${destinationVesselName}${input.notes ? ` | ${input.notes}` : ""}`,
+            transferredBy: ctx.user?.id,
+            transferredAt: input.filteredAt || new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+        }
 
         // Write filter loss ledger entry
         const filterLoss = volumeBeforeL - volumeRackedL;
@@ -5461,7 +5535,7 @@ export const batchRouter = router({
           success: true,
           filterOperation: filterOperation[0],
           volumeLoss: volumeLossL,
-          message: `Batch filtered with ${input.filterType} filter. Loss: ${volumeLossL.toFixed(2)}L`,
+          message: `Batch filtered with ${input.filterType} filter${destinationVesselName ? ` into ${destinationVesselName}` : ""}. Loss: ${volumeLossL.toFixed(2)}L`,
         };
       } catch (error) {
         if (error instanceof TRPCError) throw error;

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -369,7 +369,7 @@ export const recipeExecutionRouter = router({
         familyConditions.push(eq(batches.id, selfBatch.parentBatchId));
         familyConditions.push(eq(batches.parentBatchId, selfBatch.parentBatchId));
       }
-      const familyRows = await db
+      const familyRowsRaw = await db
         .select({
           id: batches.id,
           batchNumber: batches.batchNumber,
@@ -384,6 +384,28 @@ export const recipeExecutionRouter = router({
             isNull(batches.deletedAt),
           ),
         );
+      // Only relatives that run the SAME recipe belong to this execution's
+      // family (split clones copy recipeId + version). Without this filter a
+      // recipe batch drawing from parent batches would count its parents' and
+      // step-siblings' packaging (e.g. every keg its source cider's other
+      // children ever filled) as its own.
+      const relatedExecs = familyRowsRaw.length
+        ? await db
+            .select({ batchId: batchRecipeExecutions.batchId })
+            .from(batchRecipeExecutions)
+            .where(
+              and(
+                inArray(
+                  batchRecipeExecutions.batchId,
+                  familyRowsRaw.map((b) => b.id),
+                ),
+                eq(batchRecipeExecutions.recipeId, execution.recipeId),
+                eq(batchRecipeExecutions.recipeVersion, execution.recipeVersion),
+              ),
+            )
+        : [];
+      const sameRecipeIds = new Set(relatedExecs.map((e) => e.batchId));
+      const familyRows = familyRowsRaw.filter((b) => sameRecipeIds.has(b.id));
       const familyIds = familyRows.map((b) => b.id);
       const familyLabel = new Map(
         familyRows.map((b) => [b.id, b.customName || b.name || b.batchNumber]),

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -613,7 +613,15 @@ export const recipeExecutionRouter = router({
             .where(eq(batches.id, src.id));
           // One instant shared by the merge_history and transfer rows for this
           // source, so the activity timeline can pair and de-duplicate them.
-          const blendedAt = new Date();
+          // Back-filled executions (start date in the past) stamp the intended
+          // start date, not the data-entry moment — otherwise date validation
+          // anchors the batch's "earliest valid date" to entry day and blocks
+          // recording the July work that followed.
+          const execStart = exec.startDate ? new Date(exec.startDate) : null;
+          const blendedAt =
+            execStart && !Number.isNaN(execStart.getTime()) && execStart.getTime() < Date.now()
+              ? execStart
+              : new Date();
           await tx.insert(batchMergeHistory).values({
             targetBatchId: task.batchId,
             sourceBatchId: src.id,
@@ -663,12 +671,18 @@ export const recipeExecutionRouter = router({
         if (ogWeight > 0) fill.originalGravity = (ogWeighted / ogWeight).toFixed(4);
         await tx.update(batches).set(fill).where(eq(batches.id, task.batchId));
 
-        // Mark done + reschedule.
+        // Mark done + reschedule. The completion date mirrors the transfer
+        // date (exec start for back-fills) so the schedule re-anchors off the
+        // real event, not the data-entry day.
+        const transferDoneAt =
+          exec.startDate && new Date(exec.startDate).getTime() < Date.now()
+            ? new Date(exec.startDate)
+            : new Date();
         await tx
           .update(batchStepTasks)
           .set({
             status: "done",
-            completedAt: new Date(),
+            completedAt: transferDoneAt,
             actualData: { destinationVesselId: input.destinationVesselId, sources: draws, totalL },
             updatedAt: new Date(),
           })

--- a/packages/api/src/routers/recipes.ts
+++ b/packages/api/src/routers/recipes.ts
@@ -407,6 +407,7 @@ export const recipesRouter = router({
                 label: i.label,
                 additiveType: i.additiveType ?? null,
                 additiveName: i.additiveName ?? null,
+                additiveVarietyId: i.additiveVarietyId ?? null,
                 rateValue: i.rateValue?.toString() ?? null,
                 rateUnit: i.rateUnit ?? null,
                 sourceProductType: i.sourceProductType ?? null,


### PR DESCRIPTION
## Summary

Recipe execution & cellar fixes, several found live while back-filling July batches:

- **Filter action: optional destination tank** — `batch.filter` accepts `destinationVesselId` (validated empty vessel), moves the batch, records a full transfer; FilterModal gains a "Filter Into" selector; recipe filter steps inherit it
- **Recipe save no longer wipes ingredient-inventory links** (update mutation omitted `additiveVarietyId` on re-insert)
- **Additive steps prefill the linked inventory item** (by variety id, first available lot) and **default the date to the step's scheduled date**
- **Every real form reports its actual date** (filter/carbonate/keg/bottle/pasteurize/label/measurement) → step completes with that date → `recomputeSchedule` re-anchors remaining steps; back-filled `performTransfer` stamps the execution start date instead of entry time
- **Checklist family scoped to same-recipe relatives** — fixes packaged actuals counting the source ciders' other children ("kegged 723 of 0 L")
- **Header shows packaging progress only for planned paths**

## Testing

- `pnpm typecheck` clean (api + web) throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)