### PR TITLE
Auto-promote packaging to Ready when the last step completes

### DIFF
--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -2359,6 +2359,20 @@ export const packagingRouter = router({
             updateData.labeledAt = input.labeledAt || new Date();
           }
 
+          // Auto-promote to Ready when the last post-fill step completes:
+          // once every produced unit is labeled the run is finished goods —
+          // no manual "Mark Ready" needed. Manual promotion still works for
+          // runs labeled outside this flow.
+          if (
+            newUnitsLabeled >= bottleRun.unitsProduced &&
+            (bottleRun.status === "active" || bottleRun.status === null)
+          ) {
+            updateData.status = "ready";
+            updateData.readyAt =
+              bottleRun.readyAt ?? input.labeledAt ?? new Date();
+            updateData.readyBy = ctx.session.user.id;
+          }
+
           await tx
             .update(bottleRuns)
             .set(updateData)

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -520,17 +520,37 @@ export const recipeExecutionRouter = router({
     .mutation(async ({ input }) => {
       return await db.transaction(async (tx) => {
         const task = await loadTask(tx, input.taskId);
+        const completedAt = input.completedAt ?? new Date();
         await tx
           .update(batchStepTasks)
           .set({
             status: "done",
-            completedAt: input.completedAt ?? new Date(),
+            completedAt,
             actualHours: input.actualHours != null ? input.actualHours.toString() : task.actualHours,
             notes: input.notes ?? task.notes,
             actualData: input.actualData ?? task.actualData,
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));
+
+        // Auto-promote finished goods: completing the keg path's "Label Kegs"
+        // step means those kegs are done — flip this batch's filled kegs to
+        // ready so the operator never has to Mark Ready manually. (Bottles
+        // get the same treatment inside packaging.addLabel.)
+        if (task.packagingPath === "keg" && /label/i.test(task.label ?? "")) {
+          await tx
+            .update(kegFills)
+            .set({ status: "ready", readyAt: completedAt, updatedAt: new Date() })
+            .where(
+              and(
+                eq(kegFills.batchId, task.batchId),
+                eq(kegFills.status, "filled"),
+                isNull(kegFills.deletedAt),
+                isNull(kegFills.voidedAt),
+              ),
+            );
+        }
+
         await recomputeSchedule(tx, task.executionId);
         return { tasks: await tasksForExecution(tx, task.executionId) };
       });


### PR DESCRIPTION
"In Progress → Ready" previously always required a manual Mark Ready click even when the operator had just completed the final real step.

- **Bottles**: fully labeling a run (unitsLabeled reaches unitsProduced via `packaging.addLabel`) auto-promotes active → ready, `readyAt` = label date
- **Kegs**: completing the keg path's "Label Kegs" recipe step promotes that batch's filled kegs to ready, `readyAt` = the step's actual completion date

Manual Mark Ready still works for anything outside these flows.

## Testing
- `pnpm typecheck` clean (api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)