### PR TITLE
Supplies category for production consumables

### DIFF
--- a/packages/db/migrations/0158_supplies_item_type.sql
+++ b/packages/db/migrations/0158_supplies_item_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "packaging_item_type" ADD VALUE IF NOT EXISTS 'Supplies';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -155,6 +155,8 @@ export const packagingItemTypeEnum = pgEnum("packaging_item_type", [
   "Closures",
   "Secondary Packaging",
   "Tertiary Packaging",
+  // Disposable production consumables that hit COGS (filter pads, etc.)
+  "Supplies",
 ]);
 
 // TTB Reconciliation status enum

--- a/packages/lib/src/schemas/index.ts
+++ b/packages/lib/src/schemas/index.ts
@@ -78,6 +78,9 @@ export const packagingItemTypeSchema = z.enum(
     "Closures",
     "Secondary Packaging",
     "Tertiary Packaging",
+    // Disposable production consumables that hit COGS (filter pads, etc.) —
+    // purchased and priced like packaging, distinct from product packaging.
+    "Supplies",
   ],
   {
     message: "Invalid packaging item type",


### PR DESCRIPTION
New "Supplies" item type in the packaging varieties/purchases flow for disposable production consumables that affect COGS (owner's ask: track recurring costs like filter pads without full batch-level inventory yet).

- `packaging_item_type` enum + zod schema gain `Supplies` (migration 0158 — **already applied**); the admin dropdown derives from the schema
- First varieties created in data: **Filter Pads 20x20** and **Filter Pads 40x40**

Pairs with #140 (pads-used tracking on filter operations); the $1.25/pad standing assumption applies until real purchase prices are entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)