### PR TITLE
Filter-move flags the vacated tank for cleaning

### DIFF
--- a/packages/api/src/routers/batch.ts
+++ b/packages/api/src/routers/batch.ts
@@ -5578,6 +5578,13 @@ export const batchRouter = router({
             createdAt: new Date(),
             updatedAt: new Date(),
           });
+
+          // The source tank was just vacated — flag it for cleaning, same as
+          // packaging does when it empties a vessel.
+          await db
+            .update(vessels)
+            .set({ status: "cleaning", updatedAt: new Date() })
+            .where(eq(vessels.id, input.vesselId));
         }
 
         // Write filter loss ledger entry


### PR DESCRIPTION
Owner filtered TANK-500-1 → 500-2 → brite on the new Sundrift batch (destinations now recording correctly post-#160) but neither vacated tank entered the cleaning queue — the filter-move path never set the source vessel's status, unlike packaging. It now flags the source as cleaning as part of the move. Both tanks corrected in data for 2026-059.

## Testing
- `pnpm --filter api run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)