### PR TITLE
Clean Tank: default date to 2 h after the tank was emptied

### DIFF
--- a/apps/web/src/components/cellar/CleanTankModal.tsx
+++ b/apps/web/src/components/cellar/CleanTankModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -47,7 +47,25 @@ export function CleanTankModal({
   vesselName,
 }: CleanTankModalProps) {
   const utils = trpc.useUtils();
-  const { formatDateTimeForInput, parseDateTimeFromInput } = useDateFormat();
+  const { formatDateTimeForInput, parseDateTimeFromInput, formatDateTime } = useDateFormat();
+
+  // Owner rule: a tank gets cleaned ~2 h after the event that emptied it.
+  // Seed the date from that event when it's in the past; fall back to now.
+  const { data: lastEmptied } = trpc.vessel.lastEmptiedAt.useQuery(
+    { vesselId },
+    { enabled: open },
+  );
+  const dateTouchedRef = useRef(false);
+  const seedCleanedAt = (lastEmptiedAt?: string | Date | null) => {
+    if (lastEmptiedAt) {
+      const d = new Date(lastEmptiedAt);
+      if (!Number.isNaN(d.getTime())) {
+        const seeded = new Date(d.getTime() + 2 * 60 * 60 * 1000);
+        if (seeded.getTime() < Date.now()) return seeded;
+      }
+    }
+    return new Date();
+  };
 
   const {
     register,
@@ -72,13 +90,24 @@ export function CleanTankModal({
   // Reset when modal opens
   useEffect(() => {
     if (open) {
+      dateTouchedRef.current = false;
       reset({
-        cleanedAt: new Date(),
+        cleanedAt: seedCleanedAt(lastEmptied?.lastEmptiedAt),
         notes: "",
       });
       setLaborAssignments([]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, reset]);
+
+  // The last-emptied query resolves after open — apply the seed once it
+  // arrives, unless the user already edited the date.
+  useEffect(() => {
+    if (open && !dateTouchedRef.current && lastEmptied?.lastEmptiedAt) {
+      setValue("cleanedAt", seedCleanedAt(lastEmptied.lastEmptiedAt));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, lastEmptied]);
 
   const cleanTankMutation = trpc.vessel.cleanTank.useMutation({
     onSuccess: (data) => {
@@ -132,11 +161,18 @@ export function CleanTankModal({
               value={cleanedAt ? formatDateTimeForInput(cleanedAt) : ''}
               onChange={(e) => {
                 if (e.target.value) {
+                  dateTouchedRef.current = true;
                   setValue("cleanedAt", parseDateTimeFromInput(e.target.value));
                 }
               }}
               className="w-full mt-1"
             />
+            {lastEmptied?.lastEmptiedAt && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Tank last emptied {formatDateTime(lastEmptied.lastEmptiedAt)} —
+                defaulted to 2 h after
+              </p>
+            )}
             {errors.cleanedAt && (
               <p className="text-sm text-red-600 mt-1">
                 {errors.cleanedAt.message}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -62,6 +62,8 @@ import {
   batchCompositions,
   batchMeasurements,
   batchTransfers,
+  bottleRuns,
+  kegFills,
   vessels,
   vesselCleaningOperations,
   baseFruitVarieties,
@@ -6311,6 +6313,56 @@ export const appRouter = router({
             message: "Failed to prep vessel for cleaning",
           });
         }
+      }),
+
+    // When this tank was last vacated — the latest transfer-out, bottle run,
+    // or keg fill from it. Anchors the cleaning form's default date (owner
+    // rule: cleans happen ~2 h after the event that emptied the tank).
+    lastEmptiedAt: createRbacProcedure("read", "vessel")
+      .input(z.object({ vesselId: z.string().uuid("Invalid vessel ID") }))
+      .query(async ({ input }) => {
+        // Naive timestamp columns come back as strings without a zone marker;
+        // pin them to UTC (they store UTC wall time) before comparing.
+        const toUtc = (v: Date | string | null): Date | null => {
+          if (!v) return null;
+          if (v instanceof Date) return v;
+          const d = new Date(
+            v.replace(" ", "T") + (/[Zz]|[+-]\d{2}/.test(v.slice(10)) ? "" : "Z"),
+          );
+          return Number.isNaN(d.getTime()) ? null : d;
+        };
+
+        const [xfer] = await db
+          .select({ at: sql<string | null>`MAX(${batchTransfers.transferredAt})` })
+          .from(batchTransfers)
+          .where(
+            and(
+              eq(batchTransfers.sourceVesselId, input.vesselId),
+              isNull(batchTransfers.deletedAt),
+            ),
+          );
+        const [bottle] = await db
+          .select({ at: sql<string | null>`MAX(${bottleRuns.packagedAt})` })
+          .from(bottleRuns)
+          .where(
+            and(
+              eq(bottleRuns.vesselId, input.vesselId),
+              isNull(bottleRuns.deletedAt),
+            ),
+          );
+        const [keg] = await db
+          .select({ at: sql<string | null>`MAX(${kegFills.filledAt})` })
+          .from(kegFills)
+          .where(
+            and(eq(kegFills.vesselId, input.vesselId), isNull(kegFills.deletedAt)),
+          );
+
+        const candidates = [toUtc(xfer?.at ?? null), toUtc(bottle?.at ?? null), toUtc(keg?.at ?? null)]
+          .filter((d): d is Date => d !== null);
+        const lastEmptiedAt = candidates.length
+          ? new Date(Math.max(...candidates.map((d) => d.getTime())))
+          : null;
+        return { lastEmptiedAt };
       }),
 
     // Clean tank - mark as available after cleaning and record cleaning details.


### PR DESCRIPTION
Owner request: when cleaning a yellow (needs-cleaning) tank, the date should default to 2 hours after the last event that emptied it — not to today.

- New `vessel.lastEmptiedAt` query: max of transfers out of the vessel, bottle runs, and keg fills from it (naive timestamps pinned to UTC).
- Clean Tank dialog seeds its date from that event + 2 h when that's in the past, falls back to now otherwise, and shows a hint ("Tank last emptied Jul 15, 2026, 12:00 PM — defaulted to 2 h after"). A user-edited date is never overridden by the late-arriving query.

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)