### PR TITLE
Labor hours: allow quarter-hours everywhere

### DIFF
--- a/apps/web/src/components/labor/WorkerLaborInput.tsx
+++ b/apps/web/src/components/labor/WorkerLaborInput.tsx
@@ -155,7 +155,7 @@ export function WorkerLaborInput({
               <div className="relative">
                 <Input
                   type="number"
-                  step="0.1"
+                  step="any"
                   min="0"
                   placeholder="Hours"
                   value={hoursInput}
@@ -206,7 +206,7 @@ export function WorkerLaborInput({
                 <div className="flex items-center gap-2 flex-shrink-0">
                   <Input
                     type="number"
-                    step="0.1"
+                    step="any"
                     min="0"
                     className="w-20 h-8 text-center"
                     value={assignment.hoursWorked}


### PR DESCRIPTION
Owner entered 0.25 h on the sugar addition and the browser rejected it ("round to .2 or .3") — the shared hours inputs had `step="0.1"`, enforced only in forms that submit natively, so behavior differed between activities. Now `step="any"` in the one shared component; every labor section accepts the same values.

## Testing
- `pnpm --filter web run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)