### PR TITLE
Additive prefill: recipe units + live-volume dosing

### DIFF
--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -616,13 +616,13 @@ export function AddBatchAdditiveForm({
 
   const applyItemSelection = (item: (typeof filteredInventory)[number]) => {
     setSelectedInventoryItem(item);
-    const current = parseFloat(amount);
-    if (unit && item.unit && unit !== item.unit && Number.isFinite(current)) {
-      const converted = convertAmountBetweenUnits(current, unit, item.unit);
-      if (converted != null) setAmount(String(Number(converted.toFixed(4))));
+    // Keep the operator's / recipe's unit — submit-time reconciliation
+    // converts to the lot's unit for the stock deduction. Only adopt the
+    // lot's unit when nothing is set yet (normalizing "lb" to the
+    // dropdown's "lbs").
+    if (!unit && item.unit) {
+      setUnit(item.unit === "lb" ? "lbs" : item.unit);
     }
-    // Auto-set the unit from the inventory item
-    setUnit(item.unit);
   };
 
   const handleSelectInventoryItem = (itemId: string) => {

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -571,6 +571,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
       plannedVolumeL={
         Number(execution.bottleVolumeL ?? 0) + Number(execution.kegVolumeL ?? 0)
       }
+      currentVolumeL={currentVolumeL}
       ingredients={data.ingredients ?? []}
       kegLabel={kegLabel}
     />

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -72,6 +72,7 @@ export function StepDetailModal({
   task,
   sources,
   plannedVolumeL,
+  currentVolumeL,
   ingredients,
   kegLabel,
 }: {
@@ -81,6 +82,8 @@ export function StepDetailModal({
   task: Task | null;
   sources: Source[];
   plannedVolumeL: number;
+  /** The batch's live volume — dosing calcs prefer it over the plan. */
+  currentVolumeL?: number | null;
   ingredients: Ingredient[];
   kegLabel?: {
     batchName: string;
@@ -236,8 +239,11 @@ export function StepDetailModal({
     const rateUnit = ing.rateUnit ?? undefined;
     let amount: number | undefined;
     let unit: string | undefined;
-    if (rate != null && rateUnit?.endsWith("/L") && plannedTotalL > 0) {
-      amount = Number((rate * plannedTotalL).toFixed(2));
+    // Dose against what's actually in the tank (losses/additions shift the
+    // volume); fall back to the plan for batches not yet transferred.
+    const doseVolumeL = currentVolumeL && currentVolumeL > 0 ? currentVolumeL : plannedTotalL;
+    if (rate != null && rateUnit?.endsWith("/L") && doseVolumeL > 0) {
+      amount = Number((rate * doseVolumeL).toFixed(2));
       unit = rateUnit.replace("/L", "");
     }
     return {


### PR DESCRIPTION
Hit on the cane sugar step: a lb-denominated lot converted the 12 g/L prefill to 8.4658 with a blank unit selector ("lb" isn't a dropdown option), and the dose used planned volume instead of the tank's actual 325 L.

- Display keeps the recipe's unit; the submit-time lot-unit reconciliation (from #129) handles the deduction conversion
- Rate prefills dose against current batch volume (fallback: plan)
- Lot unit adopted only when no unit set, normalizing lb → lbs

## Testing
- `pnpm typecheck` clean (web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)