### PR TITLE
Keg cleaning history

### DIFF
--- a/apps/web/src/components/packaging/kegs/KegDetailsModal.tsx
+++ b/apps/web/src/components/packaging/kegs/KegDetailsModal.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { Package, Calendar, MapPin, Loader2, Wine, Edit } from "lucide-react";
+import { Package, Calendar, MapPin, Loader2, Wine, Edit, Droplets } from "lucide-react";
 import { formatDate } from "@/utils/date-format";
 import { trpc } from "@/utils/trpc";
 import { EditKegModal } from "./EditKegModal";
@@ -52,8 +52,14 @@ export function KegDetailsModal({
     { enabled: open && !!kegId },
   );
 
+  const { data: cleaningData } = trpc.packaging.kegs.getCleaningHistory.useQuery(
+    { kegId },
+    { enabled: open && !!kegId },
+  );
+
   const keg = data?.keg;
   const fills = data?.fills || [];
+  const cleanings = cleaningData?.items ?? [];
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
@@ -261,6 +267,50 @@ export function KegDetailsModal({
                         </TableBody>
                       </Table>
                     </div>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+
+            {/* Cleaning History */}
+            <div>
+              <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                <Droplets className="w-5 h-5" />
+                Cleaning History ({cleanings.length})
+              </h3>
+              {cleanings.length === 0 ? (
+                <Card>
+                  <CardContent className="py-8 text-center text-gray-500">
+                    No cleanings recorded yet
+                  </CardContent>
+                </Card>
+              ) : (
+                <Card>
+                  <CardContent className="p-0">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Cleaned</TableHead>
+                          <TableHead>By</TableHead>
+                          <TableHead>Notes</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {cleanings.map((c) => (
+                          <TableRow key={c.id}>
+                            <TableCell className="text-sm">
+                              {formatDate(c.cleanedAt)}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {c.cleanedByName || c.cleanedByEmail || "—"}
+                            </TableCell>
+                            <TableCell className="text-sm text-gray-600">
+                              {c.notes || "—"}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
                   </CardContent>
                 </Card>
               )}

--- a/packages/api/src/routers/kegs.ts
+++ b/packages/api/src/routers/kegs.ts
@@ -21,6 +21,7 @@ import {
   batchTransfers,
   batchCarbonationOperations,
   salesChannels,
+  kegCleaningOperations,
 } from "db";
 import { eq, and, desc, isNull, sql, like, or, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
@@ -1829,6 +1830,14 @@ export const kegsRouter = router({
           })
           .where(eq(kegs.id, input.kegId));
 
+        // Log the cleaning event (per-keg history)
+        await db.insert(kegCleaningOperations).values({
+          kegId: input.kegId,
+          cleanedAt: input.cleanedAt ?? new Date(),
+          cleanedBy: ctx.user?.id ?? null,
+          notes: input.notes ?? null,
+        });
+
         return {
           success: true,
           message: `Keg ${keg.kegNumber} is now available`,
@@ -1857,9 +1866,10 @@ export const kegsRouter = router({
           .date()
           .or(z.string().transform((val) => new Date(val)))
           .optional(),
+        notes: z.string().optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       try {
         const rows = await db
           .select({ id: kegs.id, status: kegs.status })
@@ -1875,6 +1885,17 @@ export const kegsRouter = router({
             .update(kegs)
             .set({ status: "available", updatedAt: new Date() })
             .where(inArray(kegs.id, cleanable));
+
+          // Log one cleaning event per keg (per-keg history)
+          const cleanedAt = input.cleanedAt ?? new Date();
+          await db.insert(kegCleaningOperations).values(
+            cleanable.map((kegId) => ({
+              kegId,
+              cleanedAt,
+              cleanedBy: ctx.user?.id ?? null,
+              notes: input.notes ?? null,
+            })),
+          );
         }
 
         return {
@@ -1891,6 +1912,31 @@ export const kegsRouter = router({
           message: "Failed to clean kegs",
         });
       }
+    }),
+
+  /** Per-keg cleaning history (newest first). */
+  getCleaningHistory: createRbacProcedure("list", "package")
+    .input(z.object({ kegId: z.string().uuid(), limit: z.number().min(1).max(200).default(50) }))
+    .query(async ({ input }) => {
+      const rows = await db
+        .select({
+          id: kegCleaningOperations.id,
+          cleanedAt: kegCleaningOperations.cleanedAt,
+          notes: kegCleaningOperations.notes,
+          cleanedByName: users.name,
+          cleanedByEmail: users.email,
+        })
+        .from(kegCleaningOperations)
+        .leftJoin(users, eq(kegCleaningOperations.cleanedBy, users.id))
+        .where(
+          and(
+            eq(kegCleaningOperations.kegId, input.kegId),
+            isNull(kegCleaningOperations.deletedAt),
+          ),
+        )
+        .orderBy(desc(kegCleaningOperations.cleanedAt))
+        .limit(input.limit);
+      return { items: rows };
     }),
 
   /**

--- a/packages/db/migrations/0155_keg_cleaning_operations.sql
+++ b/packages/db/migrations/0155_keg_cleaning_operations.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "keg_cleaning_operations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"keg_id" uuid NOT NULL,
+	"cleaned_at" timestamp DEFAULT now() NOT NULL,
+	"cleaned_by" uuid,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "keg_cleaning_operations" ADD CONSTRAINT "keg_cleaning_operations_keg_id_kegs_id_fk" FOREIGN KEY ("keg_id") REFERENCES "kegs"("id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "keg_cleaning_ops_keg_idx" ON "keg_cleaning_operations" ("keg_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "keg_cleaning_ops_cleaned_at_idx" ON "keg_cleaning_operations" ("cleaned_at");

--- a/packages/db/src/schema/packaging.ts
+++ b/packages/db/src/schema/packaging.ts
@@ -659,6 +659,28 @@ export const kegs = pgTable(
   }),
 );
 
+// Keg cleaning log — one row per cleaning event (single or bulk action), so
+// each physical keg carries a when/who/notes cleaning history.
+export const kegCleaningOperations = pgTable(
+  "keg_cleaning_operations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    kegId: uuid("keg_id")
+      .notNull()
+      .references(() => kegs.id),
+    cleanedAt: timestamp("cleaned_at").notNull().defaultNow(),
+    cleanedBy: uuid("cleaned_by"),
+    notes: text("notes"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at"),
+  },
+  (table) => ({
+    kegIdx: index("keg_cleaning_ops_keg_idx").on(table.kegId),
+    cleanedAtIdx: index("keg_cleaning_ops_cleaned_at_idx").on(table.cleanedAt),
+  }),
+);
+
 // Keg fills table - Track keg fill operations
 export const kegFills = pgTable(
   "keg_fills",


### PR DESCRIPTION
Cleaning a keg previously only flipped status (cleaning → available) with no record of when or by whom.

- `keg_cleaning_operations` table (migration 0155 — **already applied to the database**): one row per cleaning event with cleaned_at / cleaned_by / notes
- Both the single `cleanKeg` and the bulk `bulkCleanKegs` actions write history rows
- `packaging.kegs.getCleaningHistory` + a Cleaning History section in the keg details modal (date / who / notes)

## Testing
- `pnpm typecheck` clean (db + api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)