### PR TITLE
Labels: warn (don't block) on insufficient stock

### DIFF
--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -192,6 +192,24 @@ export function LabelModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const onSubmit = async (data: LabelForm) => {
+    // Insufficient stock warns and confirms — never blocks. The labels are
+    // physically on the bottles; inventory goes negative until restocked.
+    const shortages = data.labels
+      .map((l) => {
+        const item = packagingItems?.items.find((i) => i.id === l.packagingItemId);
+        return item && l.quantity > item.quantity
+          ? `${item.size || "Label"}: using ${l.quantity}, only ${item.quantity} in stock`
+          : null;
+      })
+      .filter(Boolean);
+    if (shortages.length > 0) {
+      const ok = window.confirm(
+        `Labeling will take inventory negative:\n\n${shortages.join("\n")}\n\n` +
+          `Record it anyway? (Add a label purchase later to bring stock back up.)`,
+      );
+      if (!ok) return;
+    }
+
     setIsSubmitting(true);
     const labeledAt = parseDateTimeFromInput(data.labeledAt);
     const appliedLabelsList: Array<{name: string, quantity: number}> = [];
@@ -473,10 +491,11 @@ export function LabelModal({
                           </div>
                         )}
                         {hasInsufficientStock && (
-                          <div className="flex items-start gap-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+                          <div className="flex items-start gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
                             <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
                             <span>
-                              Insufficient stock! Only {selectedItem?.quantity} available.
+                              Only {selectedItem?.quantity} in stock — labeling will
+                              take the inventory negative until you restock.
                             </span>
                           </div>
                         )}

--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -2299,14 +2299,11 @@ export const packagingRouter = router({
             });
           }
 
-          // Check if enough stock (available = quantity - quantityUsed)
+          // Available = quantity - quantityUsed. Insufficient stock does NOT
+          // block — recording the labels that physically went on the bottles
+          // beats the inventory record; the count goes negative until the
+          // owner restocks. The client warns and confirms before submitting.
           const available = packagingItem.quantity - (packagingItem.quantityUsed || 0);
-          if (available < input.quantity) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: `Insufficient labels in stock. Available: ${available}, Requested: ${input.quantity}`,
-            });
-          }
 
           // Increment quantityUsed instead of decrementing quantity
           await tx


### PR DESCRIPTION
Hit while labeling 216 bottles with 167 labels on record: the server rejected the operation. Physical reality wins — the modal now warns (amber notice + confirm dialog listing shortages) and proceeds; the label inventory goes negative until a purchase brings it back up. Same policy as additive stock.

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)