### PR TITLE
Kegs: Returned tab = cleaning queue; cleaned kegs return to cellar

### DIFF
--- a/packages/api/src/routers/kegs.ts
+++ b/packages/api/src/routers/kegs.ts
@@ -1821,11 +1821,12 @@ export const kegsRouter = router({
           });
         }
 
-        // Update keg status to available
+        // Update keg status to available and send it home to the cellar
         await db
           .update(kegs)
           .set({
             status: "available",
+            currentLocation: "cellar",
             updatedAt: new Date(),
           })
           .where(eq(kegs.id, input.kegId));
@@ -1883,7 +1884,7 @@ export const kegsRouter = router({
         if (cleanable.length) {
           await db
             .update(kegs)
-            .set({ status: "available", updatedAt: new Date() })
+            .set({ status: "available", currentLocation: "cellar", updatedAt: new Date() })
             .where(inArray(kegs.id, cleanable));
 
           // Log one cleaning event per keg (per-keg history)

--- a/packages/db/src/queries/unified-packaging-query.ts
+++ b/packages/db/src/queries/unified-packaging-query.ts
@@ -247,8 +247,12 @@ export async function getUnifiedPackagingRuns(
         // Distributed (out at location)
         kegConditions.push(eq(kegFills.status, "distributed"));
       } else if (filters.status === "completed") {
-        // For kegs, completed means returned
+        // For kegs, "Returned" is the cleaning queue: returned fills whose
+        // physical keg hasn't been cleaned yet. Once cleaned, the keg is back
+        // in circulation and drops off this list — its full fill/cleaning
+        // history stays on the keg's detail view.
         kegConditions.push(eq(kegFills.status, "returned"));
+        kegConditions.push(eq(kegs.status, "cleaning"));
       }
     }
 


### PR DESCRIPTION
A returned keg is on the Returned tab because it needs cleaning; once cleaned it's just an available keg again and shouldn't clutter the queue.

- The Returned tab now filters to returned fills whose keg is still in cleaning status — cleaned kegs drop off (history remains on the keg's detail view)
- Both clean actions also set the keg's location back to "cellar"

## Testing
- `pnpm typecheck` clean (db + api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)