### PR TITLE
Step modal: completion date + labor tracking

### DIFF
--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -11,7 +11,7 @@
  * the vessel, draw down inventory) get wired in next, kind by kind.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -29,6 +29,8 @@ import { Badge } from "@/components/ui/badge";
 import { Check } from "lucide-react";
 import { DateInput } from "@/components/ui/date-input";
 import { formatDateForInput, parseDateInput } from "@/utils/date-format";
+import { useDateFormat } from "@/hooks/useDateFormat";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 import { AddBatchMeasurementForm } from "@/components/cellar/AddBatchMeasurementForm";
 import { AddBatchAdditiveForm } from "@/components/cellar/AddBatchAdditiveForm";
 
@@ -98,6 +100,24 @@ export function StepDetailModal({
   const [labelDateEdit, setLabelDateEdit] = useState<{ taskId: string; value: string } | null>(
     null,
   );
+  // Completion date + labor for capture-first steps — same conventions as the
+  // cellar forms: date defaults to the step's scheduled date when back-filling
+  // (schedule re-anchors from it), labor rows feed COGS.
+  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const [completedAtStr, setCompletedAtStr] = useState("");
+  const [laborAssignments, setLaborAssignments] = useState<WorkerAssignment[]>([]);
+  useEffect(() => {
+    if (!task) return;
+    const sched = task.scheduledDate ? new Date(task.scheduledDate) : null;
+    const seed =
+      sched && !Number.isNaN(sched.getTime()) && sched.getTime() < Date.now()
+        ? sched
+        : new Date();
+    setCompletedAtStr(formatDateTimeForInput(seed));
+    setLaborAssignments([]);
+    setNotes(task.notes ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [task?.id]);
 
   // Total to transfer = sum of each source cider's planned draw (set at
   // instantiation); falls back to the batch's planned volume.
@@ -154,16 +174,16 @@ export function StepDetailModal({
   };
 
   const onMarkDone = () => {
-    // Marking an overdue step done means "done per plan" — anchor to the
-    // scheduled date so the remaining schedule doesn't jump to entry day.
-    const sched = task.scheduledDate ? new Date(task.scheduledDate) : null;
-    const backfilledAt =
-      sched && !Number.isNaN(sched.getTime()) && sched.getTime() < Date.now()
-        ? sched
-        : undefined;
+    // The visible date field is authoritative (seeded with the scheduled date
+    // for overdue steps, now otherwise) — the schedule re-anchors from it.
+    const at = completedAtStr ? parseDateTimeFromInput(completedAtStr) : undefined;
+    const labor = toApiLaborAssignments(
+      laborAssignments.filter((a) => a.workerId && a.hoursWorked > 0),
+    );
     complete.mutate({
       taskId: task.id,
-      ...(backfilledAt ? { completedAt: backfilledAt } : {}),
+      ...(at ? { completedAt: at } : {}),
+      ...(labor.length ? { laborAssignments: labor } : {}),
       actualData: buildActualData(),
       notes: notes.trim() || null,
     });
@@ -388,6 +408,21 @@ export function StepDetailModal({
               </div>
             )}
 
+            {/* Completion date — same convention as the cellar forms */}
+            {!isDone && task.kind !== "transfer" && (
+              <div>
+                <Label className="text-xs">
+                  Completed Date & Time <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  type="datetime-local"
+                  value={completedAtStr}
+                  onChange={(e) => setCompletedAtStr(e.target.value)}
+                  className="text-sm mt-1"
+                />
+              </div>
+            )}
+
             {/* Notes — every capture-first kind */}
             <div>
               <Label className="text-xs">Notes</Label>
@@ -399,6 +434,15 @@ export function StepDetailModal({
                 disabled={isDone}
               />
             </div>
+
+            {/* Labor tracking — same component as the cellar forms */}
+            {!isDone && task.kind !== "transfer" && (
+              <WorkerLaborInput
+                value={laborAssignments}
+                onChange={setLaborAssignments}
+                activityLabel="this step"
+              />
+            )}
 
             <div className="flex justify-end gap-2 pt-1">
               <Button variant="outline" size="sm" onClick={onClose}>

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -32,6 +32,8 @@ import {
   batchTransfers,
   bottleRuns,
   kegFills,
+  workers,
+  activityLaborAssignments,
 } from "db";
 import { buildStepSchedule, rescheduleWithActuals } from "lib";
 import { router, createRbacProcedure } from "../trpc";
@@ -515,23 +517,60 @@ export const recipeExecutionRouter = router({
         actualHours: z.number().nonnegative().nullish(),
         notes: z.string().nullish(),
         actualData: z.record(z.string(), z.unknown()).nullish(),
+        laborAssignments: z
+          .array(
+            z.object({
+              workerId: z.string().uuid(),
+              hoursWorked: z.number().positive(),
+            }),
+          )
+          .optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       return await db.transaction(async (tx) => {
         const task = await loadTask(tx, input.taskId);
         const completedAt = input.completedAt ?? new Date();
+        const laborSum = input.laborAssignments?.reduce((s, a) => s + a.hoursWorked, 0);
         await tx
           .update(batchStepTasks)
           .set({
             status: "done",
             completedAt,
-            actualHours: input.actualHours != null ? input.actualHours.toString() : task.actualHours,
+            actualHours:
+              input.actualHours != null
+                ? input.actualHours.toString()
+                : laborSum
+                  ? laborSum.toString()
+                  : task.actualHours,
             notes: input.notes ?? task.notes,
             actualData: input.actualData ?? task.actualData,
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));
+
+        // Labor tracking for step kinds with no dedicated operation record
+        // (remove fruit, label kegs, ...). Rack steps count as racking labor;
+        // everything else logs as generic recipe_step work, linked to the task.
+        if (input.laborAssignments?.length) {
+          for (const a of input.laborAssignments) {
+            const [w] = await tx
+              .select({ hourlyRate: workers.hourlyRate })
+              .from(workers)
+              .where(eq(workers.id, a.workerId))
+              .limit(1);
+            const rate = parseFloat(w?.hourlyRate?.toString() || "20.00");
+            await tx.insert(activityLaborAssignments).values({
+              activityType: task.kind === "rack" ? "racking" : "recipe_step",
+              batchStepTaskId: task.id,
+              workerId: a.workerId,
+              hoursWorked: a.hoursWorked.toString(),
+              hourlyRateSnapshot: rate.toString(),
+              laborCost: (a.hoursWorked * rate).toString(),
+              createdBy: ctx.user?.id ?? null,
+            });
+          }
+        }
 
         // Auto-promote finished goods: completing the keg path's "Label Kegs"
         // step means those kegs are done — flip this batch's filled kegs to

--- a/packages/db/migrations/0156_step_labor.sql
+++ b/packages/db/migrations/0156_step_labor.sql
@@ -1,0 +1,7 @@
+ALTER TYPE "activity_labor_type" ADD VALUE IF NOT EXISTS 'recipe_step';
+--> statement-breakpoint
+ALTER TABLE "activity_labor_assignments" ADD COLUMN IF NOT EXISTS "batch_step_task_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "activity_labor_assignments" ADD CONSTRAINT "activity_labor_assignments_batch_step_task_id_fk" FOREIGN KEY ("batch_step_task_id") REFERENCES "batch_step_tasks"("id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "activity_labor_step_task_idx" ON "activity_labor_assignments" ("batch_step_task_id");

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -118,6 +118,9 @@ export const activityLaborTypeEnum = pgEnum("activity_labor_type", [
   "carbonation",
   "cleaning",
   "destruction",
+  // Generic recipe-step work (linked via batchStepTaskId) for step kinds
+  // without a dedicated operation record (remove fruit, label kegs, ...)
+  "recipe_step",
 ]);
 
 // Fruit variety characteristic enums
@@ -374,6 +377,7 @@ export const activityLaborAssignments = pgTable(
     carbonationOperationId: uuid("carbonation_operation_id"),
     vesselCleaningOperationId: uuid("vessel_cleaning_operation_id"),
     batchVolumeAdjustmentId: uuid("batch_volume_adjustment_id"),
+    batchStepTaskId: uuid("batch_step_task_id"),
     // Worker assignment
     workerId: uuid("worker_id")
       .notNull()


### PR DESCRIPTION
The generic step completion panel (Remove Fruit, Label Kegs, …) only captured notes. It now matches the cellar forms:

- **Completed Date & Time** field — seeded with the step's scheduled date when overdue (back-fill friendly; the schedule re-anchors from it), now otherwise
- **Labor tracking** via the shared WorkerLaborInput; `completeTask` writes `activity_labor_assignments` rows (rack → `racking`, others → new `recipe_step` type, linked by `batch_step_task_id`); the task's actualHours defaults to the labor sum
- Migration 0156 (enum value + column + FK/index) — **already applied to the database**

## Testing
- `pnpm typecheck` clean (db + api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)