### PR TITLE
Recipe checklist: back-fill-safe completion dates

### DIFF
--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -71,6 +71,7 @@ type Task = {
   packagingPath: string;
   isOptional: boolean;
   scheduledDate: string | Date | null;
+  completedAt?: string | Date | null;
   status: string;
   notes: string | null;
   actionData: Record<string, unknown> | null;
@@ -241,7 +242,16 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
         (o.packagingPath === "all" || o.packagingPath === t.packagingPath),
     );
     if (earlierOpen && !confirm("Earlier steps aren't done yet. Complete this one anyway?")) return;
-    complete.mutate({ taskId: t.id });
+    // Quick-done on an overdue step means "done per plan" — anchor to the
+    // scheduled date so back-filled work doesn't reschedule everything to the
+    // data-entry day. Current/future steps complete at now as before.
+    const sched = t.scheduledDate ? new Date(t.scheduledDate) : null;
+    const backfilledAt =
+      sched && !Number.isNaN(sched.getTime()) && sched.getTime() < Date.now() ? sched : undefined;
+    complete.mutate({
+      taskId: t.id,
+      ...(backfilledAt ? { completedAt: backfilledAt } : {}),
+    });
   };
   const onSkip = (t: Task) => {
     // Path-specific steps (bottle-only / keg-only) are inherently optional when
@@ -425,7 +435,13 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                   <TableCell
                     className={`text-sm ${rs === "overdue" ? "text-red-600 font-medium" : ""}`}
                   >
-                    {fmtDate(t.scheduledDate)}
+                    {/* Done/skipped steps show when they actually happened;
+                        open steps show the (re-anchored) plan date. */}
+                    {fmtDate(
+                      (t.status === "done" || t.status === "skipped") && t.completedAt
+                        ? t.completedAt
+                        : t.scheduledDate,
+                    )}
                   </TableCell>
                   <TableCell>
                     <Badge variant="outline" className={`text-[10px] ${STATUS_DISPLAY[rs].cls}`}>

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -154,8 +154,16 @@ export function StepDetailModal({
   };
 
   const onMarkDone = () => {
+    // Marking an overdue step done means "done per plan" — anchor to the
+    // scheduled date so the remaining schedule doesn't jump to entry day.
+    const sched = task.scheduledDate ? new Date(task.scheduledDate) : null;
+    const backfilledAt =
+      sched && !Number.isNaN(sched.getTime()) && sched.getTime() < Date.now()
+        ? sched
+        : undefined;
     complete.mutate({
       taskId: task.id,
+      ...(backfilledAt ? { completedAt: backfilledAt } : {}),
       actualData: buildActualData(),
       notes: notes.trim() || null,
     });


### PR DESCRIPTION
Found while back-filling the Strawberry Rhubarb batch: steps completed via the generic Mark Complete / quick Done were stamped with the entry moment, which re-anchored the remaining schedule to entry day (a rack step showed due Aug 8 in a July plan). Overdue steps now complete at their scheduled date ("done per plan"); current steps still complete at now. The Due column shows the actual date for done/skipped steps instead of a stale plan date.

Also (data + recipe): the "Rack and coarse filter" step is now mandatory per the owner — recipe and in-flight batch updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)