### PR TITLE
Fix Returned tab: count query missing kegs join

### DIFF
--- a/packages/db/src/queries/unified-packaging-query.ts
+++ b/packages/db/src/queries/unified-packaging-query.ts
@@ -367,10 +367,13 @@ export async function getUnifiedPackagingRuns(
         : null,
     }));
 
-    // Get count (use same conditions as main query)
+    // Get count (use same conditions as main query). The conditions can
+    // reference kegs (Returned tab filters on kegs.status), so the count
+    // query must always carry the kegs join.
     let countQuery = db
       .select({ count: sql<number>`count(*)` })
-      .from(kegFills);
+      .from(kegFills)
+      .leftJoin(kegs, eq(kegFills.kegId, kegs.id));
 
     if (filters.batchSearch) {
       countQuery = countQuery.leftJoin(batches, eq(kegFills.batchId, batches.id));


### PR DESCRIPTION
The PR #135 cleaning-queue filter references `kegs.status` in conditions shared by the list and count queries, but the count query lacked the kegs join → SQL error → the Returned tab rendered "No keg fills found". Reproduced locally against the live DB; with the join the tab returns the 63-keg cleaning queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)