### PR TITLE
Vessel map: show the event that necessitated cleaning

### DIFF
--- a/apps/web/src/components/cellar/VesselMap.tsx
+++ b/apps/web/src/components/cellar/VesselMap.tsx
@@ -1178,18 +1178,34 @@ const updateBatchStatusMutation = trpc.batch.update.useMutation({
                         })()}
                       </div>
                     ) : (
-                      <p className="text-xs text-gray-400 italic">
+                      <p
+                        className={
+                          vessel.status === "cleaning"
+                            ? "text-xs text-amber-600 italic"
+                            : "text-xs text-gray-400 italic"
+                        }
+                      >
                         {(() => {
                           const lastActivity = (liquidMapVessel as any)?.lastActivity;
+                          const needsCleaning = vessel.status === "cleaning";
                           if (lastActivity) {
                             const activityDate = formatDate(lastActivity.date);
-                            if (lastActivity.type === "cleaned") {
-                              return `Cleaned ${activityDate}`;
-                            } else if (lastActivity.type === "transferred") {
-                              return `Batch transferred ${activityDate}`;
+                            const eventText =
+                              lastActivity.type === "cleaned"
+                                ? `Cleaned ${activityDate}`
+                                : lastActivity.type === "emptied"
+                                  ? `Emptied ${activityDate}`
+                                  : `Batch transferred ${activityDate}`;
+                            // A needs-cleaning tank leads with the event that
+                            // necessitated the clean, never a stale cleaning.
+                            if (needsCleaning) {
+                              return lastActivity.type === "cleaned"
+                                ? `Needs cleaning (last cleaned ${activityDate})`
+                                : `${eventText} — needs cleaning`;
                             }
+                            return eventText;
                           }
-                          return "No active batch";
+                          return needsCleaning ? "Needs cleaning" : "No active batch";
                         })()}
                       </p>
                     )}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -3449,6 +3449,38 @@ export const appRouter = router({
             )
             .orderBy(desc(batchRackingOperations.rackedAt));
 
+          // Packaging (bottle runs / keg fills) also empties a vessel — the
+          // owner expects the placard to show the event that necessitated
+          // cleaning, not a stale earlier cleaning.
+          const lastBottleRunsOut = await db
+            .select({
+              vesselId: bottleRuns.vesselId,
+              packagedAt: bottleRuns.packagedAt,
+            })
+            .from(bottleRuns)
+            .where(
+              and(
+                inArray(bottleRuns.vesselId, vesselIdsWithoutBatches),
+                isNull(bottleRuns.voidedAt),
+              ),
+            )
+            .orderBy(desc(bottleRuns.packagedAt));
+
+          const lastKegFillsOut = await db
+            .select({
+              vesselId: kegFills.vesselId,
+              filledAt: kegFills.filledAt,
+            })
+            .from(kegFills)
+            .where(
+              and(
+                inArray(kegFills.vesselId, vesselIdsWithoutBatches),
+                isNull(kegFills.voidedAt),
+                isNull(kegFills.deletedAt),
+              ),
+            )
+            .orderBy(desc(kegFills.filledAt));
+
           // Build map with most recent activity per vessel
           for (const cleaning of lastCleanings) {
             if (!lastActivityMap.has(cleaning.vesselId)) {
@@ -3476,6 +3508,28 @@ export const appRouter = router({
               lastActivityMap.set(racking.vesselId, {
                 type: "transferred",
                 date: racking.rackedAt,
+              });
+            }
+          }
+
+          // Packaging out of the vessel → "emptied"
+          for (const run of lastBottleRunsOut) {
+            if (!run.vesselId) continue;
+            const existing = lastActivityMap.get(run.vesselId);
+            if (!existing || run.packagedAt > existing.date) {
+              lastActivityMap.set(run.vesselId, {
+                type: "emptied",
+                date: run.packagedAt,
+              });
+            }
+          }
+          for (const fill of lastKegFillsOut) {
+            if (!fill.vesselId) continue;
+            const existing = lastActivityMap.get(fill.vesselId);
+            if (!existing || fill.filledAt > existing.date) {
+              lastActivityMap.set(fill.vesselId, {
+                type: "emptied",
+                date: fill.filledAt,
               });
             }
           }


### PR DESCRIPTION
Owner report: TANK-500-1/2 sit in the cleaning queue but their placards read "Cleaned 07/17" / "Cleaned 07/07" — stale prior cleanings, because bottle runs and keg fills were never considered vessel-emptying events.

- liquidMap's last-activity now includes bottle runs and keg fills out of the vessel as type "emptied".
- Needs-cleaning tanks render amber and lead with the vacating event: "Emptied 07/20/2026 — needs cleaning" (or "Needs cleaning (last cleaned …)" when no later event exists).

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)