### PR TITLE
Packaging modal opens on the step's type

### DIFF
--- a/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
+++ b/apps/web/src/components/packaging/UnifiedPackagingModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { BottleModal } from "./bottle-modal";
@@ -45,6 +45,13 @@ export function UnifiedPackagingModal({
   prefillPackagedAt,
 }: UnifiedPackagingModalProps) {
   const [packagingType, setPackagingType] = useState<PackagingType>(initialType);
+
+  // The modal stays mounted across opens — useState freezes the first
+  // initialType forever. Re-sync on every open so a keg step opens on Kegs
+  // and a bottle step opens on Bottles.
+  useEffect(() => {
+    if (open) setPackagingType(initialType);
+  }, [open, initialType]);
 
   // Reset packaging type when modal closes
   const handleClose = () => {

--- a/apps/web/src/components/packaging/bottle-modal.tsx
+++ b/apps/web/src/components/packaging/bottle-modal.tsx
@@ -701,7 +701,7 @@ export function BottleModal({
                   </p>
                 )}
                 {/* Auto-calculated units display */}
-                {unitsProduced !== undefined && !isNaN(unitsProduced) && packageSizeMl && (
+                {Number.isFinite(unitsProduced) && Number.isFinite(packageSizeMl) && (
                   <p className="text-xs text-green-600 mt-1">
                     = {unitsProduced} units ({packageSizeMl}ml each)
                   </p>


### PR DESCRIPTION
Owner on the "Package Cider in Kegs" step got the Bottles/Cans view: the modal froze `initialType` in useState at first mount (no step selected yet → "bottles") and never updated. It now re-syncs to the launching step's packaging path on every open — keg steps open Kegs, bottle steps open Bottles. Plus a NaN-guard on the auto-calculated units line.

## Testing
- `pnpm --filter web run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)