### PR TITLE
Timezone consistency: last-activity hint + date-only start dates

### DIFF
--- a/apps/web/src/app/batch/[id]/page.tsx
+++ b/apps/web/src/app/batch/[id]/page.tsx
@@ -549,7 +549,9 @@ export default function BatchDetailsPage() {
                 ) : (
                   <div className="flex items-center gap-2">
                     <span className="text-gray-600">
-                      Started: {formatDate(batch.startDate)}
+                      {/* startDate is date-only (midnight UTC) — render its UTC
+                          calendar date or Pacific shows the previous day */}
+                      Started: {formatDate(batch.startDate, undefined, "UTC")}
                     </span>
                     <Button
                       variant="ghost"

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -78,6 +78,11 @@ const STATUS_DISPLAY: Record<RowStatus, { label: string; cls: string; dot: strin
 
 const fmtDate = (d: string | Date | null) =>
   d ? new Date(d).toLocaleDateString() : "—";
+// Date-ONLY values (e.g. execution start dates) are stored at midnight UTC;
+// rendering them in local time shows the previous day ("started 7/6" for a
+// Jul 7 batch). Render by their UTC calendar date instead.
+const fmtDateOnly = (d: string | Date | null) =>
+  d ? new Date(d).toLocaleDateString("en-US", { timeZone: "UTC" }) : "—";
 
 type Task = {
   id: string;
@@ -386,7 +391,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
         <CardDescription>
           {/* Packaging progress is shown per planned path only — a path with
               no plan (0 L) is omitted rather than rendering "kegged X of 0 L". */}
-          Recipe v{execution.recipeVersion} · started {fmtDate(execution.startDate)}
+          Recipe v{execution.recipeVersion} · started {fmtDateOnly(execution.startDate)}
           {Number(execution.bottleVolumeL ?? 0) > 0 && (
             <>
               {" "}· bottled {fmtVol(actuals.bottledL)} of {Number(execution.bottleVolumeL)} L

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -952,10 +952,21 @@ export const batchRouter = router({
           LIMIT 1
         `);
         const lastRow = ((lastActivityResult as any).rows ?? [])[0] as
-          | { event_date: Date; label: string }
+          | { event_date: Date | string; label: string }
           | undefined;
+        // Raw execute() can hand back naive timestamp strings. These columns
+        // store UTC wall time (all inputs go local → UTC), so pin the value
+        // to UTC explicitly — otherwise the browser parses the naive string
+        // in ITS timezone and the hint shows/compares a shifted time
+        // ("Jul 10 4:28 AM" for a Jul 9 9:28 PM PDT filter).
+        const toUtcInstant = (v: Date | string): Date =>
+          v instanceof Date
+            ? v
+            : new Date(
+                v.replace(" ", "T") + (/[Zz]|[+-]\d{2}/.test(v.slice(10)) ? "" : "Z"),
+              );
         const lastActivity = lastRow
-          ? { date: lastRow.event_date, label: lastRow.label }
+          ? { date: toUtcInstant(lastRow.event_date), label: lastRow.label }
           : null;
 
         // Base response


### PR DESCRIPTION
Owner-observed: "one time is seen as Pacific Time, the other as Greenwich."

- The last-activity hint's raw-SQL timestamp came back as a naive string, parsed by the browser as local — displaying the UTC wall time as if Pacific and firing false "your date is earlier" warnings for the same instant. Fixed by pinning naive values to UTC at the API.
- Date-only start dates (midnight UTC) showed the previous day in Pacific; they now render by UTC calendar date in the checklist header and batch page.

All datetime inputs continue the existing convention: entered local → stored as UTC instant → displayed local.

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)