### PR TITLE
Schedule anchors after labor time; filter destination visible at submit

### DIFF
--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -41,7 +41,7 @@ import {
   calculateCO2FromSugar,
   estimateResidualCO2,
 } from "lib";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const SUGAR_TYPE_LABELS: Record<string, string> = {
@@ -107,7 +107,7 @@ interface CarbonateModalProps {
   } | null;
   /** Receives the operation's start date so recipe callers can anchor the
    *  remaining schedule to the actual date. */
-  onSuccess?: (startedAt?: Date) => void;
+  onSuccess?: (startedAt?: Date, laborHours?: number) => void;
   /** Recipe-planned values to prefill (method uses recipe terms forced|natural). */
   prefillTargetCo2Volumes?: number;
   prefillMethod?: "forced" | "natural";
@@ -389,6 +389,7 @@ export function CarbonateModal({
           : startedAt
             ? parseDateTimeFromInput(startedAt)
             : undefined,
+        laborDurationHours(laborAssignments),
       );
       onOpenChange(false);
     },
@@ -415,6 +416,7 @@ export function CarbonateModal({
           : startedAt
             ? parseDateTimeFromInput(startedAt)
             : undefined,
+        laborDurationHours(laborAssignments),
       );
       onOpenChange(false);
     },

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -21,7 +21,7 @@ import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { LastActivityHint } from "@/components/ui/LastActivityHint";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, Package, AlertTriangle, Calculator } from "lucide-react";
 import { additiveRateGramsPerL } from "lib/src/units/conversions";
@@ -49,7 +49,7 @@ interface AddBatchAdditiveFormProps {
   batchId: string;
   /** Receives the recorded addedAt so recipe callers can anchor the schedule
    *  to the actual date (completeTask → recomputeSchedule). */
-  onSuccess: (addedAt?: Date) => void;
+  onSuccess: (addedAt?: Date, laborHours?: number) => void;
   onCancel: () => void;
   /** Recipe-planned values to prefill (e.g. Cascade Hops @ 1.5 g/L = 180 g). */
   prefillAdditiveType?: string | null;
@@ -460,7 +460,7 @@ export function AddBatchAdditiveForm({
       if (data.reclassifiedAsWine) {
         utils.batch.invalidate();
       }
-      onSuccess(parseDateTimeFromInput(addedDate));
+      onSuccess(parseDateTimeFromInput(addedDate), laborDurationHours(laborAssignments));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -22,14 +22,14 @@ import { toast } from "@/hooks/use-toast";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { LastActivityHint } from "@/components/ui/LastActivityHint";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import { Loader2, Info } from "lucide-react";
 import { useDateFormat } from "@/hooks/useDateFormat";
 
 interface AddBatchMeasurementFormProps {
   batchId: string;
   /** Receives the measurement date for schedule anchoring. */
-  onSuccess: (measuredAt?: Date) => void;
+  onSuccess: (measuredAt?: Date, laborHours?: number) => void;
   onCancel: () => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillMeasuredAt?: string | Date | null;
@@ -188,7 +188,7 @@ export function AddBatchMeasurementForm({
         title: "Success",
         description: "Measurement added successfully",
       });
-      onSuccess(parseDateTimeFromInput(measurementDateTime));
+      onSuccess(parseDateTimeFromInput(measurementDateTime), laborDurationHours(laborAssignments));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -32,7 +32,7 @@ import { VolumeInput, VolumeUnit } from "@/components/ui/volume-input";
 import { convertVolume } from "lib";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { humanizeMutationError } from "@/utils/mutation-errors";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 
 const filterSchema = z.object({
   filterType: z.enum(["coarse", "fine", "sterile"], {
@@ -58,7 +58,7 @@ interface FilterModalProps {
   /** Called after a filter operation succeeds (e.g. to complete a recipe
    *  task). Receives the operation's filteredAt so recipe callers can anchor
    *  the remaining schedule to the actual date. */
-  onSuccess?: (filteredAt?: Date) => void;
+  onSuccess?: (filteredAt?: Date, laborHours?: number) => void;
   /** Recipe-planned filter type to prefill. */
   prefillFilterType?: "coarse" | "fine" | "sterile";
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
@@ -192,7 +192,7 @@ export function FilterModal({
       utils.batch.list.invalidate();
       onClose();
       reset();
-      onSuccess?.(filteredAt);
+      onSuccess?.(filteredAt, laborDurationHours(laborAssignments));
     },
     onError: (error) => {
       toast({
@@ -204,7 +204,14 @@ export function FilterModal({
   });
 
   const onSubmit = (data: FilterForm) => {
-    console.log("Filter form submitted with data:", data);
+    // Diagnostic for the recurring lost-destination reports: log the exact
+    // non-form state that accompanies this submit.
+    console.log("Filter submit:", {
+      ...data,
+      destinationVesselId,
+      padsUsed,
+      laborCount: laborAssignments.length,
+    });
     if (data.volumeAfter > data.volumeBefore) {
       toast({
         title: "Invalid Volumes",
@@ -414,6 +421,22 @@ export function FilterModal({
                   <span className="font-medium">Calculated Loss:</span>
                   <span className={showLossWarning ? "text-orange-700 font-semibold" : "text-gray-700"}>
                     {calculatedLoss.toFixed(2)}L ({lossPercentage.toFixed(1)}%)
+                  </span>
+                </div>
+                {/* Destination stated at the point of no return — a dropped
+                    selection must be visible BEFORE submitting. */}
+                <div className="flex items-center justify-between mt-1">
+                  <span className="font-medium">Destination:</span>
+                  <span
+                    className={
+                      destinationVesselId === "same"
+                        ? "text-gray-700"
+                        : "text-blue-700 font-semibold"
+                    }
+                  >
+                    {destinationVesselId === "same"
+                      ? `Stays in ${vesselName}`
+                      : `Moves to ${destinationOptions.find((v: any) => v.id === destinationVesselId)?.name ?? "selected tank"}`}
                   </span>
                 </div>
                 {showLossWarning && (

--- a/apps/web/src/components/labor/WorkerLaborInput.tsx
+++ b/apps/web/src/components/labor/WorkerLaborInput.tsx
@@ -267,3 +267,17 @@ export function toApiLaborAssignments(
     hoursWorked: a.hoursWorked,
   }));
 }
+
+/**
+ * Wall-clock duration of the work session: the max hours across workers
+ * (workers are assumed to work in parallel). Used to anchor the recipe
+ * schedule — the next step starts after this task's work ended.
+ */
+export function laborDurationHours(
+  assignments: WorkerAssignment[]
+): number | undefined {
+  const hours = assignments
+    .filter((a) => a.workerId && a.hoursWorked > 0)
+    .map((a) => a.hoursWorked);
+  return hours.length ? Math.max(...hours) : undefined;
+}

--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -35,7 +35,7 @@ import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { Tag, AlertTriangle, Info, Loader2, ChevronsUpDown, Check, Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import { humanizeMutationError } from "@/utils/mutation-errors";
 
 const labelSchema = z.object({
@@ -59,7 +59,7 @@ interface LabelModalProps {
   unitsProduced: number;
   unitsLabeled?: number; // Current number of labeled units (for partial labeling)
   /** Receives labeledAt for schedule anchoring. */
-  onSuccess: (labeledAt?: Date) => void;
+  onSuccess: (labeledAt?: Date, laborHours?: number) => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillLabeledAt?: string | Date | null;
 }
@@ -251,7 +251,14 @@ export function LabelModal({
       utils.packaging.list.invalidate();
       utils.packaging.get.invalidate(bottleRunId);
       refetchPackagingItems();
-      onSuccess(labeledAt);
+      onSuccess(
+        labeledAt
+          ? typeof labeledAt === "string"
+            ? parseDateTimeFromInput(labeledAt)
+            : labeledAt
+          : undefined,
+        laborDurationHours(laborAssignments),
+      );
 
       // Close modal after successful labeling
       onClose();

--- a/apps/web/src/components/packaging/PasteurizeModal.tsx
+++ b/apps/web/src/components/packaging/PasteurizeModal.tsx
@@ -29,7 +29,7 @@ import { useDateFormat } from "@/hooks/useDateFormat";
 import { useBatchDateValidation } from "@/hooks/useBatchDateValidation";
 import { DateWarning } from "@/components/ui/DateWarning";
 import { Flame, Info, Loader2, Thermometer, Droplet, AlertTriangle, Snowflake, Wind, Waves } from "lucide-react";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import {
   calculatePU,
   calculateEnhancedPasteurization,
@@ -81,7 +81,7 @@ interface PasteurizeModalProps {
   batchId: string;
   unitsProduced: number;
   /** Receives pasteurizedAt for schedule anchoring. */
-  onSuccess: (pasteurizedAt?: Date) => void;
+  onSuccess: (pasteurizedAt?: Date, laborHours?: number) => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillPasteurizedAt?: string | Date | null;
 }
@@ -361,7 +361,7 @@ export function PasteurizeModal({
         description: `Successfully recorded pasteurization for ${bottleRunName} with ${totalPU.toFixed(1)} PU`,
       });
       utils.packaging.list.invalidate();
-      onSuccess(pasteurizedAt ? parseDateTimeFromInput(pasteurizedAt) : undefined);
+      onSuccess(pasteurizedAt ? parseDateTimeFromInput(pasteurizedAt) : undefined, laborDurationHours(laborAssignments));
       onClose();
     },
     onError: (error) => {

--- a/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
+++ b/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
@@ -21,7 +21,7 @@ interface UnifiedPackagingModalProps {
   initialType?: PackagingType;
   preBottling?: PreBottlingData;
   /** Receives the packaging date (packagedAt / filledAt) from the inner modal. */
-  onSuccess?: (packagedAt?: Date) => void;
+  onSuccess?: (packagedAt?: Date, laborHours?: number) => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillPackagedAt?: string | Date | null;
 }

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -30,7 +30,7 @@ import { useDateFormat } from "@/hooks/useDateFormat";
 import { Card } from "@/components/ui/card";
 import { PackageTypeSelector } from "./UnifiedPackagingModal";
 import { PreBottlingBanner, type PreBottlingData } from "./PreBottlingBanner";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 
 // Form validation schema
 const packagingMaterialSchema = z.object({
@@ -73,7 +73,7 @@ interface BottleModalProps {
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
   /** Called after a packaging run is created; receives packagedAt for schedule anchoring. */
-  onSuccess?: (packagedAt?: Date) => void;
+  onSuccess?: (packagedAt?: Date, laborHours?: number) => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillPackagedAt?: string | Date | null;
 }
@@ -442,7 +442,7 @@ export function BottleModal({
 
       console.log("Packaging run created:", result);
       onClose();
-      onSuccess?.(parseDateTimeFromInput(getValues("packagedAt")));
+      onSuccess?.(parseDateTimeFromInput(getValues("packagedAt")), laborDurationHours(laborAssignments));
     } catch (error) {
       console.error("Failed to create packaging run:", error);
 

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -28,7 +28,7 @@ import { PreBottlingBanner, type PreBottlingData } from "../PreBottlingBanner";
 import { trpc } from "@/utils/trpc";
 import { toast } from "@/hooks/use-toast";
 import { useDateFormat } from "@/hooks/useDateFormat";
-import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments } from "@/components/labor/WorkerLaborInput";
+import { WorkerLaborInput, type WorkerAssignment, toApiLaborAssignments, laborDurationHours } from "@/components/labor/WorkerLaborInput";
 import { Card, CardContent } from "@/components/ui/card";
 import { PackageTypeSelector } from "../UnifiedPackagingModal";
 import { humanizeMutationError } from "@/utils/mutation-errors";
@@ -55,7 +55,7 @@ interface FillKegModalProps {
   onTypeChange?: (type: "bottles" | "kegs") => void; // Callback when type changes
   preBottling?: PreBottlingData;
   /** Called after kegs are filled; receives filledAt for schedule anchoring. */
-  onSuccess?: (filledAt?: Date) => void;
+  onSuccess?: (filledAt?: Date, laborHours?: number) => void;
   /** Seed the date field (e.g. a recipe step's scheduled date when back-filling). */
   prefillFilledAt?: string | Date | null;
 }
@@ -173,7 +173,7 @@ export function FillKegModal({
       setSelectedKegIds([]);
       setKegVolumes({});
       onClose();
-      onSuccess?.(parseDateTimeFromInput(getValues("filledAt")));
+      onSuccess?.(parseDateTimeFromInput(getValues("filledAt")), laborDurationHours(laborAssignments));
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
+++ b/apps/web/src/components/recipes/BatchRecipeChecklist.tsx
@@ -661,11 +661,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 : "fine"
           }
           prefillFilteredAt={actionTask?.scheduledDate ?? null}
-          onSuccess={(actualAt?: Date) =>
+          onSuccess={(actualAt?: Date, laborHours?: number) =>
             actionTask &&
             complete.mutate({
               taskId: actionTask.id,
               ...(actualAt ? { completedAt: actualAt } : {}),
+              ...(laborHours ? { laborDurationHours: laborHours } : {}),
             })
           }
         />
@@ -699,11 +700,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
                 : undefined
           }
           prefillStartedAt={actionTask?.scheduledDate ?? null}
-          onSuccess={(actualAt?: Date) =>
+          onSuccess={(actualAt?: Date, laborHours?: number) =>
             actionTask &&
             complete.mutate({
               taskId: actionTask.id,
               ...(actualAt ? { completedAt: actualAt } : {}),
+              ...(laborHours ? { laborDurationHours: laborHours } : {}),
             })
           }
         />
@@ -716,11 +718,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           currentVolumeL={currentVolumeL}
           initialType={actionTask?.packagingPath === "keg" ? "kegs" : "bottles"}
           prefillPackagedAt={actionTask?.scheduledDate ?? null}
-          onSuccess={(actualAt?: Date) =>
+          onSuccess={(actualAt?: Date, laborHours?: number) =>
             actionTask &&
             complete.mutate({
               taskId: actionTask.id,
               ...(actualAt ? { completedAt: actualAt } : {}),
+              ...(laborHours ? { laborDurationHours: laborHours } : {}),
             })
           }
         />
@@ -738,11 +741,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           batchId={batchId}
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
           prefillPasteurizedAt={actionTask?.scheduledDate ?? null}
-          onSuccess={(actualAt?: Date) =>
+          onSuccess={(actualAt?: Date, laborHours?: number) =>
             actionTask &&
             complete.mutate({
               taskId: actionTask.id,
               ...(actualAt ? { completedAt: actualAt } : {}),
+              ...(laborHours ? { laborDurationHours: laborHours } : {}),
             })
           }
         />
@@ -754,11 +758,12 @@ export function BatchRecipeChecklist({ batchId }: { batchId: string }) {
           unitsProduced={Number(latestRun.unitsProduced ?? 0)}
           unitsLabeled={Number(latestRun.unitsLabeled ?? 0)}
           prefillLabeledAt={actionTask?.scheduledDate ?? null}
-          onSuccess={(actualAt?: Date) =>
+          onSuccess={(actualAt?: Date, laborHours?: number) =>
             actionTask &&
             complete.mutate({
               taskId: actionTask.id,
               ...(actualAt ? { completedAt: actualAt } : {}),
+              ...(laborHours ? { laborDurationHours: laborHours } : {}),
             })
           }
         />

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -221,10 +221,11 @@ export function StepDetailModal({
   // The real forms report the operation's actual date; passing it as
   // completedAt lets recomputeSchedule re-anchor the remaining steps to when
   // the work really happened.
-  const onRealSuccess = (actualAt?: Date) =>
+  const onRealSuccess = (actualAt?: Date, laborHours?: number) =>
     complete.mutate({
       taskId: task.id,
       ...(actualAt ? { completedAt: actualAt } : {}),
+      ...(laborHours ? { laborDurationHours: laborHours } : {}),
     });
 
   // Prefill the add-additive form from the recipe ingredient this step references.

--- a/packages/api/src/routers/recipeExecution.ts
+++ b/packages/api/src/routers/recipeExecution.ts
@@ -79,6 +79,11 @@ async function recomputeSchedule(tx: Tx, executionId: string) {
       packagingPath: t.packagingPath ?? "all",
       status: t.status,
       completedAt: t.completedAt,
+      laborHours: (() => {
+        const ad = t.actualData as Record<string, unknown> | null;
+        if (ad && typeof ad.laborHours === "number") return ad.laborHours;
+        return t.actualHours ? parseFloat(String(t.actualHours)) : null;
+      })(),
     })),
     startDateNoon(exec.startDate) ?? exec.startDate,
   );
@@ -529,6 +534,9 @@ export const recipeExecutionRouter = router({
         taskId: z.string().uuid(),
         completedAt: z.coerce.date().optional(),
         actualHours: z.number().nonnegative().nullish(),
+        /** Wall-clock duration of the work (max hours across parallel
+         *  workers) — anchors followers to the END of this task's work. */
+        laborDurationHours: z.number().nonnegative().nullish(),
         notes: z.string().nullish(),
         actualData: z.record(z.string(), z.unknown()).nullish(),
         laborAssignments: z
@@ -546,6 +554,13 @@ export const recipeExecutionRouter = router({
         const task = await loadTask(tx, input.taskId);
         const completedAt = input.completedAt ?? new Date();
         const laborSum = input.laborAssignments?.reduce((s, a) => s + a.hoursWorked, 0);
+        // Duration for schedule anchoring: explicit from real forms, else the
+        // longest single assignment (parallel workers), stored in actualData.
+        const laborDurationH =
+          input.laborDurationHours ??
+          (input.laborAssignments?.length
+            ? Math.max(...input.laborAssignments.map((a) => a.hoursWorked))
+            : null);
         await tx
           .update(batchStepTasks)
           .set({
@@ -558,7 +573,10 @@ export const recipeExecutionRouter = router({
                   ? laborSum.toString()
                   : task.actualHours,
             notes: input.notes ?? task.notes,
-            actualData: input.actualData ?? task.actualData,
+            actualData: {
+              ...((input.actualData ?? task.actualData ?? {}) as Record<string, unknown>),
+              ...(laborDurationH != null ? { laborHours: laborDurationH } : {}),
+            },
             updatedAt: new Date(),
           })
           .where(eq(batchStepTasks.id, task.id));

--- a/packages/lib/src/__tests__/recipes/schedule.test.ts
+++ b/packages/lib/src/__tests__/recipes/schedule.test.ts
@@ -120,6 +120,39 @@ describe("rescheduleWithActuals", () => {
     expect(iso(dates[2])).toBe("2026-06-01T00:00:00.000Z");
   });
 
+  it("anchors followers to the END of a done step's labor (completedAt + laborHours)", () => {
+    // Owner rule: work started at 12 pm took 1 h → an immediate next step
+    // lands at 1 pm; an N-day wait counts from 1 pm too.
+    const dates = rescheduleWithActuals(
+      [
+        {
+          triggerKind: "date_offset_from_start",
+          triggerData: { days: 0 },
+          packagingPath: "all",
+          status: "done",
+          completedAt: new Date("2026-06-01T19:00:00Z"), // noon PDT
+          laborHours: 1,
+        },
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "all" },
+        { triggerKind: "date_offset_from_previous", triggerData: { days: 2 }, packagingPath: "all" },
+      ],
+      START,
+    );
+    expect(iso(dates[1])).toBe("2026-06-01T20:00:00.000Z"); // 1 pm — right after the work
+    expect(iso(dates[2])).toBe("2026-06-03T20:00:00.000Z"); // 2 days after the work ended
+  });
+
+  it("ignores zero/absent laborHours (anchor stays at completedAt)", () => {
+    const dates = rescheduleWithActuals(
+      [
+        { ...STEPS[0], status: "done", completedAt: new Date("2026-06-01T00:00:00Z"), laborHours: 0 },
+        { triggerKind: "after_previous", triggerData: {}, packagingPath: "all" },
+      ],
+      START,
+    );
+    expect(iso(dates[1])).toBe("2026-06-01T00:00:00.000Z");
+  });
+
   it("keeps date_offset_from_start anchored to batch start, not actuals", () => {
     const dates = rescheduleWithActuals(
       [

--- a/packages/lib/src/recipes/schedule.ts
+++ b/packages/lib/src/recipes/schedule.ts
@@ -53,6 +53,14 @@ export interface RuntimeStep extends ScheduleStep {
   status?: string;
   /** Real completion time for a done step — anchors everything after it. */
   completedAt?: Date | null;
+  /**
+   * Hours of labor the done step took (max across parallel workers). The
+   * step's effective END time — completedAt + laborHours — is what anchors
+   * followers, so an immediate next step lands after the work finished
+   * (12 pm start + 1 h labor → next step 1 pm), and N-day waits count from
+   * the end of the work, not its start.
+   */
+  laborHours?: number | null;
 }
 
 /**
@@ -85,7 +93,9 @@ export function rescheduleWithActuals(
       const s = steps[i];
       let eff: Date | null;
       if (s.status === "done" && s.completedAt) {
-        eff = s.completedAt;
+        const laborH =
+          typeof s.laborHours === "number" && s.laborHours > 0 ? s.laborHours : 0;
+        eff = new Date(s.completedAt.getTime() + laborH * MS_PER_HOUR);
       } else if (s.status === "skipped") {
         eff = prev; // pass-through — a skipped step doesn't delay the rest
       } else {


### PR DESCRIPTION
Two owner requests:

1. **Follow-on steps start after the previous step's labor.** A done step's effective end is `completedAt + labor duration` (max hours across parallel workers — they work simultaneously). Immediate next steps prefill right after the work ended; N-day waits count from the end of the work. Wired through every activity form (filter, carbonate, bottle, keg fill, pasteurize, label, measurement, additive) and the generic step panel. Duration persists in the task's `actualData.laborHours`; older rows fall back to `actualHours`. 12 schedule unit tests pass, including two new cases.

2. **Filter destination stated before submit** (third lost-destination occurrence, batch 2026-057 repaired in data): the summary box now shows "Destination: Moves to X / Stays in Y" beside Calculated Loss, and the submit console log records destination/pads/labor state to catch the drop if it recurs.

## Testing
- `pnpm typecheck` clean (lib, api, web) — exit codes verified
- test-runner: 12/12 schedule tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)