### PR TITLE
Bottling: insufficient materials warn instead of blocking

### DIFF
--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -216,10 +216,9 @@ export function BottleModal({
       return;
     }
 
-    const seededQty = Math.min(
-      unitsProduced && unitsProduced > 0 ? unitsProduced : 1,
-      selectedItem.quantity,
-    );
+    // Seed to the run's unit count even past available stock — insufficient
+    // stock warns at submit and inventory goes negative until restocked.
+    const seededQty = unitsProduced && unitsProduced > 0 ? unitsProduced : 1;
 
     const newMaterial: SelectedMaterial = {
       packagingPurchaseItemId: currentMaterialId,
@@ -260,17 +259,16 @@ export function BottleModal({
   // Sync already-added materials when unitsProduced changes. Without this, a
   // user who adds bottles/caps BEFORE typing the unit count gets quantityUsed=1
   // (the default staging value) frozen in selectedMaterials, which then prorates
-  // COGS against 1 bottle instead of e.g. 132. Cap at availableQuantity so a
-  // user-entered count larger than stock doesn't silently inflate.
+  // COGS against 1 bottle instead of e.g. 132. Deliberately NOT capped at
+  // available stock: shortages warn at submit and inventory goes negative.
   useEffect(() => {
     if (!unitsProduced || unitsProduced <= 0) return;
     setSelectedMaterials(prev => {
       let changed = false;
       const next = prev.map(m => {
-        const target = Math.min(unitsProduced, m.availableQuantity);
-        if (m.quantityUsed === target) return m;
+        if (m.quantityUsed === unitsProduced) return m;
         changed = true;
-        return { ...m, quantityUsed: target };
+        return { ...m, quantityUsed: unitsProduced };
       });
       return changed ? next : prev;
     });
@@ -380,6 +378,20 @@ export function BottleModal({
         variant: "destructive",
       });
       return;
+    }
+
+    // Insufficient stock warns but never blocks — inventory goes negative
+    // until restocked (same policy as labels and additives).
+    const shortages = selectedMaterials.filter(
+      (m) => m.quantityUsed > m.availableQuantity,
+    );
+    if (shortages.length > 0) {
+      const proceed = window.confirm(
+        `Insufficient stock for ${shortages
+          .map((m) => `${m.itemName} (need ${m.quantityUsed}, have ${m.availableQuantity})`)
+          .join(", ")}.\n\nPackage anyway? Inventory will go negative until restocked.`,
+      );
+      if (!proceed) return;
     }
 
     // Filter out any invalid labor assignments (safety check)
@@ -585,6 +597,12 @@ export function BottleModal({
                             ? `Using ${material.quantityUsed} of ${material.availableQuantity} available`
                             : `count set below · ${material.availableQuantity} available`}
                         </p>
+                        {material.quantityUsed > material.availableQuantity && (
+                          <p className="text-xs text-amber-600">
+                            Short {material.quantityUsed - material.availableQuantity} —
+                            inventory will go negative until restocked
+                          </p>
+                        )}
                       </div>
                       <Button
                         type="button"

--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -713,13 +713,14 @@ export const packagingRouter = router({
                 createdBy: ctx.session.user.id,
               });
 
-              // Increment quantityUsed on packaging inventory
+              // Increment quantityUsed on packaging inventory. No stock floor:
+              // insufficient stock warns but never blocks, and available goes
+              // negative until restocked (same policy as labels/additives).
               await tx.execute(sql`
                 UPDATE packaging_purchase_items
                 SET quantity_used = quantity_used + ${material.quantityUsed},
                     updated_at = NOW()
                 WHERE id = ${material.packagingPurchaseItemId}
-                AND (quantity - quantity_used) >= ${material.quantityUsed}
               `);
             }
           }


### PR DESCRIPTION
Owner hit this bottling 204 bottles with 0 × 750ml glass bottles in stock: the modal clamped the bottle material to `quantityUsed: 0`, which the API's `z.number().int().positive()` rejected — completion was impossible.

Applies the standing warn-don't-block policy (labels #138, additives #129):
- Material quantities track the unit count with no stock cap; short lines show an amber "inventory will go negative" note and a confirm dialog at submit.
- The inventory depletion no longer has a stock floor, so usage records truthfully and available stock goes negative until restocked (the silent-skip guard previously left usage unrecorded on shortage).

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)