### PR TITLE
Labor tracking on additives, measurements, and keg fills

### DIFF
--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -21,6 +21,7 @@ import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { LastActivityHint } from "@/components/ui/LastActivityHint";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, Package, AlertTriangle, Calculator } from "lucide-react";
 import { additiveRateGramsPerL } from "lib/src/units/conversions";
@@ -192,6 +193,7 @@ export function AddBatchAdditiveForm({
   const [amount, setAmount] = useState(prefillAmount != null ? String(prefillAmount) : "");
   const [unit, setUnit] = useState(prefillUnit ?? "");
   const [notes, setNotes] = useState("");
+  const [laborAssignments, setLaborAssignments] = useState<WorkerAssignment[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [addedDate, setAddedDate] = useState(() => {
@@ -263,12 +265,14 @@ export function AddBatchAdditiveForm({
     return null;
   }, [amount, unit, effectiveBatchVolumeL]);
 
-  // Fetch available additive inventory items, filtered by type
+  // Fetch additive inventory items, filtered by type. Depleted lots stay
+  // listed (marked "0 available") — insufficient stock warns at submit and
+  // the lot goes negative until restocked.
   const { data: inventoryData, isLoading: isLoadingInventory } =
     trpc.additivePurchases.listInventory.useQuery(
       {
         itemType: selectedAdditiveType,
-        onlyAvailable: true,
+        onlyAvailable: false,
       },
       {
         enabled: !!selectedAdditiveType,
@@ -597,6 +601,12 @@ export function AddBatchAdditiveForm({
       ...(includeVolume ? { volumeAddedL: parsedVolumeL } : {}),
       // Fruit additive classification (TTB IC 17-2)
       ...(additiveType === "Fruit/Fruit Product" ? { isApplePearFruit } : {}),
+      // Labor tracking
+      ...(laborAssignments.some((a) => a.workerId && a.hoursWorked > 0) && {
+        laborAssignments: toApiLaborAssignments(
+          laborAssignments.filter((a) => a.workerId && a.hoursWorked > 0),
+        ),
+      }),
     };
 
     addAdditive.mutate(additiveData);
@@ -827,7 +837,9 @@ export function AddBatchAdditiveForm({
                   {!isLoadingInventory && filteredInventory.length > 0 && (
                     <CommandGroup heading="Available Inventory">
                       {filteredInventory.map((item) => {
-                        const isLowStock = item.availableQuantity < item.quantity * 0.2;
+                        const isDepleted = item.availableQuantity <= 0;
+                        const isLowStock =
+                          !isDepleted && item.availableQuantity < item.quantity * 0.2;
                         const expirationDate = formatDate(item.expirationDate);
                         const isExpiringSoon = item.expirationDate &&
                           new Date(item.expirationDate) < new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
@@ -845,10 +857,12 @@ export function AddBatchAdditiveForm({
                                   {item.varietyName || item.productName}
                                 </span>
                                 <Badge
-                                  variant={isLowStock ? "destructive" : "secondary"}
+                                  variant={isDepleted || isLowStock ? "destructive" : "secondary"}
                                   className="ml-2"
                                 >
-                                  {item.availableQuantity.toFixed(2)} {item.unit}
+                                  {isDepleted
+                                    ? `${item.availableQuantity.toFixed(2)} ${item.unit} — will go negative`
+                                    : `${item.availableQuantity.toFixed(2)} ${item.unit}`}
                                 </Badge>
                               </div>
                               <div className="text-xs text-muted-foreground mt-0.5">
@@ -1081,6 +1095,12 @@ export function AddBatchAdditiveForm({
         <DateWarning warning={dateWarning} />
         <LastActivityHint batchId={batchId} date={addedDate} />
       </div>
+
+      <WorkerLaborInput
+        value={laborAssignments}
+        onChange={setLaborAssignments}
+        activityLabel="this addition"
+      />
 
       <div className="space-y-2">
         <Label htmlFor="notes">Notes</Label>

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -22,6 +22,7 @@ import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { LastActivityHint } from "@/components/ui/LastActivityHint";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 import { Loader2, Info } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
 
@@ -72,6 +73,7 @@ export function AddBatchMeasurementForm({
   const [tempUnit, setTempUnit] = useState<"C" | "F">("C");
   const [notes, setNotes] = useState("");
   const [sensoryNotes, setSensoryNotes] = useState("");
+  const [laborAssignments, setLaborAssignments] = useState<WorkerAssignment[]>([]);
   const [volume, setVolume] = useState("");
 
   // Fetch batch details to get product type
@@ -236,6 +238,10 @@ export function AddBatchMeasurementForm({
     if (notes) measurementData.notes = notes;
     if (sensoryNotes) measurementData.sensoryNotes = sensoryNotes;
     if (volume) measurementData.volume = parseFloat(volume);
+    const validLabor = laborAssignments.filter((a) => a.workerId && a.hoursWorked > 0);
+    if (validLabor.length > 0) {
+      measurementData.laborAssignments = toApiLaborAssignments(validLabor);
+    }
 
     addMeasurement.mutate(measurementData);
   };
@@ -604,6 +610,12 @@ export function AddBatchMeasurementForm({
           </p>
         </div>
       )}
+
+      <WorkerLaborInput
+        value={laborAssignments}
+        onChange={setLaborAssignments}
+        activityLabel="this measurement"
+      />
 
       <div className="space-y-2">
         <Label htmlFor="notes">Notes</Label>

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -28,6 +28,7 @@ import { PreBottlingBanner, type PreBottlingData } from "../PreBottlingBanner";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 import { Card, CardContent } from "@/components/ui/card";
 import { PackageTypeSelector } from "../UnifiedPackagingModal";
 
@@ -121,6 +122,7 @@ export function FillKegModal({
 }: FillKegModalProps) {
   const { formatDateTimeForInput, parseDateTimeFromInput, seedDateTimeForInput } = useDateFormat();
   const [selectedKegIds, setSelectedKegIds] = useState<string[]>([]);
+  const [laborAssignments, setLaborAssignments] = useState<WorkerAssignment[]>([]);
   const [kegVolumes, setKegVolumes] = useState<Record<string, number>>({});
 
   const {
@@ -186,6 +188,7 @@ export function FillKegModal({
     if (!open) {
       setSelectedKegIds([]);
       setKegVolumes({});
+      setLaborAssignments([]);
     } else {
       // Re-seed the date on open (the form mounts once; defaults go stale).
       setValue("filledAt", seedDateTimeForInput(prefillFilledAt));
@@ -271,6 +274,11 @@ export function FillKegModal({
       lossUnit: data.lossUnit,
       carbonationMethod: data.carbonationMethod,
       productionNotes: data.productionNotes,
+      ...(laborAssignments.some((a) => a.workerId && a.hoursWorked > 0) && {
+        laborAssignments: toApiLaborAssignments(
+          laborAssignments.filter((a) => a.workerId && a.hoursWorked > 0),
+        ),
+      }),
     });
   };
 
@@ -443,6 +451,12 @@ export function FillKegModal({
                 </p>
               )}
             </div>
+
+            <WorkerLaborInput
+              value={laborAssignments}
+              onChange={setLaborAssignments}
+              activityLabel="this keg fill"
+            />
 
             {/* Production Notes */}
             <div>

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -447,6 +447,10 @@ const addMeasurementSchema = z.object({
   notes: z.string().optional(),
   sensoryNotes: z.string().optional(),
   takenBy: z.string().optional(),
+  laborAssignments: z.array(z.object({
+    workerId: z.string().uuid(),
+    hoursWorked: z.number().positive(),
+  })).optional(),
 });
 
 const addAdditiveSchema = z.object({
@@ -471,6 +475,10 @@ const addAdditiveSchema = z.object({
   notes: z.string().optional(),
   addedBy: z.string().optional(),
   addedAt: z.date().or(z.string().transform((val) => new Date(val))).optional(),
+  laborAssignments: z.array(z.object({
+    workerId: z.string().uuid(),
+    hoursWorked: z.number().positive(),
+  })).optional(),
 });
 
 const updateMeasurementSchema = z.object({
@@ -1943,6 +1951,27 @@ export const batchRouter = router({
           })
           .returning();
 
+        // Save labor assignments if provided
+        if (input.laborAssignments && input.laborAssignments.length > 0) {
+          for (const assignment of input.laborAssignments) {
+            const [worker] = await db
+              .select({ hourlyRate: workers.hourlyRate })
+              .from(workers)
+              .where(eq(workers.id, assignment.workerId))
+              .limit(1);
+            const hourlyRate = parseFloat(worker?.hourlyRate?.toString() || "20.00");
+            const laborCost = assignment.hoursWorked * hourlyRate;
+            await db.insert(activityLaborAssignments).values({
+              activityType: "measurement",
+              batchMeasurementId: newMeasurement[0].id,
+              workerId: assignment.workerId,
+              hoursWorked: assignment.hoursWorked.toString(),
+              hourlyRateSnapshot: hourlyRate.toString(),
+              laborCost: laborCost.toString(),
+            });
+          }
+        }
+
         // Auto-set Original Gravity only if batch doesn't have one
         // Don't overwrite existing OG from pressing - that's the true OG for ABV calculation
         let ogAutoSet = false;
@@ -2198,6 +2227,27 @@ export const batchRouter = router({
             addedAt: input.addedAt || new Date(),
           })
           .returning();
+
+        // Save labor assignments if provided
+        if (input.laborAssignments && input.laborAssignments.length > 0) {
+          for (const assignment of input.laborAssignments) {
+            const [worker] = await db
+              .select({ hourlyRate: workers.hourlyRate })
+              .from(workers)
+              .where(eq(workers.id, assignment.workerId))
+              .limit(1);
+            const hourlyRate = parseFloat(worker?.hourlyRate?.toString() || "20.00");
+            const laborCost = assignment.hoursWorked * hourlyRate;
+            await db.insert(activityLaborAssignments).values({
+              activityType: "additive",
+              batchAdditiveId: newAdditive[0].id,
+              workerId: assignment.workerId,
+              hoursWorked: assignment.hoursWorked.toString(),
+              hourlyRateSnapshot: hourlyRate.toString(),
+              laborCost: laborCost.toString(),
+            });
+          }
+        }
 
         // If the additive contributed material liquid volume (honey, brandy
         // for fortification, fruit purée, etc.), bump the batch volume and

--- a/packages/api/src/routers/kegs.ts
+++ b/packages/api/src/routers/kegs.ts
@@ -22,6 +22,8 @@ import {
   batchCarbonationOperations,
   salesChannels,
   kegCleaningOperations,
+  workers,
+  activityLaborAssignments,
 } from "db";
 import { eq, and, desc, isNull, sql, like, or, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
@@ -215,6 +217,10 @@ const fillKegsSchema = z.object({
   sourceCarbonationOperationId: z.string().uuid().optional(),
   productionNotes: z.string().optional(),
   materials: z.array(kegMaterialSchema).optional(),
+  laborAssignments: z.array(z.object({
+    workerId: z.string().uuid(),
+    hoursWorked: z.number().positive(),
+  })).optional(),
 });
 
 const distributeKegFillSchema = z.object({
@@ -1228,6 +1234,29 @@ export const kegsRouter = router({
                 WHERE id = ${material.packagingPurchaseItemId}
               `);
             }
+          }
+        }
+
+        // Save labor assignments if provided. The whole multi-keg run is one
+        // work session, so labor attaches to the first fill record only —
+        // attaching to every keg would multiply the cost.
+        if (input.laborAssignments && input.laborAssignments.length > 0 && fillRecords.length > 0) {
+          for (const assignment of input.laborAssignments) {
+            const [worker] = await tx
+              .select({ hourlyRate: workers.hourlyRate })
+              .from(workers)
+              .where(eq(workers.id, assignment.workerId))
+              .limit(1);
+            const hourlyRate = parseFloat(worker?.hourlyRate?.toString() || "20.00");
+            const laborCost = assignment.hoursWorked * hourlyRate;
+            await tx.insert(activityLaborAssignments).values({
+              activityType: "keg_fill",
+              kegFillId: fillRecords[0].id,
+              workerId: assignment.workerId,
+              hoursWorked: assignment.hoursWorked.toString(),
+              hourlyRateSnapshot: hourlyRate.toString(),
+              laborCost: laborCost.toString(),
+            });
           }
         }
 

--- a/packages/db/migrations/0160_measurement_additive_labor.sql
+++ b/packages/db/migrations/0160_measurement_additive_labor.sql
@@ -1,0 +1,8 @@
+-- Labor tracking on measurements and additive additions ("labor on ALL activities").
+ALTER TYPE activity_labor_type ADD VALUE IF NOT EXISTS 'measurement';
+--> statement-breakpoint
+ALTER TYPE activity_labor_type ADD VALUE IF NOT EXISTS 'additive';
+--> statement-breakpoint
+ALTER TABLE activity_labor_assignments ADD COLUMN IF NOT EXISTS batch_measurement_id uuid;
+--> statement-breakpoint
+ALTER TABLE activity_labor_assignments ADD COLUMN IF NOT EXISTS batch_additive_id uuid;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -121,6 +121,8 @@ export const activityLaborTypeEnum = pgEnum("activity_labor_type", [
   // Generic recipe-step work (linked via batchStepTaskId) for step kinds
   // without a dedicated operation record (remove fruit, label kegs, ...)
   "recipe_step",
+  "measurement",
+  "additive",
 ]);
 
 // Fruit variety characteristic enums
@@ -380,6 +382,8 @@ export const activityLaborAssignments = pgTable(
     vesselCleaningOperationId: uuid("vessel_cleaning_operation_id"),
     batchVolumeAdjustmentId: uuid("batch_volume_adjustment_id"),
     batchStepTaskId: uuid("batch_step_task_id"),
+    batchMeasurementId: uuid("batch_measurement_id"),
+    batchAdditiveId: uuid("batch_additive_id"),
     // Worker assignment
     workerId: uuid("worker_id")
       .notNull()


### PR DESCRIPTION
Owner request while entering hops and sugar on Coastal Hop 2026-056: every activity should have a labor section, and depleted inventory lots (cane sugar at ≤0 after B2) must stay selectable.

- Adds the shared WorkerLaborInput to the additive form (covers hops, fruit, sugar — all types), the measurement form, and the keg fill modal — the last three activities without labor capture.
- API: `addMeasurement`, `addAdditive`, and `fillKegs` accept `laborAssignments` with the standard hourly-rate snapshot. New polymorphic links: `batch_measurement_id`, `batch_additive_id` (+ `measurement`/`additive` enum values, migration 0160 — already applied). Multi-keg fills attach labor once (first fill) to avoid multiplying cost.
- Additive inventory dropdown now requests depleted lots too; they show a red "will go negative" badge and the existing submit-time confirm handles the shortage.

## Testing
- `pnpm typecheck` clean (db, api, web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)