### PR TITLE
Pasteurization losses reduce the sellable bottle count

### DIFF
--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -2149,6 +2149,13 @@ export const packagingRouter = router({
               pasteurizationUnits: input.pasteurizationUnits.toString(),
               pasteurizedAt: pasteurizedAt,
               pasteurizationLoss: input.bottlesLost || null,
+              // Bottles lost in the bath are gone — reduce the sellable
+              // count so labeling/inventory work from what actually survived.
+              ...(input.bottlesLost
+                ? {
+                    unitsProduced: sql`GREATEST(${bottleRuns.unitsProduced} - ${input.bottlesLost}, 0)`,
+                  }
+                : {}),
               productionNotes: input.notes
                 ? `${input.notes}\n\nPasteurized at ${pasteurizedAt.toISOString()} (${input.temperatureCelsius}°C for ${input.timeMinutes} min, ${input.pasteurizationUnits} PU)${lossNote}`
                 : `Pasteurized at ${pasteurizedAt.toISOString()} (${input.temperatureCelsius}°C for ${input.timeMinutes} min, ${input.pasteurizationUnits} PU)${lossNote}`,


### PR DESCRIPTION
Owner pasteurized 210 bottles, recorded 4 lost, and the labeling step still offered 210 — `pasteurization_loss` was stored but never subtracted from `units_produced`, which everything downstream (labeling, auto-ready threshold, inventory) reads.

- The pasteurize mutation now decrements `units_produced` by the recorded loss (GREATEST(…, 0)).
- Audited all past runs: three had losses (Duskrun −4, Sundrift −4, Ruby Red −2) — counts corrected in data, including refunding Ruby Red's 2 over-counted labels.

## Testing
- `pnpm --filter api run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)