### PR TITLE
Labor defaults: prepopulate worker and expected hours everywhere

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -102,6 +102,7 @@ import { useToast } from "@/hooks/use-toast";
 import { SquareIntegration } from "@/components/admin/SquareIntegration";
 import { WorkersManagement } from "@/components/admin/WorkersManagement";
 import { OverheadSettings } from "@/components/admin/OverheadSettings";
+import { LaborDefaultsSettings } from "@/components/admin/LaborDefaultsSettings";
 import { MeasurementSchedulesSettings } from "@/components/admin/MeasurementSchedulesSettings";
 import { AdditiveVolumeDefaultsSettings } from "@/components/admin/AdditiveVolumeDefaultsSettings";
 import { BarrelOriginTypesManagement } from "@/components/cellar/BarrelOriginTypesManagement";
@@ -1972,6 +1973,9 @@ function SystemSettings() {
 
       {/* Overhead Cost Allocation - IMPLEMENTED */}
       <OverheadSettings />
+
+      {/* Labor defaults — default worker + expected hours per activity */}
+      <LaborDefaultsSettings />
 
       {/* Measurement Schedules - Product-type-specific measurement schedules */}
       <MeasurementSchedulesSettings />

--- a/apps/web/src/components/admin/LaborDefaultsSettings.tsx
+++ b/apps/web/src/components/admin/LaborDefaultsSettings.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { trpc } from "@/utils/trpc";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+import { humanizeMutationError } from "@/utils/mutation-errors";
+import { Users } from "lucide-react";
+
+/** Display labels for the labor activity keys, in workflow order. */
+const ACTIVITY_LABELS: Array<{ key: string; label: string }> = [
+  { key: "press_run", label: "Press run" },
+  { key: "racking", label: "Racking / transfer" },
+  { key: "additive", label: "Additive addition" },
+  { key: "measurement", label: "Measurement" },
+  { key: "filtering", label: "Filtering" },
+  { key: "carbonation", label: "Carbonation" },
+  { key: "keg_fill", label: "Keg fill" },
+  { key: "bottle_run", label: "Bottle run" },
+  { key: "pasteurization", label: "Pasteurization" },
+  { key: "labeling", label: "Labeling" },
+  { key: "cleaning", label: "Tank cleaning" },
+  { key: "recipe_step", label: "Generic recipe step" },
+  { key: "destruction", label: "Batch destruction" },
+];
+
+/**
+ * Admin → Labor Defaults: the worker and expected hours every activity's
+ * labor section prepopulates with.
+ */
+export function LaborDefaultsSettings() {
+  const utils = trpc.useUtils();
+  const { data: defaults, isLoading } = trpc.settings.getLaborDefaults.useQuery();
+  const { data: workersData } = trpc.workers.list.useQuery();
+  const workers = workersData?.workers ?? [];
+
+  const [defaultWorkerId, setDefaultWorkerId] = useState<string>("");
+  const [hours, setHours] = useState<Record<string, string>>({});
+  const [dirty, setDirty] = useState(false);
+
+  // Load current values once fetched (don't clobber unsaved edits).
+  useEffect(() => {
+    if (!defaults || dirty) return;
+    setDefaultWorkerId(defaults.defaultWorkerId ?? "");
+    setHours(
+      Object.fromEntries(
+        ACTIVITY_LABELS.map(({ key }) => [
+          key,
+          String(defaults.hoursByActivity?.[key] ?? ""),
+        ]),
+      ),
+    );
+  }, [defaults, dirty]);
+
+  const update = trpc.settings.updateLaborDefaults.useMutation({
+    onSuccess: () => {
+      toast({ title: "Labor defaults saved" });
+      setDirty(false);
+      utils.settings.getLaborDefaults.invalidate();
+    },
+    onError: (error) => {
+      toast({
+        title: "Save failed",
+        description: humanizeMutationError(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSave = () => {
+    const hoursByActivity: Record<string, number> = {};
+    for (const { key, label } of ACTIVITY_LABELS) {
+      const v = parseFloat(hours[key] ?? "");
+      if (Number.isNaN(v) || v < 0) {
+        toast({
+          title: "Invalid hours",
+          description: `"${label}" needs a valid non-negative number.`,
+          variant: "destructive",
+        });
+        return;
+      }
+      hoursByActivity[key] = v;
+    }
+    update.mutate({
+      defaultWorkerId: defaultWorkerId || null,
+      hoursByActivity,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          Labor Defaults
+        </CardTitle>
+        <CardDescription>
+          Every activity&apos;s labor section prepopulates with this worker and
+          the activity&apos;s expected hours — adjustable per entry.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="max-w-sm">
+          <Label>Default worker</Label>
+          <Select
+            value={defaultWorkerId}
+            onValueChange={(v) => {
+              setDefaultWorkerId(v);
+              setDirty(true);
+            }}
+          >
+            <SelectTrigger className="mt-1">
+              <SelectValue placeholder={isLoading ? "Loading…" : "Select worker…"} />
+            </SelectTrigger>
+            <SelectContent>
+              {workers.map((w) => (
+                <SelectItem key={w.id} value={w.id}>
+                  {w.name} (${parseFloat(w.hourlyRate ?? "20").toFixed(2)}/hr)
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label>Expected hours per activity</Label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2 mt-2">
+            {ACTIVITY_LABELS.map(({ key, label }) => (
+              <div key={key} className="flex items-center justify-between gap-2">
+                <span className="text-sm">{label}</span>
+                <Input
+                  type="number"
+                  step="any"
+                  min="0"
+                  className="w-24 h-8 text-right"
+                  value={hours[key] ?? ""}
+                  onChange={(e) => {
+                    setHours((prev) => ({ ...prev, [key]: e.target.value }));
+                    setDirty(true);
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <Button onClick={onSave} disabled={update.isPending || !dirty}>
+            {update.isPending ? "Saving…" : "Save defaults"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/batch/CarbonateModal.tsx
+++ b/apps/web/src/components/batch/CarbonateModal.tsx
@@ -1067,6 +1067,7 @@ export function CarbonateModal({
 
           {/* Labor Tracking */}
           <WorkerLaborInput
+              activityType="carbonation"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this carbonation operation"

--- a/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchAdditiveForm.tsx
@@ -1098,6 +1098,7 @@ export function AddBatchAdditiveForm({
       </div>
 
       <WorkerLaborInput
+              activityType="additive"
         value={laborAssignments}
         onChange={setLaborAssignments}
         activityLabel="this addition"

--- a/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
+++ b/apps/web/src/components/cellar/AddBatchMeasurementForm.tsx
@@ -612,6 +612,7 @@ export function AddBatchMeasurementForm({
       )}
 
       <WorkerLaborInput
+              activityType="measurement"
         value={laborAssignments}
         onChange={setLaborAssignments}
         activityLabel="this measurement"

--- a/apps/web/src/components/cellar/CleanTankModal.tsx
+++ b/apps/web/src/components/cellar/CleanTankModal.tsx
@@ -202,6 +202,7 @@ export function CleanTankModal({
 
           {/* Labor tracking — mirrors other activities (bottle runs, racking, etc.). */}
           <WorkerLaborInput
+              activityType="cleaning"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this cleaning"

--- a/apps/web/src/components/cellar/DestroyBatchModal.tsx
+++ b/apps/web/src/components/cellar/DestroyBatchModal.tsx
@@ -251,6 +251,7 @@ export function DestroyBatchModal({
           </div>
 
           <WorkerLaborInput
+              activityType="destruction"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this destruction"

--- a/apps/web/src/components/cellar/FilterModal.tsx
+++ b/apps/web/src/components/cellar/FilterModal.tsx
@@ -393,6 +393,7 @@ export function FilterModal({
           </div>
 
           <WorkerLaborInput
+              activityType="filtering"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this filtering operation"

--- a/apps/web/src/components/cellar/RackingModal.tsx
+++ b/apps/web/src/components/cellar/RackingModal.tsx
@@ -457,6 +457,7 @@ export function RackingModal({
 
           {/* Labor Tracking */}
           <WorkerLaborInput
+              activityType="racking"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this racking operation"

--- a/apps/web/src/components/cellar/TankTransferForm.tsx
+++ b/apps/web/src/components/cellar/TankTransferForm.tsx
@@ -580,6 +580,7 @@ export function TankTransferForm({
 
       {/* Labor Tracking */}
       <WorkerLaborInput
+              activityType="racking"
         value={laborAssignments}
         onChange={setLaborAssignments}
         activityLabel="this transfer"

--- a/apps/web/src/components/labor/WorkerLaborInput.tsx
+++ b/apps/web/src/components/labor/WorkerLaborInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -28,6 +28,13 @@ interface WorkerLaborInputProps {
   value: WorkerAssignment[];
   onChange: (assignments: WorkerAssignment[]) => void;
   activityLabel?: string;
+  /**
+   * Activity key from the labor-defaults settings (e.g. "filtering",
+   * "additive"). When set, an empty labor list seeds itself with the default
+   * worker at that activity's expected hours — the user just confirms or
+   * adjusts. Removing the seeded row keeps it removed.
+   */
+  activityType?: string;
   className?: string;
   disabled?: boolean;
 }
@@ -36,6 +43,7 @@ export function WorkerLaborInput({
   value,
   onChange,
   activityLabel = "this activity",
+  activityType,
   className,
   disabled = false,
 }: WorkerLaborInputProps) {
@@ -44,6 +52,34 @@ export function WorkerLaborInput({
 
   const { data: workersData, isLoading } = trpc.workers.list.useQuery();
   const workers = workersData?.workers || [];
+
+  const { data: laborDefaults } = trpc.settings.getLaborDefaults.useQuery(undefined, {
+    enabled: !!activityType,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Seed the default worker + expected hours whenever the list is empty —
+  // unless the user deliberately cleared it this session.
+  const userClearedRef = useRef(false);
+  useEffect(() => {
+    if (!activityType || disabled || userClearedRef.current) return;
+    if (value.length > 0) return;
+    if (!laborDefaults?.defaultWorkerId || workers.length === 0) return;
+    const worker = workers.find((w) => w.id === laborDefaults.defaultWorkerId);
+    const hours = laborDefaults.hoursByActivity?.[activityType];
+    if (!worker || !hours || hours <= 0) return;
+    const hourlyRate = parseFloat(worker.hourlyRate ?? "20.00");
+    onChange([
+      {
+        workerId: worker.id,
+        workerName: worker.name,
+        hoursWorked: hours,
+        hourlyRate,
+        laborCost: hours * hourlyRate,
+      },
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activityType, disabled, value.length, laborDefaults, workers.length]);
 
   // Filter out workers that are already assigned
   const availableWorkers = workers.filter(
@@ -74,6 +110,7 @@ export function WorkerLaborInput({
   };
 
   const handleRemoveWorker = (workerId: string) => {
+    userClearedRef.current = true; // don't re-seed a deliberately cleared list
     onChange(value.filter((v) => v.workerId !== workerId));
   };
 

--- a/apps/web/src/components/packaging/LabelModal.tsx
+++ b/apps/web/src/components/packaging/LabelModal.tsx
@@ -549,6 +549,7 @@ export function LabelModal({
 
           {/* Labor Tracking */}
           <WorkerLaborInput
+              activityType="labeling"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this labeling"

--- a/apps/web/src/components/packaging/PasteurizeModal.tsx
+++ b/apps/web/src/components/packaging/PasteurizeModal.tsx
@@ -868,6 +868,7 @@ export function PasteurizeModal({
 
             {/* Labor Tracking */}
             <WorkerLaborInput
+              activityType="pasteurization"
               value={laborAssignments}
               onChange={setLaborAssignments}
               activityLabel="this pasteurization"

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -1019,6 +1019,7 @@ export function BottleModal({
 
           {/* 8. Labor Tracking (optional) */}
           <WorkerLaborInput
+              activityType="bottle_run"
             value={laborAssignments}
             onChange={setLaborAssignments}
             activityLabel="this packaging run"

--- a/apps/web/src/components/packaging/kegs/FillKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/FillKegModal.tsx
@@ -454,6 +454,7 @@ export function FillKegModal({
             </div>
 
             <WorkerLaborInput
+              activityType="keg_fill"
               value={laborAssignments}
               onChange={setLaborAssignments}
               activityLabel="this keg fill"

--- a/apps/web/src/components/pressing/press-run-completion-form.tsx
+++ b/apps/web/src/components/pressing/press-run-completion-form.tsx
@@ -859,6 +859,7 @@ export function PressRunCompletionForm({
             </CardHeader>
             <CardContent>
               <WorkerLaborInput
+              activityType="press_run"
                 value={laborAssignments}
                 onChange={setLaborAssignments}
                 activityLabel="this press run"

--- a/apps/web/src/components/recipes/StepDetailModal.tsx
+++ b/apps/web/src/components/recipes/StepDetailModal.tsx
@@ -451,6 +451,7 @@ export function StepDetailModal({
             {/* Labor tracking — same component as the cellar forms */}
             {!isDone && task.kind !== "transfer" && (
               <WorkerLaborInput
+                activityType={task.kind === "rack" ? "racking" : "recipe_step"}
                 value={laborAssignments}
                 onChange={setLaborAssignments}
                 activityLabel="this step"

--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -5428,7 +5428,8 @@ export const batchRouter = router({
         if (batch.vesselId !== input.vesselId) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Batch is not in the specified vessel",
+            message:
+              "This page's data is out of date — the batch has moved to a different tank. Refresh the page and try again.",
           });
         }
 

--- a/packages/api/src/routers/settings.ts
+++ b/packages/api/src/routers/settings.ts
@@ -3,6 +3,7 @@ import { router, protectedProcedure, adminProcedure } from "../trpc";
 import {
   db,
   systemSettings,
+  workers,
   organizations,
   organizationSettings,
   bottleRuns,
@@ -11,6 +12,28 @@ import {
 } from "db";
 import { eq, and, gte, lt, sql, asc, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
+
+/**
+ * Baseline expected hours per activity — owner-approved 2026-08-11 from
+ * recorded labor history (median-based, with owner overrides for racking,
+ * cleaning, and carbonation). Stored overrides in system_settings
+ * ("labor_defaults") take precedence.
+ */
+export const LABOR_DEFAULT_HOURS: Record<string, number> = {
+  press_run: 2.5,
+  bottle_run: 2,
+  pasteurization: 1.5,
+  labeling: 1,
+  keg_fill: 1,
+  filtering: 1,
+  carbonation: 0.5,
+  additive: 0.5,
+  racking: 0.5,
+  cleaning: 0.5,
+  measurement: 0.25,
+  recipe_step: 0.25,
+  destruction: 0.25,
+};
 
 /**
  * Settings Router
@@ -41,6 +64,78 @@ export const settingsRouter = router({
       return "America/Los_Angeles";
     }
   }),
+
+  /**
+   * Labor defaults: the worker and expected hours each activity's labor
+   * section prepopulates with. Values approved by the owner 2026-08-11 from
+   * recorded min/max/median history; editable in Admin → Labor Defaults.
+   */
+  getLaborDefaults: protectedProcedure.query(async () => {
+    let stored: { defaultWorkerId?: string | null; hoursByActivity?: Record<string, number> } = {};
+    try {
+      const setting = await db
+        .select()
+        .from(systemSettings)
+        .where(eq(systemSettings.key, "labor_defaults"))
+        .limit(1);
+      if (setting[0]?.value && typeof setting[0].value === "object") {
+        stored = setting[0].value as typeof stored;
+      }
+    } catch (error) {
+      console.error("Error fetching labor defaults:", error);
+    }
+
+    // Default worker: stored choice, else the first active worker named
+    // Scott (the owner's standing default), else none.
+    let defaultWorkerId = stored.defaultWorkerId ?? null;
+    if (!defaultWorkerId) {
+      try {
+        const [scott] = await db
+          .select({ id: workers.id })
+          .from(workers)
+          .where(and(eq(workers.isActive, true), sql`${workers.name} ILIKE '%scott%'`))
+          .limit(1);
+        defaultWorkerId = scott?.id ?? null;
+      } catch {
+        defaultWorkerId = null;
+      }
+    }
+
+    return {
+      defaultWorkerId,
+      hoursByActivity: {
+        ...LABOR_DEFAULT_HOURS,
+        ...(stored.hoursByActivity ?? {}),
+      },
+    };
+  }),
+
+  updateLaborDefaults: adminProcedure
+    .input(
+      z.object({
+        defaultWorkerId: z.string().uuid().nullable(),
+        hoursByActivity: z.record(z.string(), z.number().nonnegative()),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await db
+        .insert(systemSettings)
+        .values({
+          key: "labor_defaults",
+          value: input as any,
+          updatedAt: new Date(),
+          updatedBy: ctx.session.user.id,
+        })
+        .onConflictDoUpdate({
+          target: systemSettings.key,
+          set: {
+            value: input as any,
+            updatedAt: new Date(),
+            updatedBy: ctx.session.user.id,
+          },
+        });
+      return { success: true, message: "Labor defaults updated" };
+    }),
 
   /**
    * Update timezone setting


### PR DESCRIPTION
Owner request: prepopulate the laborer (Scott Wierzbanowski) and expected labor time on every activity, both changeable per entry, with the defaults user-selectable in a setup section.

- New settings pair `getLaborDefaults`/`updateLaborDefaults` stores `{ defaultWorkerId, hoursByActivity }` in `system_settings`; when no worker is stored it resolves the active worker named Scott.
- The shared `WorkerLaborInput` gains `activityType`; an empty labor list auto-seeds with the default worker at that activity's hours. Removing the seeded row keeps it removed for that session. All 14 forms wired (press run, racking/transfer, additive, measurement, filter, carbonate, keg fill, bottle, pasteurize, label, clean tank, destroy, generic recipe step).
- Admin page gains a **Labor Defaults** card (worker picker + hours grid) seeded with the owner-approved values: press 2.5 / bottle 2 / pasteurize 1.5 / label, keg fill, filter 1 / carbonate, additive, rack, clean 0.5 / measurement, generic step, destruction 0.25.
- Bonus: the filter mutation's stale-tab rejection now reads "This page's data is out of date — the batch has moved to a different tank. Refresh the page and try again."

## Testing
- `pnpm typecheck` clean (api + web), exit codes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)