### PR TITLE
Filter: allow zero-loss operations

### DIFF
--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -194,9 +194,20 @@ export function FilterModal({
       onSuccess?.(filteredAt);
     },
     onError: (error) => {
+      // Zod input errors arrive as a JSON array of issues — surface the
+      // first issue's message instead of the raw blob.
+      let description = error.message;
+      try {
+        const issues = JSON.parse(error.message);
+        if (Array.isArray(issues) && issues[0]?.message) {
+          description = issues[0].message;
+        }
+      } catch {
+        // not JSON — show as-is
+      }
       toast({
         title: "Filter Operation Failed",
-        description: error.message,
+        description,
         variant: "destructive",
       });
     },

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -555,8 +555,8 @@ const filterBatchSchema = z.object({
     workerId: z.string().uuid(),
     hoursWorked: z.number().positive(),
   })).optional(),
-}).refine((data) => data.volumeAfter < data.volumeBefore, {
-  message: "Volume after filtering must be less than volume before",
+}).refine((data) => data.volumeAfter <= data.volumeBefore, {
+  message: "Volume after filtering cannot exceed volume before",
   path: ["volumeAfter"],
 });
 


### PR DESCRIPTION
Owner's fine filter (315 L → 315 L into the brite) silently refused to save: the API schema required `volumeAfter < volumeBefore` strictly, so zero-loss runs failed input validation, and the zod error rendered as raw JSON. Zero-loss filters are legitimate; the constraint is now `<=`, and the filter modal parses zod issue arrays into a readable toast message.

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)