### PR TITLE
Filter toast: state whether the batch moved tanks

### DIFF
--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -5599,7 +5599,7 @@ export const batchRouter = router({
           success: true,
           filterOperation: filterOperation[0],
           volumeLoss: volumeLossL,
-          message: `Batch filtered with ${input.filterType} filter${destinationVesselName ? ` into ${destinationVesselName}` : ""}. Loss: ${volumeLossL.toFixed(2)}L`,
+          message: `Batch filtered with ${input.filterType} filter — ${destinationVesselName ? `moved into ${destinationVesselName}` : "stayed in the current tank"}. Loss: ${volumeLossL.toFixed(2)}L`,
         };
       } catch (error) {
         if (error instanceof TRPCError) throw error;


### PR DESCRIPTION
Follow-up to the fine-filter investigation: the destination selection was lost between attempts (the modal resets on reopen, and the original failure was silent pre-#152), and the success toast didn't mention the batch had stayed in TANK-500-1. The message now always states "moved into <vessel>" or "stayed in the current tank" so a dropped destination is immediately visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)