### PR TITLE
Filter operations: track pads used

### DIFF
--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -82,6 +82,8 @@ export function FilterModal({
   // "same" = cider stays in the current tank; otherwise the id of the empty
   // vessel the cider is filtered into.
   const [destinationVesselId, setDestinationVesselId] = useState<string>("same");
+  // Consumable tracking: pads used this run (feeds pad-efficiency analysis)
+  const [padsUsed, setPadsUsed] = useState("");
 
   // Empty, available vessels the batch can be filtered into.
   const { data: vesselList } = trpc.vessel.listWithBatches.useQuery(undefined, {
@@ -162,6 +164,7 @@ export function FilterModal({
       });
       setLaborAssignments([]);
       setDestinationVesselId("same");
+      setPadsUsed("");
     }
   }, [open, currentVolumeL, reset, prefillFilterType]);
 
@@ -205,6 +208,10 @@ export function FilterModal({
       vesselId,
       destinationVesselId:
         destinationVesselId !== "same" ? destinationVesselId : undefined,
+      padsUsed:
+        padsUsed && Number.isInteger(Number(padsUsed)) && Number(padsUsed) > 0
+          ? Number(padsUsed)
+          : undefined,
       filterType: data.filterType,
       volumeBefore: data.volumeBefore,
       volumeBeforeUnit: data.volumeBeforeUnit,
@@ -311,6 +318,23 @@ export function FilterModal({
             </Select>
             <p className="text-xs text-gray-500 mt-1">
               Filtering into another tank moves the batch there as part of this operation
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="padsUsed">Filter Pads Used</Label>
+            <Input
+              id="padsUsed"
+              type="number"
+              min="1"
+              step="1"
+              value={padsUsed}
+              onChange={(e) => setPadsUsed(e.target.value)}
+              placeholder="e.g. 4"
+              className="mt-1"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              How many pads this run consumed — builds the pads-per-liter history for predicting future batches
             </p>
           </div>
 

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -534,6 +534,8 @@ const filterBatchSchema = z.object({
   // the batch moves there as part of the operation. Must be an empty vessel.
   destinationVesselId: z.string().uuid("Invalid destination vessel ID").optional(),
   filterType: z.enum(["coarse", "fine", "sterile"]),
+  // Consumable tracking for pad-efficiency analysis
+  padsUsed: z.number().int().positive().optional(),
   volumeBefore: z.number().positive("Volume before must be positive"),
   volumeBeforeUnit: z.enum(['L', 'gal']).default('L'),
   volumeAfter: z.number().positive("Volume after must be positive"),
@@ -5401,6 +5403,7 @@ export const batchRouter = router({
             batchId: input.batchId,
             vesselId: input.vesselId,
             filterType: input.filterType,
+            padsUsed: input.padsUsed ?? null,
             volumeBefore: input.volumeBefore.toString(),
             volumeBeforeUnit: input.volumeBeforeUnit,
             volumeAfter: input.volumeAfter.toString(),

--- a/packages/db/migrations/0157_filter_pads_used.sql
+++ b/packages/db/migrations/0157_filter_pads_used.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "batch_filter_operations" ADD COLUMN IF NOT EXISTS "pads_used" integer;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1265,6 +1265,9 @@ export const batchFilterOperations = pgTable(
       .notNull()
       .references(() => vessels.id, { onDelete: "cascade" }),
     filterType: filterTypeEnum("filter_type").notNull(),
+    // Consumables: how many filter pads this operation used. Feeds pad
+    // efficiency analysis (pads per liter by filter type / fruit load).
+    padsUsed: integer("pads_used"),
     // Volume tracking
     volumeBefore: decimal("volume_before", {
       precision: 10,


### PR DESCRIPTION
Adds consumable tracking to filter runs for pad-efficiency analysis: `pads_used` on `batch_filter_operations` (migration 0157 — **already applied**), accepted by `batch.filter`, entered via a new optional field in the FilterModal. Recipe filter steps inherit it automatically (same modal).

## Testing
- `pnpm typecheck` clean (db + api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)