### PR TITLE
Unify the four distribution dialogs

### DIFF
--- a/apps/web/src/components/packaging/DistributeBottlesModal.tsx
+++ b/apps/web/src/components/packaging/DistributeBottlesModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -31,6 +32,8 @@ const distributeBottlesSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
   distributionLocation: z.string().min(1, "Location is required"),
   salesChannelId: z.string().uuid().optional(),
+  pricePerUnit: z.number().nonnegative().optional().or(z.nan().transform(() => undefined)),
+  notes: z.string().optional(),
 });
 
 type DistributeBottlesForm = z.infer<typeof distributeBottlesSchema>;
@@ -111,6 +114,8 @@ export function DistributeBottlesModal({
       distributedAt,
       distributionLocation: data.distributionLocation,
       salesChannelId: data.salesChannelId,
+      ...(data.pricePerUnit != null && !Number.isNaN(data.pricePerUnit) ? { pricePerUnit: data.pricePerUnit } : {}),
+      ...(data.notes ? { notes: data.notes } : {}),
     });
   };
 
@@ -192,6 +197,34 @@ export function DistributeBottlesModal({
               For TTB reporting and sales analytics
             </p>
           </div>
+          {/* Price (optional) */}
+          <div>
+            <Label htmlFor="pricePerUnit">Price per bottle ($) <span className="text-muted-foreground text-xs">(optional)</span></Label>
+            <Input
+              id="pricePerUnit"
+              type="number"
+              step="any"
+              min="0"
+              placeholder="0.00"
+              {...register("pricePerUnit", { valueAsNumber: true })}
+              className="mt-1"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Leave blank when this isn't a sale (taproom, samples, festival)
+            </p>
+          </div>
+
+          {/* Notes (optional) */}
+          <div>
+            <Label htmlFor="notes">Notes <span className="text-muted-foreground text-xs">(optional)</span></Label>
+            <Textarea
+              id="notes"
+              placeholder="Anything worth remembering about this distribution..."
+              {...register("notes")}
+              className="mt-1"
+            />
+          </div>
+
 
           {/* Info about distribution */}
           <div className="text-sm text-muted-foreground bg-green-50 border border-green-100 rounded-lg p-3">

--- a/apps/web/src/components/packaging/DistributeInventoryModal.tsx
+++ b/apps/web/src/components/packaging/DistributeInventoryModal.tsx
@@ -33,7 +33,7 @@ const distributeInventorySchema = z.object({
   salesChannelId: z.string().uuid().optional(),
   distributorName: z.string().optional(),
   quantityDistributed: z.number().int().positive("Quantity must be positive"),
-  pricePerUnit: z.number().positive("Price must be positive"),
+  pricePerUnit: z.number().nonnegative().optional().or(z.nan().transform(() => undefined)),
   distributionDate: z.string().min(1, "Date is required"),
   notes: z.string().optional(),
 });
@@ -135,7 +135,9 @@ export function DistributeInventoryModal({
       salesChannelId: data.salesChannelId,
       distributorName: isWholesaleChannel ? data.distributorName : undefined,
       quantityDistributed: data.quantityDistributed,
-      pricePerUnit: data.pricePerUnit,
+      ...(data.pricePerUnit != null && !Number.isNaN(data.pricePerUnit)
+        ? { pricePerUnit: data.pricePerUnit }
+        : {}),
       distributionDate: distributionDate.toISOString(),
       notes: data.notes,
     });
@@ -287,7 +289,7 @@ export function DistributeInventoryModal({
             {/* Price per Unit */}
             <div>
               <Label htmlFor="pricePerUnit">
-                Price per Unit <span className="text-red-500">*</span>
+                Price per Unit <span className="text-muted-foreground text-xs">(optional)</span>
               </Label>
               <div className="relative mt-1">
                 <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />

--- a/apps/web/src/components/packaging/kegs/BulkDistributeKegsModal.tsx
+++ b/apps/web/src/components/packaging/kegs/BulkDistributeKegsModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -32,6 +33,8 @@ const bulkDistributeSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
   distributionLocation: z.string().min(1, "Location is required"),
   salesChannelId: z.string().uuid().optional(),
+  pricePerKeg: z.number().nonnegative().optional().or(z.nan().transform(() => undefined)),
+  notes: z.string().optional(),
 });
 
 type BulkDistributeForm = z.infer<typeof bulkDistributeSchema>;
@@ -120,6 +123,8 @@ export function BulkDistributeKegsModal({
       distributedAt,
       distributionLocation: data.distributionLocation,
       salesChannelId: data.salesChannelId,
+      ...(data.pricePerKeg != null && !Number.isNaN(data.pricePerKeg) ? { pricePerKeg: data.pricePerKeg } : {}),
+      ...(data.notes ? { notes: data.notes } : {}),
     });
   };
 
@@ -260,6 +265,34 @@ export function BulkDistributeKegsModal({
                 For TTB reporting and sales analytics
               </p>
             </div>
+            {/* Price (optional) */}
+            <div>
+              <Label htmlFor="pricePerKeg">Price per keg ($) <span className="text-muted-foreground text-xs">(optional)</span></Label>
+              <Input
+                id="pricePerKeg"
+                type="number"
+                step="any"
+                min="0"
+                placeholder="0.00"
+                {...register("pricePerKeg", { valueAsNumber: true })}
+                className="mt-1"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Leave blank when this isn't a sale (taproom, samples, festival)
+              </p>
+            </div>
+
+            {/* Notes (optional) */}
+            <div>
+              <Label htmlFor="notes">Notes <span className="text-muted-foreground text-xs">(optional)</span></Label>
+              <Textarea
+                id="notes"
+                placeholder="Anything worth remembering about this distribution..."
+                {...register("notes")}
+                className="mt-1"
+              />
+            </div>
+
 
             <div className="flex justify-end space-x-2 pt-4">
               <Button type="button" variant="outline" onClick={handleClose}>

--- a/apps/web/src/components/packaging/kegs/DistributeKegModal.tsx
+++ b/apps/web/src/components/packaging/kegs/DistributeKegModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -31,6 +32,8 @@ const distributeKegSchema = z.object({
   distributedAt: z.string().min(1, "Date is required"),
   distributionLocation: z.string().min(1, "Location is required"),
   salesChannelId: z.string().uuid().optional(),
+  pricePerKeg: z.number().nonnegative().optional().or(z.nan().transform(() => undefined)),
+  notes: z.string().optional(),
 });
 
 type DistributeKegForm = z.infer<typeof distributeKegSchema>;
@@ -96,6 +99,8 @@ export function DistributeKegModal({
       distributedAt: distributedAt,
       distributionLocation: data.distributionLocation,
       salesChannelId: data.salesChannelId,
+      ...(data.pricePerKeg != null && !Number.isNaN(data.pricePerKeg) ? { pricePerKeg: data.pricePerKeg } : {}),
+      ...(data.notes ? { notes: data.notes } : {}),
     });
   };
 
@@ -180,6 +185,34 @@ export function DistributeKegModal({
               For TTB reporting and sales analytics
             </p>
           </div>
+          {/* Price (optional) */}
+          <div>
+            <Label htmlFor="pricePerKeg">Price per keg ($) <span className="text-muted-foreground text-xs">(optional)</span></Label>
+            <Input
+              id="pricePerKeg"
+              type="number"
+              step="any"
+              min="0"
+              placeholder="0.00"
+              {...register("pricePerKeg", { valueAsNumber: true })}
+              className="mt-1"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Leave blank when this isn't a sale (taproom, samples, festival)
+            </p>
+          </div>
+
+          {/* Notes (optional) */}
+          <div>
+            <Label htmlFor="notes">Notes <span className="text-muted-foreground text-xs">(optional)</span></Label>
+            <Textarea
+              id="notes"
+              placeholder="Anything worth remembering about this distribution..."
+              {...register("notes")}
+              className="mt-1"
+            />
+          </div>
+
 
           <div className="flex justify-end space-x-2 pt-4">
             <Button type="button" variant="outline" onClick={onClose}>

--- a/packages/api/src/routers/inventory.ts
+++ b/packages/api/src/routers/inventory.ts
@@ -821,7 +821,9 @@ export const inventoryRouter = router({
         // (future LIQ-777 breakdown). Optional and non-breaking.
         distributorName: z.string().optional(),
         quantityDistributed: z.number().int().positive(),
-        pricePerUnit: z.number().positive(),
+        // Optional — not every distribution is a sale (taproom transfers,
+        // samples, festival pours). Absent price = no revenue recorded.
+        pricePerUnit: z.number().nonnegative().optional(),
         distributionDate: z.string().datetime(),
         notes: z.string().optional(),
       }),
@@ -851,7 +853,8 @@ export const inventoryRouter = router({
         }
 
         // Calculate total revenue
-        const totalRevenue = input.quantityDistributed * input.pricePerUnit;
+        const pricePerUnit = input.pricePerUnit ?? 0;
+        const totalRevenue = input.quantityDistributed * pricePerUnit;
 
         // Create distribution record and update quantity in a transaction
         await db.transaction(async (tx) => {
@@ -863,7 +866,7 @@ export const inventoryRouter = router({
             salesChannelId: input.salesChannelId,
             distributorName: input.distributorName,
             quantityDistributed: input.quantityDistributed,
-            pricePerUnit: input.pricePerUnit.toString(),
+            pricePerUnit: pricePerUnit.toString(),
             totalRevenue: totalRevenue.toString(),
             notes: input.notes,
             distributedBy: ctx.session?.user?.id || "unknown",

--- a/packages/api/src/routers/kegs.ts
+++ b/packages/api/src/routers/kegs.ts
@@ -231,6 +231,10 @@ const distributeKegFillSchema = z.object({
     .default(() => new Date()),
   distributionLocation: z.string().min(1, "Location is required"),
   salesChannelId: z.string().uuid().optional(),
+  // Unified distribution fields (same set as bottles): optional sale price
+  // per keg and free-text notes.
+  pricePerKeg: z.number().nonnegative().optional(),
+  notes: z.string().optional(),
 });
 
 const returnKegFillSchema = z.object({
@@ -255,6 +259,8 @@ const bulkDistributeKegFillsSchema = z.object({
     .default(() => new Date()),
   distributionLocation: z.string().min(1, "Location is required"),
   salesChannelId: z.string().uuid().optional(),
+  pricePerKeg: z.number().nonnegative().optional(),
+  notes: z.string().optional(),
 });
 
 const bulkReturnKegFillsSchema = z.object({
@@ -1379,6 +1385,12 @@ export const kegsRouter = router({
           distributedAt: input.distributedAt,
           distributionLocation: input.distributionLocation,
           salesChannelId: input.salesChannelId,
+          ...(input.pricePerKeg != null ? { retailPrice: input.pricePerKeg.toString() } : {}),
+          ...(input.notes
+            ? {
+                productionNotes: sql`COALESCE(${kegFills.productionNotes} || E'\n\n', '') || ${"Distribution: " + input.notes}`,
+              }
+            : {}),
           updatedBy: ctx.user.id,
           updatedAt: new Date(),
         };
@@ -1491,6 +1503,15 @@ export const kegsRouter = router({
     .mutation(async ({ input, ctx }) => {
       try {
         const { kegFillIds, distributedAt, distributionLocation, salesChannelId } = input;
+        // Unified distribution fields — applied to every keg in the batch.
+        const sharedFields = {
+          ...(input.pricePerKeg != null ? { retailPrice: input.pricePerKeg.toString() } : {}),
+          ...(input.notes
+            ? {
+                productionNotes: sql`COALESCE(${kegFills.productionNotes} || E'\n\n', '') || ${"Distribution: " + input.notes}`,
+              }
+            : {}),
+        };
 
         // Get all keg fills with their current status
         const fills = await db
@@ -1537,6 +1558,7 @@ export const kegsRouter = router({
                 distributedAt,
                 distributionLocation,
                 salesChannelId,
+                ...sharedFields,
                 updatedBy: ctx.user.id,
                 updatedAt: new Date(),
               })
@@ -1552,6 +1574,7 @@ export const kegsRouter = router({
                 distributedAt,
                 distributionLocation,
                 salesChannelId,
+                ...sharedFields,
                 updatedBy: ctx.user.id,
                 updatedAt: new Date(),
               })

--- a/packages/api/src/routers/packaging.ts
+++ b/packages/api/src/routers/packaging.ts
@@ -1923,6 +1923,9 @@ export const packagingRouter = router({
       distributedAt: z.date().or(z.string().transform((val) => new Date(val))).optional(),
       distributionLocation: z.string().min(1, "Distribution location is required"),
       salesChannelId: z.string().uuid().optional(),
+      // Unified distribution fields (same set as kegs/inventory)
+      pricePerUnit: z.number().nonnegative().optional(),
+      notes: z.string().optional(),
     }))
     .mutation(async ({ input, ctx }) => {
       try {
@@ -1971,6 +1974,14 @@ export const packagingRouter = router({
             updateData.bottleRunSalesChannelId = input.salesChannelId;
           }
 
+          // Unified distribution fields: optional sale price and notes
+          if (input.pricePerUnit != null) {
+            updateData.retailPrice = input.pricePerUnit.toString();
+          }
+          if (input.notes) {
+            updateData.productionNotes = sql`COALESCE(${bottleRuns.productionNotes} || E'\n\n', '') || ${"Distribution: " + input.notes}`;
+          }
+
           // Update bottle run status to distributed
           const [updated] = await tx
             .update(bottleRuns)
@@ -1994,8 +2005,8 @@ export const packagingRouter = router({
                 distributionLocation: input.distributionLocation,
                 salesChannelId: input.salesChannelId,
                 quantityDistributed: qty,
-                pricePerUnit: "0",
-                totalRevenue: "0",
+                pricePerUnit: (input.pricePerUnit ?? 0).toString(),
+                totalRevenue: (qty * (input.pricePerUnit ?? 0)).toString(),
                 distributedBy: ctx.user.id,
               });
 


### PR DESCRIPTION
Owner-approved plan: every distribution pop-up (bottles from packaging, bottles/cans from finished goods, single keg, bulk kegs) asks the same five things — **when, where, channel, price (optional), notes** — plus its context-appropriate quantity.

- Kegs: new optional price-per-keg (stored in `retail_price`, previously never populated — keg revenue was untracked) and notes (appended to production notes). Single + bulk.
- Bottle-run distribution: same two additions; its inventory distribution rows now record real `pricePerUnit`/`totalRevenue` instead of hardcoded zeros.
- Finished-goods dialog: price now optional (taproom transfers/samples aren't sales — warn-don't-block philosophy).
- One deliberate deviation from the approved plan, in the owner's favor: the "Distributor Name" field stays — inspection showed it's conditional (appears only for wholesale channels) and captures the distributor identity for the planned WA LIQ-777 breakdown; it is not a duplicate of Location.

## Testing
- `pnpm typecheck` clean (api + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)