### PR TITLE
Never fail silently: readable error on every mutation

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -112,6 +112,7 @@ import { LegacyInventorySection } from "@/components/admin/LegacyInventorySectio
 import { TTBClassificationSettings } from "@/components/admin/TTBClassificationSettings";
 import { useSettings } from "@/contexts/SettingsContext";
 import { cn } from "@/lib/utils";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Form schemas
 const userSchema = z.object({
@@ -936,7 +937,7 @@ function BusinessProfile() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -1375,7 +1376,7 @@ function SystemSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/app/batch/[id]/page.tsx
+++ b/apps/web/src/app/batch/[id]/page.tsx
@@ -84,6 +84,7 @@ import {
   WeightDisplay,
   type WeightUnit,
 } from "@/components/ui/weight-display";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 export default function BatchDetailsPage() {
   const params = useParams();
@@ -141,7 +142,7 @@ export default function BatchDetailsPage() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/app/distillation/page.tsx
+++ b/apps/web/src/app/distillation/page.tsx
@@ -52,6 +52,7 @@ import { SendToDistilleryDialog } from "@/components/cellar/SendToDistilleryDial
 import { ReceiveBrandyDialog } from "@/components/cellar/ReceiveBrandyDialog";
 import { CreatePommeauBlendDialog } from "@/components/cellar/CreatePommeauBlendDialog";
 import { toast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 export default function DistillationPage() {
   const [activeTab, setActiveTab] = useState("overview");
@@ -85,7 +86,7 @@ export default function DistillationPage() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/app/pressing/page.tsx
+++ b/apps/web/src/app/pressing/page.tsx
@@ -56,6 +56,7 @@ import {
   WeightDisplay,
   type WeightUnit,
 } from "@/components/ui/weight-display";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface PressRun {
   id: string;
@@ -346,7 +347,7 @@ function CompletedRunsSection({
     onError: (error) => {
       toast({
         title: "Update Failed",
-        description: error.message || "Failed to update press run date",
+        description: humanizeMutationError(error) || "Failed to update press run date",
         variant: "destructive",
       });
     },

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import { SessionProvider } from "next-auth/react";
 import { useState } from "react";
 import { trpc } from "../utils/trpc";
+import { toast } from "../hooks/use-toast";
+import { humanizeMutationError } from "../utils/mutation-errors";
 import { ToastProvider } from "../components/ui/toast-provider";
 import { performanceMonitor } from "../lib/performance-monitor";
 import { IdleTimeoutProvider } from "../components/providers/idle-timeout-provider";
@@ -15,6 +17,19 @@ import { SettingsProvider } from "../contexts/SettingsContext";
 // Enhanced QueryClient with performance optimizations
 function createOptimizedQueryClient() {
   return new QueryClient({
+    // Safety net: a failed action must NEVER be silent. Mutations that
+    // define their own onError keep their tailored toast; everything else
+    // gets a readable error here (zod issue arrays are unwrapped).
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        if (mutation.options.onError) return;
+        toast({
+          title: "Action failed",
+          description: humanizeMutationError(error),
+          variant: "destructive",
+        });
+      },
+    }),
     defaultOptions: {
       queries: {
         // Increased stale time for better caching

--- a/apps/web/src/app/reports/ttb/page.tsx
+++ b/apps/web/src/app/reports/ttb/page.tsx
@@ -36,6 +36,7 @@ import { LIQ774Preview } from "@/components/reports/LIQ774Preview";
 import { TTBPeriodFinalization } from "@/components/reports/TTBPeriodFinalization";
 import { ReportExportDropdown } from "@/components/reports/ReportExportDropdown";
 import { downloadTTBFormExcel, type TTBFormPDFData } from "@/utils/excel/ttbForm512017";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const currentYear = new Date().getFullYear();
 const years = [currentYear, currentYear - 1, currentYear - 2];
@@ -140,7 +141,7 @@ export default function TTBReportsPage() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/BatchLifecycleAudit.tsx
+++ b/apps/web/src/components/admin/BatchLifecycleAudit.tsx
@@ -59,6 +59,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/lib/utils";
 import { toast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface BatchLifecycleAuditProps {
   reconciliationSnapshotId?: string;
@@ -172,7 +173,7 @@ export function BatchLifecycleAudit({
       setPhysicalCountDialogOpen(false);
     },
     onError: (error) => {
-      toast({ title: "Error saving count", description: error.message, variant: "destructive" });
+      toast({ title: "Error saving count", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 

--- a/apps/web/src/components/admin/CalibrationSessionDialog.tsx
+++ b/apps/web/src/components/admin/CalibrationSessionDialog.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface CalibrationSessionDialogProps {
   calibrationId: string;
@@ -77,7 +78,7 @@ export function CalibrationSessionDialog({
       refetch();
     },
     onError: (error) => {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: "Error", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 
@@ -87,7 +88,7 @@ export function CalibrationSessionDialog({
       refetch();
     },
     onError: (error) => {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: "Error", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 
@@ -101,7 +102,7 @@ export function CalibrationSessionDialog({
       onCalibrationUpdated();
     },
     onError: (error) => {
-      toast({ title: "Error", description: error.message, variant: "destructive" });
+      toast({ title: "Error", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 

--- a/apps/web/src/components/admin/CalibrationSettings.tsx
+++ b/apps/web/src/components/admin/CalibrationSettings.tsx
@@ -57,6 +57,7 @@ import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
 import { formatDate } from "@/utils/date-format";
 import { CalibrationSessionDialog } from "./CalibrationSessionDialog";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 export function CalibrationSettings() {
   const { toast } = useToast();
@@ -92,7 +93,7 @@ export function CalibrationSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -109,7 +110,7 @@ export function CalibrationSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -126,7 +127,7 @@ export function CalibrationSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -144,7 +145,7 @@ export function CalibrationSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/LegacyInventorySection.tsx
+++ b/apps/web/src/components/admin/LegacyInventorySection.tsx
@@ -57,6 +57,7 @@ import {
 } from "lucide-react";
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const TAX_CLASS_OPTIONS = [
   { value: "hardCider", label: "Hard Cider (<8.5% ABV)", productType: "cider" },
@@ -116,7 +117,7 @@ export function LegacyInventorySection() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -133,7 +134,7 @@ export function LegacyInventorySection() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/MeasurementSchedulesSettings.tsx
+++ b/apps/web/src/components/admin/MeasurementSchedulesSettings.tsx
@@ -50,6 +50,7 @@ import {
   type PerTypeMeasurementSchedule,
   type MeasurementTypeInterval,
 } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Types
 interface CustomProductType {
@@ -194,7 +195,7 @@ export function MeasurementSchedulesSettings() {
     } catch (error: any) {
       toast({
         title: "Error",
-        description: error.message || "Failed to save custom product type.",
+        description: humanizeMutationError(error) || "Failed to save custom product type.",
         variant: "destructive",
       });
     }

--- a/apps/web/src/components/admin/OverheadSettings.tsx
+++ b/apps/web/src/components/admin/OverheadSettings.tsx
@@ -40,6 +40,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface OverheadFormData {
   overheadTrackingEnabled: boolean;
@@ -119,7 +120,7 @@ export function OverheadSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/SquareIntegration.tsx
+++ b/apps/web/src/components/admin/SquareIntegration.tsx
@@ -51,6 +51,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { formatDate } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 export function SquareIntegration() {
   const [activeTab, setActiveTab] = useState<"config" | "mapping" | "logs" | "stats">("config");
@@ -105,7 +106,7 @@ function SquareConfiguration() {
     onError: (error) => {
       toast({
         title: "Configuration Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -397,7 +398,7 @@ function ProductMapping() {
     onError: (error) => {
       toast({
         title: "Mapping Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/TTBClassificationSettings.tsx
+++ b/apps/web/src/components/admin/TTBClassificationSettings.tsx
@@ -18,6 +18,7 @@ import {
   type TTBClassificationConfig,
   DEFAULT_TTB_CLASSIFICATION_CONFIG,
 } from "lib/src/calculations/ttb";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 function NumberField({
   label,
@@ -75,7 +76,7 @@ export function TTBClassificationSettings() {
     onError: (error) => {
       toast({
         title: "Save Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/TTBOpeningBalancesSettings.tsx
+++ b/apps/web/src/components/admin/TTBOpeningBalancesSettings.tsx
@@ -28,6 +28,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface TaxClassBalances {
   hardCider: number;
@@ -142,7 +143,7 @@ export function TTBOpeningBalancesSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/TTBReconciliationSummary.tsx
+++ b/apps/web/src/components/admin/TTBReconciliationSummary.tsx
@@ -64,6 +64,7 @@ import { downloadReconciliationPDF } from "@/utils/pdf/ttbReconciliation";
 import { formatDate } from "@/utils/date-format";
 import { BatchLifecycleAudit } from "./BatchLifecycleAudit";
 import { CheckpointHistory } from "./CheckpointHistory";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Type for batch details from TTB API
 interface BatchDetail {
@@ -120,7 +121,7 @@ export function TTBReconciliationSummary() {
     onError: (error) => {
       toast({
         title: "Error Saving Reconciliation",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/TaxReportingSettings.tsx
+++ b/apps/web/src/components/admin/TaxReportingSettings.tsx
@@ -36,6 +36,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
 import { US_STATES, getRecommendedTtbFrequency } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 type ReportingFrequency = "monthly" | "quarterly" | "annual";
 
@@ -85,7 +86,7 @@ export function TaxReportingSettings() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -464,7 +465,7 @@ function FilingFrequencyDeterminationCard() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/WorkersManagement.tsx
+++ b/apps/web/src/components/admin/WorkersManagement.tsx
@@ -34,6 +34,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
 import { Switch } from "@/components/ui/switch";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const workerSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -80,7 +81,7 @@ export function WorkersManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -99,7 +100,7 @@ export function WorkersManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -116,7 +117,7 @@ export function WorkersManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -133,7 +134,7 @@ export function WorkersManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/admin/ttb-onboarding/Step2Reconciliation.tsx
+++ b/apps/web/src/components/admin/ttb-onboarding/Step2Reconciliation.tsx
@@ -57,6 +57,7 @@ import {
   TAX_CLASS_LABELS,
   TaxClassBalances,
 } from "./types";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Type for batch details from TTB API
 interface BatchDetail {
@@ -114,7 +115,7 @@ export function Step2Reconciliation({
     onError: (error) => {
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -42,6 +42,7 @@ import {
   estimateResidualCO2,
 } from "lib";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const SUGAR_TYPE_LABELS: Record<string, string> = {
   sucrose: "Sucrose (Table Sugar)",
@@ -393,7 +394,7 @@ export function CarbonateModal({
     },
     onError: (error) => {
       console.error("Carbonation start error:", error.message);
-      toast({ title: "Carbonation Failed", description: error.message, variant: "destructive" });
+      toast({ title: "Carbonation Failed", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 
@@ -418,7 +419,7 @@ export function CarbonateModal({
       onOpenChange(false);
     },
     onError: (error) => {
-      toast({ title: "Failed to Record Carbonation", description: error.message, variant: "destructive" });
+      toast({ title: "Failed to Record Carbonation", description: humanizeMutationError(error), variant: "destructive" });
     },
   });
 

--- a/apps/web/src/components/batch/CompleteCarbonationModal.tsx
+++ b/apps/web/src/components/batch/CompleteCarbonationModal.tsx
@@ -39,6 +39,7 @@ import {
   Thermometer,
 } from "lucide-react";
 import { calculateCO2Volumes } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const completeCarbonationSchema = z
   .object({
@@ -240,7 +241,7 @@ export function CompleteCarbonationModal({
     onError: (error) => {
       toast({
         title: "Completion Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/batch/EditCarbonationModal.tsx
+++ b/apps/web/src/components/batch/EditCarbonationModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Loader2, Save } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editCarbonationSchema = z.object({
   startedAt: z.string().min(1, "Start date is required"),
@@ -143,7 +144,7 @@ export function EditCarbonationModal({
     onError: (error) => {
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/popover";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface AddBatchAdditiveFormProps {
   batchId: string;
@@ -464,7 +465,7 @@ export function AddBatchAdditiveForm({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to add additive",
+        description: humanizeMutationError(error) || "Failed to add additive",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/AssignToVesselDialog.tsx
+++ b/apps/web/src/components/cellar/AssignToVesselDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { Search, Container } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface AssignToVesselDialogProps {
   open: boolean;
@@ -61,7 +62,7 @@ export function AssignToVesselDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/BarrelContentsHistory.tsx
+++ b/apps/web/src/components/cellar/BarrelContentsHistory.tsx
@@ -43,6 +43,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
 import { formatDate } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const contentsHistorySchema = z.object({
   contentsType: z.string().min(1, "Contents type is required"),
@@ -102,7 +103,7 @@ export function BarrelContentsHistory({ vesselId, vesselName }: BarrelContentsHi
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -121,7 +122,7 @@ export function BarrelContentsHistory({ vesselId, vesselName }: BarrelContentsHi
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -138,7 +139,7 @@ export function BarrelContentsHistory({ vesselId, vesselName }: BarrelContentsHi
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/BarrelOriginTypesManagement.tsx
+++ b/apps/web/src/components/cellar/BarrelOriginTypesManagement.tsx
@@ -33,6 +33,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useToast } from "@/hooks/use-toast";
 import { Switch } from "@/components/ui/switch";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const originTypeSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -80,7 +81,7 @@ export function BarrelOriginTypesManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -99,7 +100,7 @@ export function BarrelOriginTypesManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -116,7 +117,7 @@ export function BarrelOriginTypesManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/BatchHistoryModal.tsx
+++ b/apps/web/src/components/cellar/BatchHistoryModal.tsx
@@ -65,6 +65,7 @@ import { useToast } from "@/hooks/use-toast";
 import { EditMeasurementDialog } from "@/components/cellar/EditMeasurementDialog";
 import { EditAdditiveDialog } from "@/components/cellar/EditAdditiveDialog";
 import { MeasurementChart } from "@/components/batch/MeasurementChart";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface BatchHistoryModalProps {
   batchId: string;
@@ -108,7 +109,7 @@ export function BatchHistoryModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update batch name",
+        description: humanizeMutationError(error) || "Failed to update batch name",
         variant: "destructive",
       });
     },
@@ -126,7 +127,7 @@ export function BatchHistoryModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete measurement",
+        description: humanizeMutationError(error) || "Failed to delete measurement",
         variant: "destructive",
       });
     },
@@ -144,7 +145,7 @@ export function BatchHistoryModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete additive",
+        description: humanizeMutationError(error) || "Failed to delete additive",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/BatchManagementTable.tsx
+++ b/apps/web/src/components/cellar/BatchManagementTable.tsx
@@ -81,6 +81,7 @@ import { AssignToVesselDialog } from "./AssignToVesselDialog";
 import { toast } from "@/hooks/use-toast";
 import { VolumeDisplay } from "@/components/ui/volume-input";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface BatchManagementTableProps {
   className?: string;
@@ -162,7 +163,7 @@ export function BatchManagementTable({ className }: BatchManagementTableProps) {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -182,7 +183,7 @@ export function BatchManagementTable({ className }: BatchManagementTableProps) {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/CleanTankModal.tsx
+++ b/apps/web/src/components/cellar/CleanTankModal.tsx
@@ -24,6 +24,7 @@ import {
   type WorkerAssignment,
   toApiLaborAssignments,
 } from "@/components/labor/WorkerLaborInput";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const cleanTankSchema = z.object({
   cleanedAt: z.date(),
@@ -93,7 +94,7 @@ export function CleanTankModal({
     onError: (error) => {
       toast({
         title: "Cleaning Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/CreateFortifiedBlendDialog.tsx
+++ b/apps/web/src/components/cellar/CreateFortifiedBlendDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { Loader2, Wine } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface CreateFortifiedBlendDialogProps {
   open: boolean;
@@ -128,7 +129,7 @@ export function CreateFortifiedBlendDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/CreatePommeauBlendDialog.tsx
+++ b/apps/web/src/components/cellar/CreatePommeauBlendDialog.tsx
@@ -24,6 +24,7 @@ import { toast } from "@/hooks/use-toast";
 import { Loader2, Beaker, Info, AlertTriangle } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface CreatePommeauBlendDialogProps {
   open: boolean;
@@ -193,7 +194,7 @@ export function CreatePommeauBlendDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/DestroyBatchModal.tsx
+++ b/apps/web/src/components/cellar/DestroyBatchModal.tsx
@@ -32,6 +32,7 @@ import {
   toApiLaborAssignments,
 } from "@/components/labor/WorkerLaborInput";
 import { AlertTriangle } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const DESTRUCTION_CATEGORIES = [
   { value: "contamination_spoilage", label: "Contamination / spoilage (VA, brett, off-flavor)" },
@@ -130,7 +131,7 @@ export function DestroyBatchModal({
       setSubmitError(error.message);
       toast({
         title: "Destruction failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/EditAdditiveDialog.tsx
+++ b/apps/web/src/components/cellar/EditAdditiveDialog.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface Additive {
   id: string;
@@ -88,7 +89,7 @@ export function EditAdditiveDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update additive",
+        description: humanizeMutationError(error) || "Failed to update additive",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/EditDateDialog.tsx
+++ b/apps/web/src/components/cellar/EditDateDialog.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 type EventType =
   | "transfer"
@@ -175,7 +176,7 @@ export function EditDateDialog({
     } catch (error: any) {
       toast({
         title: "Error",
-        description: error.message || "Failed to update date",
+        description: humanizeMutationError(error) || "Failed to update date",
         variant: "destructive",
       });
     }

--- a/apps/web/src/components/cellar/EditMeasurementDialog.tsx
+++ b/apps/web/src/components/cellar/EditMeasurementDialog.tsx
@@ -17,6 +17,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface Measurement {
   id: string;
@@ -88,7 +89,7 @@ export function EditMeasurementDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update measurement",
+        description: humanizeMutationError(error) || "Failed to update measurement",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -31,6 +31,7 @@ import { Filter, AlertTriangle } from "lucide-react";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
 import { convertVolume } from "lib";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 
 const filterSchema = z.object({
@@ -194,20 +195,9 @@ export function FilterModal({
       onSuccess?.(filteredAt);
     },
     onError: (error) => {
-      // Zod input errors arrive as a JSON array of issues — surface the
-      // first issue's message instead of the raw blob.
-      let description = error.message;
-      try {
-        const issues = JSON.parse(error.message);
-        if (Array.isArray(issues) && issues[0]?.message) {
-          description = issues[0].message;
-        }
-      } catch {
-        // not JSON — show as-is
-      }
       toast({
         title: "Filter Operation Failed",
-        description,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/PrepForCleaningModal.tsx
+++ b/apps/web/src/components/cellar/PrepForCleaningModal.tsx
@@ -18,6 +18,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Sparkles } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const prepSchema = z.object({
   residueL: z.number().nonnegative("Residue can't be negative"),
@@ -78,7 +79,7 @@ export function PrepForCleaningModal({
       setSubmitError(error.message);
       toast({
         title: "Couldn't prep tank",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/RackingModal.tsx
+++ b/apps/web/src/components/cellar/RackingModal.tsx
@@ -33,6 +33,7 @@ import { convertVolume } from "lib";
 import { Badge } from "@/components/ui/badge";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const rackingSchema = z.object({
   destinationVesselId: z.string().min(1, "Please select a destination vessel"),
@@ -190,7 +191,7 @@ export function RackingModal({
     onError: (error) => {
       toast({
         title: "Racking Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/ReceiveBrandyDialog.tsx
+++ b/apps/web/src/components/cellar/ReceiveBrandyDialog.tsx
@@ -24,6 +24,7 @@ import { toast } from "@/hooks/use-toast";
 import { Loader2, Wine, Info, Check, Plus, X } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { formatDate } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface ReceiveBrandyDialogProps {
   open: boolean;
@@ -119,7 +120,7 @@ export function ReceiveBrandyDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/SendToDistilleryDialog.tsx
+++ b/apps/web/src/components/cellar/SendToDistilleryDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { Loader2, Truck, Plus, Trash2 } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface BatchSelection {
   sourceBatchId: string;
@@ -111,7 +112,7 @@ export function SendToDistilleryDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/TankTransferForm.tsx
+++ b/apps/web/src/components/cellar/TankTransferForm.tsx
@@ -34,6 +34,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { VolumeDisplay } from "@/components/ui/volume-input";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const transferSchema = z.object({
   fromVesselId: z.string().uuid("Select source vessel"),
@@ -254,7 +255,7 @@ export function TankTransferForm({
       setTransferError(error.message);
       toast({
         title: "Transfer failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
       console.error("Transfer failed:", error.message);

--- a/apps/web/src/components/cellar/VesselMap.tsx
+++ b/apps/web/src/components/cellar/VesselMap.tsx
@@ -87,6 +87,7 @@ import { AddBatchMeasurementForm } from "@/components/cellar/AddBatchMeasurement
 import { AddBatchAdditiveForm } from "@/components/cellar/AddBatchAdditiveForm";
 import { TankForm, EditVesselBarrelHistory } from "@/components/cellar/TankForm";
 import { TankTransferForm } from "@/components/cellar/TankTransferForm";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 function BatchMeasurementFormWrapper({
   vesselId,
@@ -353,7 +354,7 @@ export function VesselMap() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete tank",
+        description: humanizeMutationError(error) || "Failed to delete tank",
         variant: "destructive",
       });
     },
@@ -374,7 +375,7 @@ const updateBatchStatusMutation = trpc.batch.update.useMutation({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/cellar/VolumeAdjustmentModal.tsx
+++ b/apps/web/src/components/cellar/VolumeAdjustmentModal.tsx
@@ -30,6 +30,7 @@ import { Scale, AlertTriangle, TrendingUp, TrendingDown } from "lucide-react";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
 import { convertVolume } from "lib";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const ADJUSTMENT_TYPES = [
   { value: "evaporation", label: "Evaporation", description: "Natural evaporation (angel's share)" },
@@ -181,7 +182,7 @@ export function VolumeAdjustmentModal({
     onError: (error) => {
       toast({
         title: "Volume Adjustment Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/EditAdditiveItemModal.tsx
+++ b/apps/web/src/components/inventory/EditAdditiveItemModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit } from "lucide-react";
 import { formatDateForInput, parseDateInput } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editAdditiveItemSchema = z.object({
   quantity: z.number().positive("Quantity must be positive").optional(),
@@ -115,7 +116,7 @@ export function EditAdditiveItemModal({
       console.error("Error data:", error.data);
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/EditBaseFruitItemModal.tsx
+++ b/apps/web/src/components/inventory/EditBaseFruitItemModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit } from "lucide-react";
 import { formatDateForInput, parseDateInput } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editBaseFruitItemSchema = z.object({
   quantity: z.number().positive("Quantity must be positive").optional(),
@@ -110,7 +111,7 @@ export function EditBaseFruitItemModal({
     onError: (error) => {
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/EditJuiceItemModal.tsx
+++ b/apps/web/src/components/inventory/EditJuiceItemModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit } from "lucide-react";
 import { formatDateForInput } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editJuiceItemSchema = z.object({
   volume: z.number().positive("Volume must be positive").optional(),
@@ -130,7 +131,7 @@ export function EditJuiceItemModal({
     onError: (error) => {
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/EditPackagingItemModal.tsx
+++ b/apps/web/src/components/inventory/EditPackagingItemModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit } from "lucide-react";
 import { formatDateForInput, parseDateInput } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editPackagingItemSchema = z.object({
   quantity: z.number().positive("Quantity must be positive").optional(),
@@ -115,7 +116,7 @@ export function EditPackagingItemModal({
       console.error("Error data:", error.data);
       toast({
         title: "Update Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/InventoryEditDialog.tsx
+++ b/apps/web/src/components/inventory/InventoryEditDialog.tsx
@@ -35,6 +35,7 @@ import { HarvestDatePicker } from "@/components/ui/harvest-date-picker";
 import { Loader2 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Schema for base fruit items
 const baseFruitEditSchema = z.object({
@@ -166,7 +167,7 @@ export function InventoryEditDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -185,7 +186,7 @@ export function InventoryEditDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -204,7 +205,7 @@ export function InventoryEditDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -223,7 +224,7 @@ export function InventoryEditDialog({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/JuiceInventoryTable.tsx
+++ b/apps/web/src/components/inventory/JuiceInventoryTable.tsx
@@ -60,6 +60,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { TransferToTankModal } from "@/components/juice/TransferToTankModal";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Type for juice inventory item from API
 interface JuiceInventoryItem {
@@ -150,7 +151,7 @@ export function JuiceInventoryTable({
       console.error("Delete failed:", error);
       toast({
         title: "Error",
-        description: error.message || "Failed to delete juice item",
+        description: humanizeMutationError(error) || "Failed to delete juice item",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/inventory/StartFruitWineBatchDialog.tsx
+++ b/apps/web/src/components/inventory/StartFruitWineBatchDialog.tsx
@@ -42,6 +42,7 @@ import {
   type WeightUnit,
 } from "@/components/ui/weight-display";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const fruitWineSchema = z.object({
   vesselId: z.string().min(1, "Please select a vessel"),
@@ -134,7 +135,7 @@ export function StartFruitWineBatchDialog({
     onError: (error) => {
       toast({
         title: "Failed to Create Batch",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/juice/TransferToTankModal.tsx
+++ b/apps/web/src/components/juice/TransferToTankModal.tsx
@@ -27,6 +27,7 @@ import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { ArrowRight, AlertTriangle, Info, Plus, Droplets, Search } from "lucide-react";
 import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const transferSchema = z.object({
   vesselId: z.string().min(1, "Please select a vessel"),
@@ -138,7 +139,7 @@ export function TransferToTankModal({
       console.error("❌ Transfer failed:", error);
       toast({
         title: "Transfer Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/AdjustInventoryModal.tsx
+++ b/apps/web/src/components/packaging/AdjustInventoryModal.tsx
@@ -25,6 +25,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit, AlertCircle, Package } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const adjustInventorySchema = z.object({
   adjustmentType: z.enum(["breakage", "sample", "transfer", "correction", "void"]),
@@ -106,7 +107,7 @@ export function AdjustInventoryModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/DistributeBottlesModal.tsx
+++ b/apps/web/src/components/packaging/DistributeBottlesModal.tsx
@@ -25,6 +25,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Send, Store, Loader2 } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const distributeBottlesSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
@@ -97,7 +98,7 @@ export function DistributeBottlesModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/DistributeInventoryModal.tsx
+++ b/apps/web/src/components/packaging/DistributeInventoryModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Send, DollarSign, Package, Store } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const distributeInventorySchema = z.object({
   distributionLocation: z.string().min(1, "Location is required"),
@@ -110,7 +111,7 @@ export function DistributeInventoryModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -36,6 +36,7 @@ import { DateWarning } from "@/components/ui/DateWarning";
 import { Tag, AlertTriangle, Info, Loader2, ChevronsUpDown, Check, Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const labelSchema = z.object({
   unitsToLabel: z.number().int().positive("Units to label must be positive"),
@@ -258,7 +259,7 @@ export function LabelModal({
     } catch (error: any) {
       toast({
         title: "Labeling Failed",
-        description: error.message || "Failed to apply labels",
+        description: humanizeMutationError(error) || "Failed to apply labels",
         variant: "destructive",
       });
     } finally {

--- a/apps/web/src/components/packaging/MarkCompleteModal.tsx
+++ b/apps/web/src/components/packaging/MarkCompleteModal.tsx
@@ -22,6 +22,7 @@ import { calculateAbv } from "lib";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { CheckCircle, Loader2, AlertTriangle, Minus, Tag, Flame, Beaker, Wine, Package, FileText, Sparkles, Calendar } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const markCompleteSchema = z.object({
   completedAt: z.string()
@@ -180,7 +181,7 @@ export function MarkCompleteModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to mark packaging run as complete",
+        description: humanizeMutationError(error) || "Failed to mark packaging run as complete",
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/MarkReadyModal.tsx
+++ b/apps/web/src/components/packaging/MarkReadyModal.tsx
@@ -18,6 +18,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { CheckCircle2, Loader2 } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const markReadySchema = z.object({
   readyAt: z.string().min(1, "Date is required"),
@@ -80,7 +81,7 @@ export function MarkReadyModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -101,7 +102,7 @@ export function MarkReadyModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/PasteurizeModal.tsx
+++ b/apps/web/src/components/packaging/PasteurizeModal.tsx
@@ -41,6 +41,7 @@ import {
   type CooldownMethod,
   type EnhancedPasteurizationResult,
 } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const pasteurizeSchema = z.object({
   pasteurizedAt: z.string(),
@@ -366,7 +367,7 @@ export function PasteurizeModal({
     onError: (error) => {
       toast({
         title: "Pasteurization Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/UpdatePricingModal.tsx
+++ b/apps/web/src/components/packaging/UpdatePricingModal.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { DollarSign, TrendingUp } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const updatePricingSchema = z.object({
   retailPrice: z
@@ -101,7 +102,7 @@ export function UpdatePricingModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/AddKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/AddKegModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Plus } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const addKegSchema = z.object({
   kegNumber: z.string().min(1, "Keg number is required"),
@@ -126,7 +127,7 @@ export function AddKegModal({ open, onClose, onSuccess }: AddKegModalProps) {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -146,7 +147,7 @@ export function AddKegModal({ open, onClose, onSuccess }: AddKegModalProps) {
     onError: (error) => {
       toast({
         title: "Bulk Create Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/BottleFromKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/BottleFromKegModal.tsx
@@ -27,6 +27,7 @@ import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Wine, AlertTriangle, CheckCircle, Loader2, Plus, X } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 // Form validation schema
 const packagingMaterialSchema = z.object({
@@ -287,7 +288,7 @@ export function BottleFromKegModal({
     onError: (error) => {
       toast({
         title: "Bottling Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/BulkDistributeKegsModal.tsx
+++ b/apps/web/src/components/packaging/kegs/BulkDistributeKegsModal.tsx
@@ -26,6 +26,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Send, Store, AlertTriangle, Beer } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const bulkDistributeSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
@@ -106,7 +107,7 @@ export function BulkDistributeKegsModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/BulkReturnKegsModal.tsx
+++ b/apps/web/src/components/packaging/kegs/BulkReturnKegsModal.tsx
@@ -20,6 +20,7 @@ import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { RotateCcw, AlertTriangle, Beer, MapPin, Calendar } from "lucide-react";
 import { formatDate } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const bulkReturnSchema = z.object({
   returnedAt: z.string().min(1, "Date is required"),
@@ -92,7 +93,7 @@ export function BulkReturnKegsModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/CleanKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/CleanKegModal.tsx
@@ -19,6 +19,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { CheckCircle } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const cleanKegSchema = z.object({
   cleanedAt: z.date(),
@@ -86,7 +87,7 @@ export function CleanKegModal({
     onError: (error) => {
       toast({
         title: "Cleaning Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/DistributeKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/DistributeKegModal.tsx
@@ -25,6 +25,7 @@ import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { Send, Store } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const distributeKegSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
@@ -82,7 +83,7 @@ export function DistributeKegModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/EditKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/EditKegModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { Edit, Loader2 } from "lucide-react";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const editKegSchema = z.object({
   kegNumber: z.string().min(1, "Keg number is required"),
@@ -130,7 +131,7 @@ export function EditKegModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -31,6 +31,7 @@ import { useDateFormat } from "@/hooks/useDateFormat";
 import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
 import { Card, CardContent } from "@/components/ui/card";
 import { PackageTypeSelector } from "../UnifiedPackagingModal";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const fillKegsSchema = z.object({
   filledAt: z.string().min(1, "Date/time is required"),
@@ -177,7 +178,7 @@ export function FillKegModal({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/KegsManagement.tsx
+++ b/apps/web/src/components/packaging/kegs/KegsManagement.tsx
@@ -57,6 +57,7 @@ import { CleanKegModal } from "./CleanKegModal";
 import { ReturnKegModal } from "./ReturnKegModal";
 import { BottleFromKegModal } from "./BottleFromKegModal";
 import { formatVolume, convertVolume, type VolumeUnit } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 type KegStatus =
   | "all"
@@ -221,7 +222,7 @@ export function KegsManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -238,7 +239,7 @@ export function KegsManagement() {
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/packaging/kegs/ReturnKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/ReturnKegModal.tsx
@@ -20,6 +20,7 @@ import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { RotateCcw, MapPin, Calendar, Loader2 } from "lucide-react";
 import { formatDate } from "@/utils/date-format";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const returnKegSchema = z.object({
   returnedAt: z.date(),
@@ -89,7 +90,7 @@ export function ReturnKegModal({
     onError: (error) => {
       toast({
         title: "Return Failed",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/components/reports/TTBPeriodFinalization.tsx
+++ b/apps/web/src/components/reports/TTBPeriodFinalization.tsx
@@ -43,6 +43,7 @@ import {
 import { trpc } from "@/utils/trpc";
 import { useToast } from "@/hooks/use-toast";
 import type { TTBForm512017Data } from "lib";
+import { humanizeMutationError } from "@/utils/mutation-errors";
 
 interface TTBPeriodFinalizationProps {
   periodType: "monthly" | "quarterly" | "annual";
@@ -102,7 +103,7 @@ export function TTBPeriodFinalization({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -130,7 +131,7 @@ export function TTBPeriodFinalization({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },
@@ -150,7 +151,7 @@ export function TTBPeriodFinalization({
     onError: (error) => {
       toast({
         title: "Error",
-        description: error.message,
+        description: humanizeMutationError(error),
         variant: "destructive",
       });
     },

--- a/apps/web/src/utils/mutation-errors.ts
+++ b/apps/web/src/utils/mutation-errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Turn a tRPC/React Query mutation error into a message a user can act on.
+ *
+ * Zod input-validation failures arrive as error.message set to a JSON array
+ * of issues (e.g. `[{"message":"Volume after filtering...","path":[...]}]`),
+ * which reads as a wall of JSON — or worse, gets dropped entirely by forms
+ * without an onError handler. This extracts the human-written issue messages.
+ */
+export function humanizeMutationError(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : String(error ?? "Unknown error");
+  try {
+    const issues = JSON.parse(message);
+    if (Array.isArray(issues)) {
+      const msgs = issues
+        .map((i) => (i && typeof i.message === "string" ? i.message : null))
+        .filter(Boolean);
+      if (msgs.length > 0) return msgs.join("\n");
+    }
+  } catch {
+    // not JSON — use as-is
+  }
+  return message;
+}


### PR DESCRIPTION
Owner requirement after the fine-filter silent failure: the system must always tell the user why an action can't proceed.

- New `humanizeMutationError()` util unwraps tRPC/zod issue-array messages into the human-written validation text.
- Query client gains a `MutationCache.onError` safety net: any mutation without its own error handler now toasts a readable "Action failed: <reason>" — nothing can fail silently again.
- Swept all 68 components that toasted raw `error.message` to run it through the humanizer, so zod validation failures read as sentences everywhere.

## Testing
- `pnpm --filter web run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)