### PR TITLE
Fix lastEmptiedAt soft-delete columns

### DIFF
--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6347,14 +6347,18 @@ export const appRouter = router({
           .where(
             and(
               eq(bottleRuns.vesselId, input.vesselId),
-              isNull(bottleRuns.deletedAt),
+              isNull(bottleRuns.voidedAt),
             ),
           );
         const [keg] = await db
           .select({ at: sql<string | null>`MAX(${kegFills.filledAt})` })
           .from(kegFills)
           .where(
-            and(eq(kegFills.vesselId, input.vesselId), isNull(kegFills.deletedAt)),
+            and(
+              eq(kegFills.vesselId, input.vesselId),
+              isNull(kegFills.deletedAt),
+              isNull(kegFills.voidedAt),
+            ),
           );
 
         const candidates = [toUtc(xfer?.at ?? null), toUtc(bottle?.at ?? null), toUtc(keg?.at ?? null)]


### PR DESCRIPTION
Hotfix for #154, which merged with a masked typecheck failure: `bottle_runs` soft-deletes via `voidedAt` (no `deletedAt` column), and keg fills must exclude both `voidedAt` and `deletedAt`. Unblocks the Vercel build.

## Testing
- `pnpm typecheck` clean (api + web), exit codes verified with pipefail

🤖 Generated with [Claude Code](https://claude.com/claude-code)