### PR TITLE
Press run completion: full date + time

### DIFF
--- a/apps/web/src/app/pressing/create/page.tsx
+++ b/apps/web/src/app/pressing/create/page.tsx
@@ -54,7 +54,8 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import { trpc } from "@/utils/trpc";
-import { formatDate, formatDateForInput } from "@/utils/date-format";
+import { formatDate } from "@/utils/date-format";
+import { useDateFormat } from "@/hooks/useDateFormat";
 import { gallonsToLiters, litersToGallons } from "lib";
 import {
   WeightDisplay,
@@ -87,13 +88,14 @@ interface VesselAssignment {
 
 export default function BuildPressRunPage() {
   const router = useRouter();
+  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
 
   // State
   const [vendorFilter, setVendorFilter] = useState("");
   const [expandedVendors, setExpandedVendors] = useState<Set<string>>(new Set());
   const [selections, setSelections] = useState<Map<string, InventorySelection>>(new Map());
   const [vendorWeightUnits, setVendorWeightUnits] = useState<Map<string, WeightUnit>>(new Map());
-  const [completionDate, setCompletionDate] = useState(formatDateForInput(new Date()));
+  const [completionDate, setCompletionDate] = useState(() => formatDateTimeForInput(new Date()));
   const [totalJuiceVolumeL, setTotalJuiceVolumeL] = useState<number>(0);
   const [juiceVolumeUnit, setJuiceVolumeUnit] = useState<"L" | "gal">("L");
   const [assignments, setAssignments] = useState<VesselAssignment[]>([
@@ -301,7 +303,7 @@ export default function BuildPressRunPage() {
         fruitVarietyId: s.fruitVarietyId,
         quantityKg: s.useQuantityKg,
       })),
-      completionDate: new Date(completionDate),
+      completionDate: parseDateTimeFromInput(completionDate),
       totalJuiceVolumeL,
       assignments: assignments
         .filter((a) => a.toVesselId && a.volumeL > 0)
@@ -563,9 +565,9 @@ export default function BuildPressRunPage() {
           {/* Completion Date */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label>Completion Date</Label>
+              <Label>Completion Date & Time</Label>
               <Input
-                type="date"
+                type="datetime-local"
                 value={completionDate}
                 onChange={(e) => setCompletionDate(e.target.value)}
               />

--- a/apps/web/src/app/pressing/page.tsx
+++ b/apps/web/src/app/pressing/page.tsx
@@ -51,6 +51,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { formatDate } from "@/utils/date-format";
+import { useDateFormat } from "@/hooks/useDateFormat";
 import {
   WeightDisplay,
   type WeightUnit,
@@ -264,6 +265,7 @@ function CompletedRunsSection({
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
   const [searchTerm, setSearchTerm] = useState("");
   const [weightDisplayUnit, setWeightDisplayUnit] = useState<WeightUnit>("lb");
   const [editDateModalOpen, setEditDateModalOpen] = useState(false);
@@ -353,25 +355,27 @@ function CompletedRunsSection({
   const handleEditDate = (pressRun: {
     id: string;
     pressRunName: string | null;
-    dateCompleted: string | null;
+    dateCompleted: string | Date | null;
   }) => {
     setEditingPressRun({
       id: pressRun.id,
       name: pressRun.pressRunName || "Press Run",
-      currentDate: pressRun.dateCompleted || "",
+      currentDate: pressRun.dateCompleted ? String(pressRun.dateCompleted) : "",
     });
-    setNewDate(pressRun.dateCompleted || "");
+    setNewDate(
+      pressRun.dateCompleted
+        ? formatDateTimeForInput(new Date(pressRun.dateCompleted))
+        : formatDateTimeForInput(new Date()),
+    );
     setEditDateModalOpen(true);
   };
 
   const handleSaveDate = () => {
     if (!editingPressRun || !newDate) return;
 
-    // Parse date at noon UTC to avoid timezone issues
-    const dateCompleted = new Date(`${newDate}T12:00:00.000Z`);
     updateDateMutation.mutate({
       id: editingPressRun.id,
-      dateCompleted: dateCompleted,
+      dateCompleted: parseDateTimeFromInput(newDate),
     });
   };
 
@@ -711,10 +715,10 @@ function CompletedRunsSection({
           </DialogHeader>
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <Label htmlFor="completion-date">Completion Date</Label>
+              <Label htmlFor="completion-date">Completion Date & Time</Label>
               <Input
                 id="completion-date"
-                type="date"
+                type="datetime-local"
                 value={newDate}
                 onChange={(e) => setNewDate(e.target.value)}
                 className="w-full"

--- a/apps/web/src/components/pressing/press-run-completion-form.tsx
+++ b/apps/web/src/components/pressing/press-run-completion-form.tsx
@@ -59,7 +59,7 @@ import {
 } from "lucide-react";
 import { gallonsToLiters, litersToGallons, formatUnitConversion } from "lib";
 import { trpc } from "@/utils/trpc";
-import { formatDate, formatDateForInput } from "@/utils/date-format";
+import { useDateFormat } from "@/hooks/useDateFormat";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 
 // Assignment schema for vessel assignments
@@ -77,7 +77,7 @@ const assignmentSchema = z.object({
 const pressRunCompletionSchema = z.object({
   completionDate: z
     .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, "Please enter a valid date"),
+    .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/, "Please enter a valid date and time"),
   totalJuiceVolume: z
     .number()
     .min(1, "Total juice volume must be at least 1L")
@@ -140,10 +140,12 @@ export function PressRunCompletionForm({
   const availableVessels =
     vesselsData?.vessels?.filter((vessel) => vessel.isAvailable) || [];
 
-  // Use press run creation date as default, fall back to today if not available
+  const { formatDateTimeForInput, parseDateTimeFromInput, formatDateTime } = useDateFormat();
+
+  // Use press run creation date as default, fall back to now if not available
   const defaultCompletionDate = pressRun?.createdAt
-    ? formatDateForInput(new Date(pressRun.createdAt))
-    : formatDateForInput(new Date());
+    ? formatDateTimeForInput(new Date(pressRun.createdAt))
+    : formatDateTimeForInput(new Date());
 
   const form = useForm<PressRunCompletionForm>({
     resolver: zodResolver(pressRunCompletionSchema),
@@ -192,10 +194,8 @@ export function PressRunCompletionForm({
     })) || [];
 
   const onSubmit = (data: PressRunCompletionForm) => {
-    // Parse the date string (YYYY-MM-DD) and create a Date object in local timezone
-    // to avoid timezone conversion issues
-    const [year, month, day] = data.completionDate.split("-").map(Number);
-    const completionDate = new Date(year, month - 1, day); // month is 0-indexed
+    // Interpret the datetime-local value in the org timezone → UTC instant
+    const completionDate = parseDateTimeFromInput(data.completionDate);
 
     const submissionPayload = {
       pressRunId,
@@ -295,13 +295,13 @@ export function PressRunCompletionForm({
                 name="completionDate"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Completion Date</FormLabel>
+                    <FormLabel>Completion Date & Time</FormLabel>
                     <FormControl>
-                      <Input type="date" {...field} />
+                      <Input type="datetime-local" {...field} />
                     </FormControl>
                     <FormDescription>
                       Press run will be named as:{" "}
-                      {field.value ? `${field.value}-01` : "YYYY-MM-DD-01"}
+                      {field.value ? `${field.value.slice(0, 10)}-01` : "YYYY-MM-DD-01"}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -932,11 +932,13 @@ export function PressRunCompletionForm({
                 <div className="bg-gray-50 p-3 rounded-md space-y-2 text-sm">
                   <p>
                     <strong>Press Run Name:</strong>{" "}
-                    {watchedValues.completionDate}-01
+                    {watchedValues.completionDate?.slice(0, 10)}-01
                   </p>
                   <p>
                     <strong>Completion Date:</strong>{" "}
-                    {formatDate(new Date(watchedValues.completionDate))}
+                    {watchedValues.completionDate
+                      ? formatDateTime(parseDateTimeFromInput(watchedValues.completionDate))
+                      : "—"}
                   </p>
                   <p>
                     <strong>Total Juice Volume:</strong>{" "}

--- a/apps/web/src/components/reports/OnHandReconciliation.tsx
+++ b/apps/web/src/components/reports/OnHandReconciliation.tsx
@@ -146,7 +146,11 @@ export function OnHandReconciliation() {
                         </TableCell>
                         <TableCell>{r.fermentationStart ?? "—"}</TableCell>
                         <TableCell>{r.startDate ?? "—"}</TableCell>
-                        <TableCell>{r.pressedDate ?? "—"}</TableCell>
+                        <TableCell>
+                          {r.pressedDate
+                            ? new Date(r.pressedDate).toLocaleDateString()
+                            : "—"}
+                        </TableCell>
                         <TableCell className="text-muted-foreground">
                           {r.parentName ?? "—"}
                         </TableCell>

--- a/packages/api/src/routers/pressRun.ts
+++ b/packages/api/src/routers/pressRun.ts
@@ -16,6 +16,7 @@ import {
   batchMergeHistory,
   batchTransfers,
   batchRackingOperations,
+  systemSettings,
 } from "db";
 import { eq, and, desc, asc, sql, isNull, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
@@ -26,6 +27,27 @@ import {
 } from "lib";
 import { generateBatchNameFromComposition, type BatchComposition } from "lib";
 import { recomputeBatchVolume } from "../services/batch-volume-recompute";
+
+/**
+ * Press runs are named by the org-local calendar date of completion
+ * (YYYY-MM-DD-##). Completion is a full datetime, so derive the date part in
+ * the configured org timezone — an evening pressing must not roll the name
+ * over to the next UTC day.
+ */
+async function orgLocalDateStr(completionDate: Date): Promise<string> {
+  let timeZone = "America/Los_Angeles";
+  try {
+    const setting = await db
+      .select()
+      .from(systemSettings)
+      .where(eq(systemSettings.key, "timezone"))
+      .limit(1);
+    if (setting[0]?.value) timeZone = setting[0].value as string;
+  } catch {
+    // fall through to the default timezone
+  }
+  return completionDate.toLocaleDateString("en-CA", { timeZone });
+}
 
 // Input validation schemas
 const createPressRunSchema = z.object({
@@ -342,7 +364,7 @@ export const pressRunRouter = router({
           }
 
           // 3. Generate press run name
-          const completionDateStr = input.completionDate.toISOString().split("T")[0];
+          const completionDateStr = await orgLocalDateStr(input.completionDate);
           const existingRuns = await tx
             .select({ pressRunName: pressRuns.pressRunName })
             .from(pressRuns)
@@ -398,7 +420,7 @@ export const pressRunRouter = router({
             .values({
               pressRunName,
               status: "completed",
-              dateCompleted: completionDateStr,
+              dateCompleted: input.completionDate,
               totalAppleWeightKg: totalAppleWeightKg.toString(),
               totalJuiceVolume: input.totalJuiceVolumeL.toString(),
               totalJuiceVolumeUnit: "L",
@@ -1107,9 +1129,7 @@ export const pressRunRouter = router({
           }
 
           // Generate press run name based on completion date (YYYY-MM-DD-##)
-          const completionDateStr = input.completionDate
-            .toISOString()
-            .split("T")[0];
+          const completionDateStr = await orgLocalDateStr(input.completionDate);
 
           // Find existing press runs on the same date to determine sequence number
           const existingRuns = await tx
@@ -1149,7 +1169,7 @@ export const pressRunRouter = router({
               pressRunName,
               vesselId: input.vesselId,
               status: "completed",
-              dateCompleted: input.completionDate.toISOString().split("T")[0],
+              dateCompleted: input.completionDate,
               totalJuiceVolume: input.totalJuiceVolumeL.toString(),
               totalJuiceVolumeUnit: "L",
               extractionRate: extractionRate.toString(),
@@ -1317,7 +1337,7 @@ export const pressRunRouter = router({
               vesselId: input.vesselId,
               totalJuiceVolumeL: input.totalJuiceVolumeL,
               extractionRate: extractionRate,
-              dateCompleted: input.completionDate.toISOString().split("T")[0],
+              dateCompleted: input.completionDate,
             },
             ctx.session?.user?.id,
             "Press run completed and juice assigned to vessel",
@@ -1417,7 +1437,7 @@ export const pressRunRouter = router({
           if (pressRun[0].status === "in_progress") {
 
             // Generate press run name based on user-selected completion date (YYYY-MM-DD-##)
-            const completionDateStr = input.completionDate.toISOString().split("T")[0];
+            const completionDateStr = await orgLocalDateStr(input.completionDate);
 
             // Find existing press runs on the same date to determine sequence number
             const existingRuns = await tx
@@ -1464,7 +1484,7 @@ export const pressRunRouter = router({
               .set({
                 pressRunName,
                 status: "completed",
-                dateCompleted: input.completionDate.toISOString().split("T")[0], // Use user-selected completion date
+                dateCompleted: input.completionDate, // Use user-selected completion datetime
                 totalJuiceVolume: totalJuiceVolume.toString(),
                 totalJuiceVolumeUnit: "L",
                 extractionRate: extractionRate.toString(),
@@ -2827,14 +2847,16 @@ export const pressRunRouter = router({
         // Allow updating metadata fields (notes, pressingMethod, weatherConditions, dateCompleted)
         // even on completed press runs
 
-        // Convert dateCompleted to ISO date string if provided
         const updatePayload: Record<string, unknown> = { ...updateData };
         if (updateData.dateCompleted) {
-          updatePayload.dateCompleted = updateData.dateCompleted.toISOString().split("T")[0];
+          updatePayload.dateCompleted = updateData.dateCompleted;
 
-          // If date is changing and press run is completed, regenerate pressRunName
-          const newDateStr = updateData.dateCompleted.toISOString().split("T")[0];
-          const oldDateStr = existingPressRun[0].dateCompleted;
+          // If the local calendar date is changing and the press run is
+          // completed, regenerate pressRunName (names use the org-local date)
+          const newDateStr = await orgLocalDateStr(updateData.dateCompleted);
+          const oldDateStr = existingPressRun[0].dateCompleted
+            ? await orgLocalDateStr(new Date(existingPressRun[0].dateCompleted))
+            : null;
 
           if (existingPressRun[0].status === "completed" && newDateStr !== oldDateStr) {
             // Find existing press runs on the new date (excluding this press run)

--- a/packages/api/src/routers/productionReports.ts
+++ b/packages/api/src/routers/productionReports.ts
@@ -37,8 +37,8 @@ export const productionReportsRouter = router({
         .from(pressRuns)
         .where(
           and(
-            gte(pressRuns.dateCompleted, input.startDate.toISOString().split("T")[0]),
-            lte(pressRuns.dateCompleted, input.endDate.toISOString().split("T")[0]),
+            sql`${pressRuns.dateCompleted}::date >= ${input.startDate.toISOString().split("T")[0]}::date`,
+            sql`${pressRuns.dateCompleted}::date <= ${input.endDate.toISOString().split("T")[0]}::date`,
             isNull(pressRuns.deletedAt),
             eq(pressRuns.status, "completed")
           )
@@ -59,8 +59,8 @@ export const productionReportsRouter = router({
         .innerJoin(baseFruitVarieties, eq(pressRunLoads.fruitVarietyId, baseFruitVarieties.id))
         .where(
           and(
-            gte(pressRuns.dateCompleted, input.startDate.toISOString().split("T")[0]),
-            lte(pressRuns.dateCompleted, input.endDate.toISOString().split("T")[0]),
+            sql`${pressRuns.dateCompleted}::date >= ${input.startDate.toISOString().split("T")[0]}::date`,
+            sql`${pressRuns.dateCompleted}::date <= ${input.endDate.toISOString().split("T")[0]}::date`,
             isNull(pressRuns.deletedAt),
             isNull(pressRunLoads.deletedAt),
             eq(pressRuns.status, "completed")

--- a/packages/api/src/routers/ttb.ts
+++ b/packages/api/src/routers/ttb.ts
@@ -6696,8 +6696,8 @@ export const ttbRouter = router({
             and(
               isNull(pressRuns.deletedAt),
               eq(pressRuns.status, "completed"),
-              gte(pressRuns.dateCompleted, startDate.toISOString().split("T")[0]),
-              lte(pressRuns.dateCompleted, endDate.toISOString().split("T")[0])
+              sql`${pressRuns.dateCompleted}::date >= ${startDate.toISOString().split("T")[0]}::date`,
+              sql`${pressRuns.dateCompleted}::date <= ${endDate.toISOString().split("T")[0]}::date`
             )
           );
 

--- a/packages/db/migrations/0159_press_run_datetime.sql
+++ b/packages/db/migrations/0159_press_run_datetime.sql
@@ -1,0 +1,6 @@
+-- Press run completion becomes a full datetime (was DATE).
+-- Existing rows back-fill to noon Pacific (19:00 UTC) on their recorded date
+-- so no row shifts to a different local calendar day.
+ALTER TABLE press_runs
+  ALTER COLUMN date_completed TYPE timestamp
+  USING (date_completed::timestamp + interval '19 hours');

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1054,7 +1054,7 @@ export const pressRuns = pgTable(
     status: pressRunStatusEnum("status").notNull().default("draft"),
 
     // Timing fields for session management
-    dateCompleted: date("date_completed"), // Date when press run was completed
+    dateCompleted: timestamp("date_completed"), // When the press run was completed (full datetime)
 
     // Aggregate measurements (calculated from loads)
     // Using existing decimal precision patterns: precision 10, scale 3 for weights/volumes


### PR DESCRIPTION
Closes the last date-only production activity per the owner's policy (activities = date + time; schedule targets may be date-only).

- `press_runs.date_completed` DATE → timestamp. Migration 0159 already applied to the shared DB; existing rows back-filled to noon Pacific on their recorded date so no row shifts a calendar day.
- Both completion flows and the Edit Completion Date dialog take a datetime-local value, interpreted in the org timezone.
- Press run naming (`YYYY-MM-DD-##`) now uses the org-local calendar date of the completion instant (server reads the timezone system setting; defaults to America/Los_Angeles).
- Production/TTB range filters on `date_completed` cast to `::date` so entries later in the end day are not excluded.
- On-hand reconciliation renders the pressed date from the new Date value.

## Testing
- `pnpm typecheck` clean on db, api, web
- Verified back-fill: rows show `19:00:00` UTC (= noon PDT) on their original dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)