### PR TITLE
Packaging: bulk keg cleaning

### DIFF
--- a/apps/web/src/app/packaging/page.tsx
+++ b/apps/web/src/app/packaging/page.tsx
@@ -46,6 +46,7 @@ import {
   CheckCircle,
   Package2,
   AlertTriangle,
+  Droplets,
 } from "lucide-react";
 import { performanceMonitor } from "@/lib/performance-monitor";
 import { PackagingFiltersSkeleton, PackagingTableRowSkeleton } from "./loading";
@@ -241,8 +242,10 @@ export default function PackagingPage() {
       .filter((item: any) => selectedItems.includes(item.id))
       .map((item: any) => ({
         id: item.id,
+        kegId: item.kegId,
         kegNumber: item.kegNumber,
         status: item.status,
+        kegStatus: item.kegStatus,
         distributedAt: item.distributedAt,
         distributionLocation: item.distributionLocation,
       }));
@@ -251,15 +254,48 @@ export default function PackagingPage() {
   // Determine which bulk actions are available based on selected kegs
   const bulkActionAvailability = useMemo(() => {
     if (selectedKegs.length === 0) {
-      return { canDistribute: false, canReturn: false };
+      return { canDistribute: false, canReturn: false, canClean: false };
     }
     const hasFilledKegs = selectedKegs.some((k) => k.status === "filled");
     const hasDistributedKegs = selectedKegs.some((k) => k.status === "distributed");
+    // "Needs Cleaning" = the physical keg sits in cleaning status
+    const hasDirtyKegs = selectedKegs.some((k) => k.kegStatus === "cleaning" && k.kegId);
     return {
       canDistribute: hasFilledKegs,
       canReturn: hasDistributedKegs,
+      canClean: hasDirtyKegs,
     };
   }, [selectedKegs]);
+
+  const bulkCleanMutation = trpc.packaging.kegs.bulkCleanKegs.useMutation({
+    onSuccess: (res) => {
+      toast({
+        title: "Kegs cleaned",
+        description:
+          res.skipped > 0
+            ? `${res.message} (${res.skipped} skipped — not in cleaning status)`
+            : res.message,
+      });
+      utils.packaging.list.invalidate();
+      utils.packaging.getStats.invalidate();
+      setSelectedItems([]);
+      setShowBulkActions(false);
+    },
+    onError: (e) =>
+      toast({ title: "Cleaning failed", description: e.message, variant: "destructive" }),
+  });
+  const handleBulkClean = useCallback(() => {
+    // Unique physical kegs among the selected fills that need cleaning
+    const kegIds = Array.from(
+      new Set(
+        selectedKegs
+          .filter((k) => k.kegStatus === "cleaning" && k.kegId)
+          .map((k) => k.kegId as string),
+      ),
+    );
+    if (kegIds.length === 0) return;
+    bulkCleanMutation.mutate({ kegIds });
+  }, [selectedKegs, bulkCleanMutation]);
 
   const handleBulkDistribute = useCallback(() => {
     setBulkDistributeOpen(true);
@@ -761,6 +797,21 @@ export default function PackagingPage() {
                         <RotateCcw className="w-3.5 h-3.5 mr-2" />
                         <span className="hidden sm:inline">Return</span>
                         <span className="sm:hidden">Ret</span>
+                      </Button>
+                    )}
+                    {bulkActionAvailability.canClean && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleBulkClean}
+                        disabled={bulkCleanMutation.isPending}
+                        className="border-blue-300 bg-white text-blue-700 hover:bg-blue-50 h-9"
+                      >
+                        <Droplets className="w-3.5 h-3.5 mr-2" />
+                        <span className="hidden sm:inline">
+                          {bulkCleanMutation.isPending ? "Cleaning…" : "Mark Cleaned"}
+                        </span>
+                        <span className="sm:hidden">Clean</span>
                       </Button>
                     )}
                     <Button

--- a/packages/api/src/routers/kegs.ts
+++ b/packages/api/src/routers/kegs.ts
@@ -1844,6 +1844,56 @@ export const kegsRouter = router({
     }),
 
   /**
+   * Mass-clean kegs: every selected keg in "cleaning" status becomes
+   * "available". Kegs in other states are counted as skipped rather than
+   * failing the whole batch — the operator selects rows in bulk and some may
+   * already be clean.
+   */
+  bulkCleanKegs: createRbacProcedure("update", "package")
+    .input(
+      z.object({
+        kegIds: z.array(z.string().uuid()).min(1).max(500),
+        cleanedAt: z
+          .date()
+          .or(z.string().transform((val) => new Date(val)))
+          .optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      try {
+        const rows = await db
+          .select({ id: kegs.id, status: kegs.status })
+          .from(kegs)
+          .where(and(inArray(kegs.id, input.kegIds), isNull(kegs.deletedAt)));
+
+        const cleanable = rows
+          .filter((k) => k.status === "cleaning")
+          .map((k) => k.id);
+
+        if (cleanable.length) {
+          await db
+            .update(kegs)
+            .set({ status: "available", updatedAt: new Date() })
+            .where(inArray(kegs.id, cleanable));
+        }
+
+        return {
+          success: true,
+          cleaned: cleanable.length,
+          skipped: input.kegIds.length - cleanable.length,
+          message: `${cleanable.length} keg${cleanable.length === 1 ? "" : "s"} marked clean and available`,
+        };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        console.error("Error bulk-cleaning kegs:", error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to clean kegs",
+        });
+      }
+    }),
+
+  /**
    * Get detailed information about a specific keg fill
    * Returns full fill details with batch composition, keg info, and history
    */


### PR DESCRIPTION
Returned kegs pile up in "Needs Cleaning" with no mass action — 91 kegs meant 91 modal round-trips. Selecting rows in the Kegs tab now offers **Mark Cleaned** alongside Distribute/Return/Export: every selected keg in cleaning status becomes available in one call (kegs in other states are skipped and reported, not errored).

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)