### PR TITLE
Recipe steps: seed action-form dates from the scheduled date

### DIFF
--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -110,6 +110,8 @@ interface CarbonateModalProps {
   /** Recipe-planned values to prefill (method uses recipe terms forced|natural). */
   prefillTargetCo2Volumes?: number;
   prefillMethod?: "forced" | "natural";
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillStartedAt?: string | Date | null;
 }
 
 export function CarbonateModal({
@@ -120,9 +122,10 @@ export function CarbonateModal({
   onSuccess,
   prefillTargetCo2Volumes,
   prefillMethod,
+  prefillStartedAt,
 }: CarbonateModalProps) {
   const utils = trpc.useUtils();
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
   const [carbonationMethod, setCarbonationMethod] = React.useState<"forced" | "bottle_conditioning">("forced");
   const [lastEditedField, setLastEditedField] = React.useState<"co2" | "sugar">("co2");
   const [dateWarning, setDateWarning] = React.useState<string | null>(null);
@@ -219,7 +222,7 @@ export function CarbonateModal({
     resolver: zodResolver(carbonationSchema) as any,
     defaultValues: {
       carbonationMethod: "forced",
-      startedAt: formatDateTimeForInput(new Date()),
+      startedAt: seedDateTimeForInput(prefillStartedAt),
       startingVolume: batch.currentVolume,
       startingVolumeUnit: (batch.currentVolumeUnit as "L" | "gal") || "L",
       startingTemperature: 10,
@@ -271,7 +274,7 @@ export function CarbonateModal({
         recipeMethod ?? (vessel?.isPressureVessel === "yes" ? "forced" : "bottle_conditioning");
       reset({
         carbonationMethod: defaultMethod,
-        startedAt: formatDateTimeForInput(new Date()) as any,
+        startedAt: seedDateTimeForInput(prefillStartedAt) as any,
         startingVolume: batch.currentVolume,
         startingVolumeUnit: (batch.currentVolumeUnit as "L" | "gal") || "L",
         startingTemperature: 10,
@@ -289,7 +292,8 @@ export function CarbonateModal({
       setDateWarning(null);
       setLaborAssignments([]);
     }
-  }, [open, reset, batch.currentVolume, batch.currentVolumeUnit, vessel?.isPressureVessel, prefillMethod, prefillTargetCo2Volumes]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, reset, batch.currentVolume, batch.currentVolumeUnit, vessel?.isPressureVessel, prefillMethod, prefillTargetCo2Volumes, prefillStartedAt]);
 
   // Convert volume to liters for calculations
   const volumeInLiters = useMemo(() => {

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -30,6 +30,8 @@ interface AddBatchMeasurementFormProps {
   /** Receives the measurement date for schedule anchoring. */
   onSuccess: (measuredAt?: Date) => void;
   onCancel: () => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillMeasuredAt?: string | Date | null;
 }
 
 type MeasurementMethod = "hydrometer" | "refractometer" | "calculated";
@@ -38,12 +40,14 @@ export function AddBatchMeasurementForm({
   batchId,
   onSuccess,
   onCancel,
+  prefillMeasuredAt,
 }: AddBatchMeasurementFormProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
 
-  const localISOTime = formatDateTimeForInput(new Date());
-
-  const [measurementDateTime, setMeasurementDateTime] = useState(localISOTime);
+  const [measurementDateTime, setMeasurementDateTime] = useState(() => {
+    const seed = prefillMeasuredAt ? new Date(prefillMeasuredAt) : new Date();
+    return formatDateTimeForInput(Number.isNaN(seed.getTime()) ? new Date() : seed);
+  });
   const [dateWarning, setDateWarning] = useState<string | null>(null);
   const [measurementMethod, setMeasurementMethod] = useState<MeasurementMethod>("hydrometer");
 

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -60,6 +60,8 @@ interface FilterModalProps {
   onSuccess?: (filteredAt?: Date) => void;
   /** Recipe-planned filter type to prefill. */
   prefillFilterType?: "coarse" | "fine" | "sterile";
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillFilteredAt?: string | Date | null;
 }
 
 export function FilterModal({
@@ -71,6 +73,7 @@ export function FilterModal({
   currentVolumeL,
   onSuccess,
   prefillFilterType,
+  prefillFilteredAt,
 }: FilterModalProps) {
   const utils = trpc.useUtils();
   const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
@@ -84,6 +87,12 @@ export function FilterModal({
   const [destinationVesselId, setDestinationVesselId] = useState<string>("same");
   // Consumable tracking: pads used this run (feeds pad-efficiency analysis)
   const [padsUsed, setPadsUsed] = useState("");
+
+  // Seed the date from the recipe step's scheduled date when back-filling.
+  const seedFilteredAt = () => {
+    const d = prefillFilteredAt ? new Date(prefillFilteredAt) : new Date();
+    return Number.isNaN(d.getTime()) ? new Date() : d;
+  };
 
   // Empty, available vessels the batch can be filtered into.
   const { data: vesselList } = trpc.vessel.listWithBatches.useQuery(undefined, {
@@ -112,7 +121,7 @@ export function FilterModal({
       volumeBeforeUnit: "L",
       volumeAfterUnit: "L",
       volumeBefore: currentVolumeL,
-      filteredAt: new Date(),
+      filteredAt: seedFilteredAt(),
       notes: "",
     },
   });
@@ -159,14 +168,15 @@ export function FilterModal({
         volumeAfter: currentVolumeL,
         volumeBeforeUnit: "L",
         volumeAfterUnit: "L",
-        filteredAt: new Date(),
+        filteredAt: seedFilteredAt(),
         notes: "",
       });
       setLaborAssignments([]);
       setDestinationVesselId("same");
       setPadsUsed("");
     }
-  }, [open, currentVolumeL, reset, prefillFilterType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, currentVolumeL, reset, prefillFilterType, prefillFilteredAt]);
 
   const filterMutation = trpc.batch.filter.useMutation({
     onSuccess: (data) => {

--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -59,6 +59,8 @@ interface LabelModalProps {
   unitsLabeled?: number; // Current number of labeled units (for partial labeling)
   /** Receives labeledAt for schedule anchoring. */
   onSuccess: (labeledAt?: Date) => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillLabeledAt?: string | Date | null;
 }
 
 export function LabelModal({
@@ -69,9 +71,10 @@ export function LabelModal({
   unitsProduced,
   unitsLabeled: initialUnitsLabeled = 0,
   onSuccess,
+  prefillLabeledAt,
 }: LabelModalProps) {
   const utils = trpc.useUtils();
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
   const [comboboxOpen, setComboboxOpen] = useState<{[key: number]: boolean}>({});
   const [appliedLabels, setAppliedLabels] = useState<Array<{name: string, quantity: number}>>([]);
   const [dateWarning, setDateWarning] = useState<string | null>(null);
@@ -106,7 +109,7 @@ export function LabelModal({
     defaultValues: {
       unitsToLabel: remainingUnits,
       labels: [{ packagingItemId: "", quantity: remainingUnits }],
-      labeledAt: formatDateTimeForInput(new Date()),
+      labeledAt: seedDateTimeForInput(prefillLabeledAt),
       laborHours: undefined,
     },
   });
@@ -150,14 +153,15 @@ export function LabelModal({
       reset({
         unitsToLabel: remainingUnits,
         labels: [{ packagingItemId: "", quantity: remainingUnits }],
-        labeledAt: formatDateTimeForInput(new Date()),
+        labeledAt: seedDateTimeForInput(prefillLabeledAt),
         laborHours: undefined,
       });
       setAppliedLabels([]);
       setComboboxOpen({});
       setLaborAssignments([]);
     }
-  }, [open, reset, remainingUnits]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, reset, remainingUnits, prefillLabeledAt]);
 
   // Pre-select the label that matches this run's recipe/product name (e.g.
   // "Duskrun - Lavender Salal" → the Duskrun label), so the operator just

--- a/apps/web/src/components/packaging/PasteurizeModal.tsx
+++ b/apps/web/src/components/packaging/PasteurizeModal.tsx
@@ -81,6 +81,8 @@ interface PasteurizeModalProps {
   unitsProduced: number;
   /** Receives pasteurizedAt for schedule anchoring. */
   onSuccess: (pasteurizedAt?: Date) => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillPasteurizedAt?: string | Date | null;
 }
 
 export function PasteurizeModal({
@@ -91,9 +93,10 @@ export function PasteurizeModal({
   batchId,
   unitsProduced,
   onSuccess,
+  prefillPasteurizedAt,
 }: PasteurizeModalProps) {
   const utils = trpc.useUtils();
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
 
   // State for custom starting temperature input
   const [useCustomStartTemp, setUseCustomStartTemp] = useState(false);
@@ -127,7 +130,7 @@ export function PasteurizeModal({
   } = useForm<PasteurizeForm>({
     resolver: zodResolver(pasteurizeSchema),
     defaultValues: {
-      pasteurizedAt: formatDateTimeForInput(new Date()),
+      pasteurizedAt: seedDateTimeForInput(prefillPasteurizedAt),
       bottleTypeId: "750ml_glass",
       startingTempC: 20, // Room temperature default
       temperatureCelsius: 65, // Hot-start bath temperature
@@ -233,7 +236,7 @@ export function PasteurizeModal({
   useEffect(() => {
     if (open) {
       reset({
-        pasteurizedAt: formatDateTimeForInput(new Date()),
+        pasteurizedAt: seedDateTimeForInput(prefillPasteurizedAt),
         bottleTypeId: "750ml_glass",
         startingTempC: 20,
         temperatureCelsius: 65,
@@ -246,7 +249,8 @@ export function PasteurizeModal({
       setHasSetRecommendedTime(false);
       setLaborAssignments([]);
     }
-  }, [open, reset]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, reset, prefillPasteurizedAt]);
 
   // Set timeMinutes to recommended value once it's calculated (only once per modal open)
   useEffect(() => {

--- a/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
+++ b/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
@@ -22,6 +22,8 @@ interface UnifiedPackagingModalProps {
   preBottling?: PreBottlingData;
   /** Receives the packaging date (packagedAt / filledAt) from the inner modal. */
   onSuccess?: (packagedAt?: Date) => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillPackagedAt?: string | Date | null;
 }
 
 /**
@@ -40,6 +42,7 @@ export function UnifiedPackagingModal({
   initialType = "bottles",
   preBottling,
   onSuccess,
+  prefillPackagedAt,
 }: UnifiedPackagingModalProps) {
   const [packagingType, setPackagingType] = useState<PackagingType>(initialType);
 
@@ -64,6 +67,7 @@ export function UnifiedPackagingModal({
         onTypeChange={setPackagingType}
         preBottling={preBottling}
         onSuccess={onSuccess}
+        prefillFilledAt={prefillPackagedAt}
       />
     );
   }
@@ -80,6 +84,7 @@ export function UnifiedPackagingModal({
       onTypeChange={setPackagingType}
       preBottling={preBottling}
       onSuccess={onSuccess}
+      prefillPackagedAt={prefillPackagedAt}
     />
   );
 }

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -74,6 +74,8 @@ interface BottleModalProps {
   preBottling?: PreBottlingData;
   /** Called after a packaging run is created; receives packagedAt for schedule anchoring. */
   onSuccess?: (packagedAt?: Date) => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillPackagedAt?: string | Date | null;
 }
 
 type InputMode = "volume" | "units";
@@ -90,8 +92,9 @@ export function BottleModal({
   onTypeChange,
   preBottling,
   onSuccess,
+  prefillPackagedAt,
 }: BottleModalProps) {
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedMaterials, setSelectedMaterials] = useState<SelectedMaterial[]>([]);
   const [currentMaterialId, setCurrentMaterialId] = useState<string>("");
@@ -136,7 +139,7 @@ export function BottleModal({
       volumeTakenL: undefined,
       packageSizeMl: undefined,
       unitsProduced: undefined,
-      packagedAt: formatDateTimeForInput(new Date()),
+      packagedAt: seedDateTimeForInput(prefillPackagedAt),
       notes: "",
       materials: [],
       laborHours: undefined,
@@ -343,7 +346,7 @@ export function BottleModal({
   useEffect(() => {
     if (open) {
       reset({
-        packagedAt: formatDateTimeForInput(new Date()),
+        packagedAt: seedDateTimeForInput(prefillPackagedAt),
         notes: "",
         materials: [],
         // packageSizeMl will be set automatically when primary packaging is selected
@@ -360,7 +363,8 @@ export function BottleModal({
       setLossReason("sediment");
       setLossNotes("");
     }
-  }, [open, reset]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, reset, prefillPackagedAt]);
 
   const handleFormSubmit = async (data: BottleFormData) => {
     if (lossL < -0.001) {

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -54,6 +54,8 @@ interface FillKegModalProps {
   preBottling?: PreBottlingData;
   /** Called after kegs are filled; receives filledAt for schedule anchoring. */
   onSuccess?: (filledAt?: Date) => void;
+  /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
+  prefillFilledAt?: string | Date | null;
 }
 
 // Memoized keg item component to prevent re-renders
@@ -115,8 +117,9 @@ export function FillKegModal({
   onTypeChange,
   preBottling,
   onSuccess,
+  prefillFilledAt,
 }: FillKegModalProps) {
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
   const [selectedKegIds, setSelectedKegIds] = useState<string[]>([]);
   const [kegVolumes, setKegVolumes] = useState<Record<string, number>>({});
 
@@ -131,7 +134,7 @@ export function FillKegModal({
   } = useForm<FillKegsForm>({
     resolver: zodResolver(fillKegsSchema),
     defaultValues: {
-      filledAt: formatDateTimeForInput(new Date()),
+      filledAt: seedDateTimeForInput(prefillFilledAt),
       volumeTakenUnit: "L",
       lossUnit: "L",
       carbonationMethod: "none",
@@ -183,8 +186,12 @@ export function FillKegModal({
     if (!open) {
       setSelectedKegIds([]);
       setKegVolumes({});
+    } else {
+      // Re-seed the date on open (the form mounts once; defaults go stale).
+      setValue("filledAt", seedDateTimeForInput(prefillFilledAt));
     }
-  }, [open]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, prefillFilledAt]);
 
   // Memoized toggle handler with stable reference using useCallback
   const handleKegToggle = React.useCallback((kegId: string) => {

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -660,6 +660,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 ? "sterile"
                 : "fine"
           }
+          prefillFilteredAt={actionTask?.scheduledDate ?? null}
           onSuccess={(actualAt?: Date) =>
             actionTask &&
             complete.mutate({
@@ -697,6 +698,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 ? "forced"
                 : undefined
           }
+          prefillStartedAt={actionTask?.scheduledDate ?? null}
           onSuccess={(actualAt?: Date) =>
             actionTask &&
             complete.mutate({
@@ -713,6 +715,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           batchId={batchId}
           currentVolumeL={currentVolumeL}
           initialType={actionTask?.packagingPath === "keg" ? "kegs" : "bottles"}
+          prefillPackagedAt={actionTask?.scheduledDate ?? null}
           onSuccess={(actualAt?: Date) =>
             actionTask &&
             complete.mutate({
@@ -734,6 +737,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
           batchId={batchId}
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
+          prefillPasteurizedAt={actionTask?.scheduledDate ?? null}
           onSuccess={(actualAt?: Date) =>
             actionTask &&
             complete.mutate({
@@ -749,6 +753,7 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           bottleRunName={`${latestRun.batch?.name ?? "Run"} — ${new Date(latestRun.packagedAt ?? latestRun.createdAt).toLocaleDateString()}`}
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
           unitsLabeled={Number(latestRun.unitsLabeled ?? 0)}
+          prefillLabeledAt={actionTask?.scheduledDate ?? null}
           onSuccess={(actualAt?: Date) =>
             actionTask &&
             complete.mutate({

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -274,7 +274,13 @@ export function StepDetailModal({
 
         {useRealForm ? (
           task.kind === "measurement" ? (
-            <AddBatchMeasurementForm key={task.id} batchId={batchId} onSuccess={onRealSuccess} onCancel={onClose} />
+            <AddBatchMeasurementForm
+              key={task.id}
+              batchId={batchId}
+              onSuccess={onRealSuccess}
+              onCancel={onClose}
+              prefillMeasuredAt={task.scheduledDate ?? null}
+            />
           ) : (
             <AddBatchAdditiveForm
               key={task.id}

--- a/apps/web/src/hooks/useDateFormat.ts
+++ b/apps/web/src/hooks/useDateFormat.ts
@@ -91,6 +91,20 @@ export function useDateFormat() {
     parseDateTimeFromInput: (value: string) => baseParseDateTimeFromInput(value, timezone),
 
     /**
+     * Seed a datetime-local input: use the prefill date when provided and
+     * valid (e.g. a recipe step's scheduled date when back-filling), else now.
+     * @param prefill - Optional date to seed from
+     * @returns Date string in YYYY-MM-DDTHH:mm format in the current timezone
+     */
+    seedDateTimeForInput: (prefill?: string | Date | null) => {
+      const d = prefill ? new Date(prefill) : new Date();
+      return baseFormatDateTimeForInput(
+        Number.isNaN(d.getTime()) ? new Date() : d,
+        timezone,
+      );
+    },
+
+    /**
      * Get the current date/time in the configured timezone
      * @returns Current date in the current timezone
      */


### PR DESCRIPTION
When completing a recipe step via its real action form, the date field defaulted to today instead of the step's expected date — every back-filled step needed manual re-dating.

Now every step-launched form (SG/pH + CO2 measurements, filter, carbonate, keg fill, bottling, pasteurize, label bottles) seeds its Date & Time from the step's scheduled date, exactly like the additive form and the generic Mark Complete panel already did. Standalone launches (cellar page, batch page) still default to now.

## Testing
- `pnpm --filter web run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)